### PR TITLE
Revise C04 levels and terminology

### DIFF
--- a/1.0/en/0x10-C04-Infrastructure.md
+++ b/1.0/en/0x10-C04-Infrastructure.md
@@ -14,8 +14,8 @@ Prevent container escapes and privilege escalation through OS-level isolation pr
 |:--------:|--------------------------------------------------------------------------------------------|:---:|:---:|
 | **4.1.1** | **Verify that** all AI workloads run with minimal permissions needed on the operating system, by e.g. dropping unnecessary Linux capabilities in case of a container. | 1 | D/V |
 | **4.1.2** | **Verify that** workloads are protected by technologies limiting exploitation such as sandboxing, seccomp profiles, AppArmor, SELinux or similar, and that the configuration is appropriate. | 1 | D/V |
-| **4.1.3** | **Verify that** workloads run with a read-only root filesystem, and that any writable mounts are explicitly defined and hardened with restrictive options (e.g., noexec, nosuid, nodev). | 2 | D/V |
-| **4.1.4** | **Verify that** runtime monitoring detects privilege-escalation and container-escape behaviors and automatically terminates offending processes. | 2 | D/V |
+| **4.1.3** | **Verify that** workloads run with a read-only root filesystem, and that any writable mounts are explicitly defined and hardened with restrictive options that prevent execution and privilege escalation (e.g., noexec, nosuid, nodev). | 2 | D/V |
+| **4.1.4** | **Verify that** runtime monitoring detects privilege-escalation and container-escape behaviors and automatically terminates offending processes. | 3 | D/V |
 | **4.1.5** | **Verify that** high-risk AI workloads run in hardware-isolated environments (e.g., TEEs, trusted hypervisors, or bare-metal nodes) only after successful remote attestation. | 3 | D/V |
 
 ---
@@ -26,9 +26,10 @@ Ensure cryptographic integrity and supply chain security through reproducible bu
 
 | # | Description | Level | Role |
 |:--------:|--------------------------------------------------------------------------------------------|:---:|:---:|
-| **4.2.1** | **Verify that** builds are reproducible and produce signed provenance metadata as appropriate for the build artifacts that can be independently verified. | 1 | D/V |
-| **4.2.2** | **Verify that** builds produce a software bill of materials (SBOM) and are signed before being accepted for deployment. | 2 | D/V |
-| **4.2.3** | **Verify that** build artifact (e.g., container images) signatures and provenance metadata are validated at deployment, and unverified artifacts are rejected. | 2 | D/V |
+| **4.2.1** | **Verify that** builds are completely automated and produce a software bill of materials (SBOM). | 1 | D/V |
+| **4.2.2** | **Verify that** build artifacts are cryptographically signed with provenance metadata that can be independently verified. | 2 | D/V |
+| **4.2.3** | **Verify that** build artifact signatures and provenance metadata are validated at deployment admission, and unverified artifacts are rejected. | 2 | D/V |
+| **4.2.4** | **Verify that** builds are reproducible, producing identical output from identical source inputs, enabling independent verification of build integrity. | 3 | D/V |
 
 ---
 
@@ -39,10 +40,11 @@ Implement zero-trust networking with default-deny policies and encrypted communi
 | # | Description | Level | Role |
 |:--------:|--------------------------------------------------------------------------------------------|:---:|:---:|
 | **4.3.1** | **Verify that** network policies enforce default-deny ingress and egress, with only required services explicitly allowed. | 1 | D/V |
-| **4.3.2** | **Verify that** administrative access protocols (e.g., SSH, RDP) and access to cloud metadata services are restricted and require strong authentication. | 1 | D/V |
-| **4.3.3** | **Verify that** egress traffic is restricted to approved destinations and all requests are logged. | 2 | D/V |
+| **4.3.2** | **Verify that** AI workloads across environments (development, testing, production) run in isolated network segments with no direct internet access and no shared identity roles, security groups, or cross-environment connectivity. | 1 | D/V |
+| **4.3.3** | **Verify that** administrative and remote access protocols and access to cloud metadata services are restricted and require strong authentication. | 1 | D/V |
 | **4.3.4** | **Verify that** inter-service communication uses mutual TLS with certificate validation and regular automated rotation. | 2 | D/V |
-| **4.3.5** | **Verify that** AI workloads and environments (dev, test, prod) run in isolated network segments (VPCs/VNets) with no direct internet access and no shared IAM roles, security groups, or cross-environment connectivity. | 2 | D/V |
+| **4.3.5** | **Verify that** egress traffic is restricted to approved destinations and all requests are logged. | 3 | D/V |
+
 
 ## C4.4 Secrets & Cryptographic Key Management
 
