### PR TITLE
Add few initial items to glossary

### DIFF
--- a/1.0/en/0x90-Appendix-A_Glossary.md
+++ b/1.0/en/0x90-Appendix-A_Glossary.md
@@ -1,3 +1,10 @@
 # Appendix A: Glossary
 
-TODO!
+**Adversarial Robustness** – Adversarial robustness in AI refers to a model's ability to maintain its performance and resist being fooled or manipulated by intentionally crafted, malicious inputs designed to cause errors.
+**Agent** – AI agents are software systems that use AI to pursue goals and complete tasks on behalf of users. They show reasoning, planning, and memory and have a level of autonomy to make decisions, learn, and adapt.
+**Differential Privacy** – Differential privacy is a mathematically rigorous framework for releasing statistical information about datasets while protecting the privacy of individual data subjects. It enables a data holder to share aggregate patterns of the group while limiting information that is leaked about specific individuals.
+**Explainability** – Explainability in AI is the ability of an AI system to provide human-understandable reasons for its decisions and predictions, offering insights into its internal workings.
+**Hallucination** – An AI hallucination refers to a phenomenon where an AI model generates incorrect or misleading information that is not based on its training data or factual reality.
+**Model Card** – A model card is a document that provides standardized information about an AI model's performance, limitations, intended uses, and ethical considerations to promote transparency and responsible AI development.
+**Model Lifecycle Management** – AI Model Lifecycle Management is the process of overseeing all stages of an AI model's existence, including its design, development, deployment, monitoring, maintenance, and eventual retirement, to ensure it remains effective and aligned with objectives.
+**Retrieval-Augmented Generation** (RAG) – Retrieval-augmented generation is a technique that enables generative AI models to retrieve and incorporate new information.


### PR DESCRIPTION
As requested by @jmanico start of our glossary. 

Did not intend to now include all possible terminology since we do not yet even have a finalized scope, but there are now few items to get started with. Used ASVS glossary as a reference, and like there kept the definitions quite compact.