### PR TITLE
Relax rules:relax no-multiple-blanks, blanks-around-headings, blanks-…

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -3,9 +3,12 @@
   
     "MD004": {"style": "asterisk"},               // ul-style
     "MD007": {"indent": "4"},                     // ul-style
+    "MD012": false,                               // no-multiple-blanks
     "MD013": false,                               // line-length
+    "MD022": false,                               // blanks-around-headings
     "MD024": {"allow_different_nesting": true},   // no-duplicate-header
     "MD026": {"punctuation": ".,;:"},             // no-trailing-punctuation (allows !?)
+    "MD032": false,                               // blanks-around-lists
     "MD033": false,                               // no-inline-html
     "MD034": false,                               // bare URLs
     "MD035": {"style": "---"},                    // hr-style


### PR DESCRIPTION
Resolve a few too-strict, noisy lint rules: no-multiple-blanks, blanks-around-headings, blanks-around-lists
resolves #113 