@@ -51,9 +53,9 @@ Protect secrets and cryptographic keys with secure storage, automated rotation, 
 | # | Description | Level | Role |
 |:--------:|--------------------------------------------------------------------------------------------|:---:|:---:|
 | **4.4.1** | **Verify that** secrets are stored in a dedicated secrets management system with encryption at rest and isolated from application workloads. | 1 | D/V |
-| **4.4.2** | **Verify that** cryptographic keys are generated and stored in hardware-backed modules (e.g., HSMs, cloud KMS). | 1 | D/V |
-| **4.4.3** | **Verify that** access to production secrets requires strong authentication. | 1 | D/V |
-| **4.4.4** | **Verify that** secrets are deployed to applications at runtime through a dedicated secrets management system. Secrets must never be embedded in source code, configuration files, build artifacts, container images, or environment variables. | 1 | D/V |
+| **4.4.2** | **Verify that** access to production secrets requires strong authentication. | 1 | D/V |
+| **4.4.3** | **Verify that** secrets are deployed to applications at runtime through a dedicated secrets management system. Secrets must never be embedded in source code, configuration files, build artifacts, container images, or environment variables. | 1 | D/V |
+| **4.4.4** | **Verify that** cryptographic keys are generated and stored in hardware-backed modules (e.g., HSMs, cloud KMS). | 2 | D/V |
 | **4.4.5** | **Verify that** secrets rotation is automated. | 2 | D/V |
 
 ---
@@ -66,7 +68,7 @@ Isolate untrusted AI models in secure sandboxes and protect sensitive AI workloa
 |:--------:|--------------------------------------------------------------------------------------------|:---:|:---:|
 | **4.5.1** | **Verify that** external or untrusted AI models execute in isolated sandboxes.| 1 | D/V |
 | **4.5.2** | **Verify that** sandboxed workloads have no outbound network connectivity by default, with any required access explicitly defined.| 1 | D/V |
-| **4.5.3** | **Verify that** workload attestation is performed before model or workload loading, ensuring cryptographic proof of a trusted execution environment. | 2 | D/V |
+| **4.5.3** | **Verify that** workload attestation is performed before model loading, ensuring cryptographic proof that the execution environment has not been tampered with. | 2 | D/V |
 | **4.5.4** | **Verify that** confidential workloads execute within a trusted execution environment (TEE) that provides hardware-enforced isolation, memory encryption, and integrity protection. | 3 | D/V |
 | **4.5.5** | **Verify that** confidential inference services prevent model extraction through encrypted computation with sealed model weights and protected execution. | 3 | D/V |
 | **4.5.6** | **Verify that** orchestration of trusted execution environments includes lifecycle management, remote attestation, and encrypted communication channels. | 3 | D/V |
@@ -80,7 +82,7 @@ Prevent resource exhaustion attacks and ensure fair resource allocation through 
 
 | # | Description | Level | Role |
 |:--------:|--------------------------------------------------------------------------------------------|:---:|:---:|
-| **4.6.1** | **Verify that** workload's resource consumption is limited appropriately with e.g. Kubernetes ResourceQuotas or similar to mitigate Denial of Service attacks. | 2 | D/V |
+| **4.6.1** | **Verify that** workload resource consumption is limited through quotas and limits (e.g., CPU, memory, GPU) to mitigate denial-of-service attacks. | 1 | D/V |
 | **4.6.2** | **Verify that** resource exhaustion triggers automated protections (e.g., rate limiting or workload isolation) once defined CPU, memory, or request thresholds are exceeded. | 2 | D/V |
 | **4.6.3** | **Verify that** backup systems run in isolated networks with separate credentials, and the storage system is either run in an air-gapped network or implements WORM (write-once-read-many) protection against unauthorized modification. | 2 | D/V |
 
@@ -94,12 +96,12 @@ Secure AI-specific hardware components including GPUs, TPUs, and specialized AI 
 |:--------:|--------------------------------------------------------------------------------------------|:---:|:---:|
 | **4.7.1** | **Verify that** before workload execution, AI accelerator integrity is validated using hardware-based attestation mechanisms (e.g., TPM, DRTM, or equivalent). | 2 | D/V |
 | **4.7.2** | **Verify that** accelerator (GPU) memory is isolated between workloads through partitioning mechanisms with memory sanitization between jobs. | 2 | D/V |
