### PR TITLE
Check TRANSLATE_ACCESS_KEY only if 'mt' is set

### DIFF
--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -90,7 +90,7 @@ jobs:
             echo "The command '$EVENT_COMMENT_BODY' is invalid."
             exit 1
           fi
-          if ${{ env.TRANSLATE_ACCESS_KEY == '' }}; then
+          if ${{ env.MT_X == 'mt' && env.TRANSLATE_ACCESS_KEY == '' }}; then
             echo "MT is disabled. Pls consult with the repo maintener."
             exit 1
           fi


### PR DESCRIPTION
Workflow fix: check the env variable TRANSLATE_ACCESS_KEY only if 'mt' command is set.