### PR TITLE
Update 0x10-C01-Training-Data-Governance.md

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Governance.md
+++ b/1.0/en/0x10-C01-Training-Data-Governance.md
@@ -53,7 +53,7 @@ Combine automated validation, manual spot-checks, and logged remediation to guar
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **1.4.1** | **Verify that** automated tests catch format errors amd nulls on every ingest or significant data transformation. | 1 | D |
+| **1.4.1** | **Verify that** automated tests catch format errors and nulls on every ingest or significant data transformation. | 1 | D |
 | **1.4.2** | **Verify that** LLM training and fine-tuning pipelines implement poisoning detection & data integrity validation (e.g., statistical methods, outlier detection, embedding analysis) to identify potential poisoning attacks (e.g., label flipping, backdoor trigger insertion, role-switching commands, influential instance attacks) or unintentional data corruption in training data. | 2 | D/V |
 | **1.4.3** | **Verify that** automatically generated labels (e.g., via LLMs or weak supervision) are subject to confidence thresholds and consistency checks to detect hallucinated, misleading, or low-confidence labels. | 2 | D/V |
 | **1.4.4** | **Verify that** appropriate defenses, such as adversarial training (using generated adversarial examples), data augmentation with perturbed inputs, or robust optimization techniques, are implemented and tuned for relevant models based on risk assessment. | 3 | D/V |


### PR DESCRIPTION
Fixed a typo in **1.4.1**. Instead of "errors amd nulls",  proposing to fix it to "errors and nulls"

<!---
IMPORTANT NOTES:
- Changes should always be made only in the raw .md files and not in the CSV, JSON, XLSX, PDF, DOCX files, etc.
- Please do not open a pull request without first opening an associated issue.
- Please carry out all discussion in the associated issue only.
-->

This Pull Request relates to issue #...