-| **4.7.3** | **Verify that** hardware security modules (HSMs) protect AI model weights and cryptographic keys with certification to FIPS 140-3 Level 3 or Common Criteria EAL4+. | 3 | D/V |
-| **4.7.4** | **Verify that** accelerator firmware (GPU/TPU/NPUs) is version-pinned, signed, and attested at boot; unsigned or debug firmware is blocked. | 2 | D/V |
-| **4.7.5** | **Verify that** VRAM and on-package memory are zeroed between jobs/tenants and that device reset policies prevent cross-tenant data remanence. | 2 | D/V |
-| **4.7.6** | **Verify that** partitioning/isolation features (e.g., MIG/VM partitioning) are enforced per tenant and prevent peer-to-peer memory access across partitions. | 2 | D/V |
+| **4.7.3** | **Verify that** AI accelerator firmware is version-pinned, signed, and attested at boot; unsigned or debug firmware is blocked. | 2 | D/V |
+| **4.7.4** | **Verify that** VRAM and on-package memory are zeroed between jobs/tenants and that device reset policies prevent cross-tenant data remanence. | 2 | D/V |
+| **4.7.5** | **Verify that** partitioning/isolation features (e.g., MIG/VM partitioning) are enforced per tenant and prevent peer-to-peer memory access across partitions. | 2 | D/V |
+| **4.7.6** | **Verify that** hardware security modules (HSMs) or equivalent tamper-resistant hardware protect AI model weights and cryptographic keys, with certification to an appropriate assurance level (e.g., FIPS 140-3 Level 3 or Common Criteria EAL4+). | 3 | D/V |
 | **4.7.7** | **Verify that** accelerator interconnects (NVLink/PCIe/InfiniBand/RDMA/NCCL) are restricted to approved topologies and authenticated endpoints; plaintext cross-tenant links are disallowed. | 3 | D/V |
-| **4.7.8** | **Verify that** accelerator telemetry (power, temps, ECC, perf counters) is exported to SIEM/OTel and alerts on anomalies indicative of side-channels or covert channels. | 3 | D |
+| **4.7.8** | **Verify that** accelerator telemetry (power draw, temperature, error correction, performance counters) is exported to centralized security monitoring and alerts on anomalies indicative of side-channels or covert channels. | 3 | D |
 
 ---
 
@@ -109,12 +111,12 @@ Secure distributed AI deployments including edge computing, federated learning, 
 
 | # | Description | Level | Role |
 |:--------:|--------------------------------------------------------------------------------------------|:---:|:---:|
-| **4.8.1** | **Verify that** edge AI devices authenticate to central infrastructure using mutual TLS. | 2 | D/V |
-| **4.8.2** | **Verify that** edge devices implement secure boot with verified signatures and rollback protection to prevent firmware downgrade attacks. | 2 | D/V |
-| **4.8.3** | **Verify that** distributed AI coordination uses Byzantine fault-tolerant consensus mechanisms with participant validation and malicious node detection. | 3 | D/V |
-| **4.8.4** | **Verify that** edge-to-cloud communication supports bandwidth throttling, data compression, and secure offline operation with encrypted local storage. | 3 | D/V |
-| **4.8.5** | **Verify that** mobile or edge inference applications implement platform-level anti-tampering protections (e.g., code signing, verified boot, runtime self-integrity checks) that detect and block modified binaries, repackaged apps, or attached instrumentation frameworks. | 3 | D/V |
-| **4.8.6** | **Verify that** models deployed to edge or mobile devices are cryptographically signed during packaging, and that the on-device runtime validates these signatures or checksums before loading or inference; unverified or altered models must be rejected. | 3 | D/V |
+| **4.8.1** | **Verify that** edge AI devices authenticate to central infrastructure using mutual authentication with certificate validation (e.g., mutual TLS). | 1 | D/V |
+| **4.8.2** | **Verify that** models deployed to edge or mobile devices are cryptographically signed during packaging, and that the on-device runtime validates these signatures or checksums before loading or inference; unverified or altered models must be rejected. | 1 | D/V |
+| **4.8.3** | **Verify that** edge devices implement secure boot with verified signatures and rollback protection to prevent firmware downgrade attacks. | 2 | D/V |
+| **4.8.4** | **Verify that** mobile or edge inference applications implement platform-level anti-tampering protections (e.g., code signing, verified boot, runtime integrity checks) that detect and block modified binaries, repackaged applications, or attached instrumentation frameworks. | 2 | D/V |
+| **4.8.5** | **Verify that** distributed AI coordination uses Byzantine fault-tolerant consensus mechanisms with participant validation and malicious node detection. | 3 | D/V |
+| **4.8.6** | **Verify that** edge-to-cloud communication supports bandwidth throttling, data compression, and secure offline operation with encrypted local storage. | 3 | D/V |
 | **4.8.7** | **Verify that** on-device inference runtimes enforce process, memory, and file access isolation to prevent model dumping, debugging, or extraction of intermediate embeddings and activations. | 3 | D/V |
 | **4.8.8** | **Verify that** model weights and sensitive parameters stored locally are encrypted using hardware-backed key stores or secure enclaves (e.g., Android Keystore, iOS Secure Enclave, TPM/TEE), with keys inaccessible to user space. | 3 | D/V |
 | **4.8.9** | **Verify that** models packaged within mobile, IoT, or embedded applications are encrypted or obfuscated at rest, and decrypted only inside a trusted runtime or secure enclave, preventing direct extraction from the app package or filesystem. | 3 | D/V |


