### PR TITLE
Update year notices from 2025 to 2026

### DIFF
--- a/.github/workflows/build-documents.yml
+++ b/.github/workflows/build-documents.yml
@@ -2,7 +2,7 @@ name: Build Documents
 
 # BSD 3-Clause License
 
-# Copyright (c) 2025, Tetsuo Seto
+# Copyright (c) 2025-2026, Tetsuo Seto
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/1.0/en/0x01-Frontispiece.md
+++ b/1.0/en/0x01-Frontispiece.md
@@ -10,7 +10,7 @@ Version 0.1 (First Public Draft - Work In Progress), 2025
 
 ![license](../images/license.png)
 
-Copyright © 2025 The AISVS Project.  
+Copyright © 2025-2026 The AISVS Project.  
 
 Released under the [Creative Commons Attribution‑ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).  
 For any reuse or distribution, you must clearly communicate the license terms of this work to others.


### PR DESCRIPTION
- Updated the copyright year notices to include 2026.
- The year range was extended from 2025 to 2026 in the workflow header and the frontispiece to reflect ongoing maintenance.
- No other content or references were changed.

Fixes #117