### PR DESCRIPTION
Rebalances C04 level assignments as in previous PRs for C01–C03 and generalizes vendor/technology-specific terminology. Note that it looks like there are a lot of changes, most of that is just renumbering and reordering accordingly.

### Level changes

**Five controls promoted (to a lower level):**

| Control | Change | Rationale |
|---------|--------|-----------|
| 4.3.2 (was 4.3.5) | L2 → L1 | Environment isolation (dev/test/prod) is a baseline cloud security practice; matches C03's 3.4.1 which is already L1 |
| 4.6.1 | L2 → L1 | Resource quotas are basic DoS mitigation per OWASP LLM10 (Unbounded Consumption) |
| 4.8.1 | L2 → L1 | Mutual authentication for edge devices is foundational for any distributed deployment |
| 4.8.2 (was 4.8.6) | L3 → L1 | On-device model signature validation is a baseline integrity control; OWASP LLM03 mitigation #10 recommends this |
| 4.8.4 (was 4.8.5) | L3 → L2 | Anti-tampering for mobile/edge apps is standard practice per OWASP MASVS; LLM03 lists app tampering as known attack vector |

**Three controls demoted (to a higher level):**

| Control | Change | Rationale |
|---------|--------|-----------|
| 4.1.4 | L2 → L3 | Runtime monitoring with automatic process termination requires specialized tooling and tuning; defense-in-depth measure |
| 4.3.5 (was 4.3.3) | L2 → L3 | Full egress logging of all requests to approved destinations is operationally complex at scale |
| 4.4.4 (was 4.4.2) | L1 → L2 | Hardware-backed key storage (HSMs/cloud KMS) is a maturity step beyond basic secrets management |

### Restructured C4.2

Original 4.2.1 (L1, combined reproducible builds + signed provenance) and 4.2.2 (L2, SBOM + signing) were split and redistributed across the section:

- **4.2.1** (L1): Builds are completely automated and produce an SBOM — build automation is new; SBOM promoted from L2 (was part of old 4.2.2)
- **4.2.2** (L2): Build artifacts are cryptographically signed with verifiable provenance metadata — signing separated from old 4.2.1
- **4.2.3** (L2): Artifact signatures and provenance validated at deployment admission — carried from old 4.2.3
- **4.2.4** (L3): Builds are reproducible, producing identical output from identical inputs — separated from old 4.2.1 and moved to L3

This creates a clear maturity progression seen often: automate and inventory (L1) → sign and verify (L2) → completely reproducible builds (L3).

### Language and terminology changes

- **4.1.3**: Added "that prevent execution and privilege escalation" before mount option examples
- **4.2.1**: Rewritten to focus on build automation and SBOM production
- **4.3.2** (was 4.3.5): "VPCs/VNets" → "isolated network segments"; "IAM roles" → "identity roles"
- **4.3.3** (was 4.3.2): "SSH, RDP" → "administrative and remote access protocols"
- **4.5.3**: Generalized attestation language ("cryptographic proof that the execution environment has not been tampered with")
- **4.6.1**: "Kubernetes ResourceQuotas" → "quotas and limits (e.g., CPU, memory, GPU)" to account for non-k8s environments
- **4.7.3** (was 4.7.4): "GPU/TPU/NPUs" → "AI accelerator firmware"
- **4.7.6** (was 4.7.3): Added "or equivalent tamper-resistant hardware"; softened certification to "appropriate assurance level" to account for various different possible combinations of hardware 
- **4.7.8**: "temps, ECC, perf counters" → descriptive terms; "SIEM/OTel" → "centralized security monitoring"
- **4.8.1**: "mutual TLS" → "mutual authentication with certificate validation (e.g., mutual TLS)"
- **4.8.4** (was 4.8.5): "self-integrity" → "integrity"; "apps" → "applications"
