### PR TITLE
Revise levels and terminology for C06

### DIFF
--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -12,39 +12,39 @@ Assess and authenticate third‑party model origins, licenses, and hidden behavi
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **6.1.1** | **Verify that** every third‑party model artifact includes a signed origin record identifying source repository and commit hash. | 1 | D/V |
+| **6.1.1** | **Verify that** every third‑party model artifact includes a signed provenance record identifying its source, version, and integrity checksum. | 1 | D/V |
 | **6.1.2** | **Verify that** models are scanned for malicious layers or Trojan triggers using automated tools before import. | 1 | D/V |
-| **6.1.3** | **Verify that** transfer‑learning fine‑tunes pass adversarial evaluation to detect hidden behaviors. | 2 | D |
-| **6.1.4** | **Verify that** model licenses, export‑control tags, and data‑origin statements are recorded in a ML‑BOM entry. | 2 | V |
-| **6.1.5** | **Verify that** high‑risk models (publicly uploaded weights, unverified creators) remain quarantined until human review and sign‑off. | 3 | D/V |
+| **6.1.3** | **Verify that** model licenses, export‑control tags, and data‑origin statements are recorded in an AI BOM entry. | 2 | V |
+| **6.1.4** | **Verify that** high‑risk models (e.g., publicly uploaded weights, unverified creators) remain quarantined until human review and sign‑off. | 2 | D/V |
+| **6.1.5** | **Verify that** transfer‑learning fine‑tunes pass adversarial evaluation to detect hidden behaviors. | 3 | D |
 
 ---
 
 ## C6.2 Framework & Library Scanning
 
-Continuously scan ML frameworks and libraries for CVEs and malicious code to keep the runtime stack secure.
+Continuously scan AI frameworks and libraries for vulnerabilities and malicious code to keep the runtime stack secure.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
 | **6.2.1** | **Verify that** CI pipelines run dependency scanners on AI frameworks and critical libraries. | 1 | D/V |
-| **6.2.2** | **Verify that** critical vulnerabilities (CVSS ≥ 7.0) block promotion to production images. | 1 | D/V |
-| **6.2.3** | **Verify that** static code analysis runs on forked or vendored ML libraries. | 2 | D |
-| **6.2.4** | **Verify that** framework upgrade proposals include a security impact assessment referencing public CVE feeds. | 2 | V |
+| **6.2.2** | **Verify that** critical and high‑severity vulnerabilities block promotion to production images. | 2 | D/V |
+| **6.2.3** | **Verify that** static code analysis runs on forked or vendored AI libraries. | 2 | D |
+| **6.2.4** | **Verify that** framework upgrade proposals include a security impact assessment referencing public vulnerability feeds. | 2 | V |
 | **6.2.5** | **Verify that** runtime sensors alert on unexpected dynamic library loads that deviate from the signed SBOM. | 3 | V |
 
 ---
 
 ## C6.3 Dependency Pinning & Verification
 
-Pin every dependency to immutable digests and reproduce builds to guarantee identical, tamper‑free artifacts.
+Pin every dependency to immutable digests and verify builds to guarantee tamper‑free artifacts.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
 | **6.3.1** | **Verify that** all package managers enforce version pinning via lockfiles. | 1 | D/V |
 | **6.3.2** | **Verify that** immutable digests are used instead of mutable tags in container references. | 1 | D/V |
-| **6.3.3** | **Verify that** reproducible‑build checks compare hashes across CI runs to ensure identical outputs. | 2 | D |
-| **6.3.4** | **Verify that** build attestations are stored for 18 months for audit traceability. | 2 | V |
-| **6.3.5** | **Verify that** expired dependencies trigger automated PRs to update or fork pinned versions. | 3 | D |
+| **6.3.3** | **Verify that** expired or unmaintained dependencies trigger automated notifications to update or replace pinned versions. | 2 | D |
+| **6.3.4** | **Verify that** build attestations are retained for a period defined by organizational policy for audit traceability. | 3 | V |
+| **6.3.5** | **Verify that** reproducible‑build checks compare hashes across CI runs to ensure identical outputs. | 3 | D |
 
 ---
 
@@ -54,10 +54,10 @@ Allow artifact downloads only from cryptographically verified, organization‑ap
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **6.4.1** | **Verify that** model weights, datasets, and containers are downloaded only from approved domains or internal registries. | 1 | D/V |
-| **6.4.2** | **Verify that** Sigstore/Cosign signatures validate publisher identity before artifacts are cached locally. | 1 | D/V |
-| **6.4.3** | **Verify that** egress proxies block unauthenticated artifact downloads to enforce trusted‑source policy. | 2 | D |
-| **6.4.4** | **Verify that** repository allow‑lists are reviewed quarterly with evidence of business justification for each entry. | 2 | V |
+| **6.4.1** | **Verify that** model weights, datasets, and containers are downloaded only from approved sources or internal registries. | 1 | D/V |
+| **6.4.2** | **Verify that** cryptographic signatures validate publisher identity before artifacts are cached locally. | 1 | D/V |
+| **6.4.3** | **Verify that** egress controls block unauthenticated artifact downloads to enforce trusted‑source policy. | 2 | D |
+| **6.4.4** | **Verify that** repository allow‑lists are reviewed periodically with evidence of business justification for each entry. | 3 | V |
 | **6.4.5** | **Verify that** policy violations trigger quarantining of artifacts and rollback of dependent pipeline runs. | 3 | V |
 
 ---
@@ -68,37 +68,37 @@ Evaluate external datasets for poisoning, bias, and legal compliance, and monito
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **6.5.1** | **Verify that** external datasets undergo poisoning risk scoring (e.g., data fingerprinting, outlier detection). | 1 | D/V |
-| **6.5.2** | **Verify that** bias metrics (demographic parity, equal opportunity) are calculated before dataset approval. | 1 | D |
-| **6.5.3** | **Verify that** origin, lineage, and license terms for datasets are captured in ML‑BOM entries. | 2 | V |
-| **6.5.4** | **Verify that** periodic monitoring detects drift or corruption in hosted datasets. | 2 | V |
-| **6.5.5** | **Verify that** disallowed content (copyright and PII) is removed via automated scrubbing prior to training. | 3 | D |
+| **6.5.1** | **Verify that** external datasets undergo poisoning risk assessment (e.g., data fingerprinting, outlier detection). | 1 | D/V |
+| **6.5.2** | **Verify that** disallowed content (e.g., copyrighted material, PII) is detected and removed via automated scrubbing prior to training. | 1 | D |
+| **6.5.3** | **Verify that** origin, lineage, and license terms for datasets are captured in AI BOM entries. | 2 | V |
+| **6.5.4** | **Verify that** bias metrics (e.g., demographic parity, equal opportunity) are calculated before dataset approval. | 2 | D |
+| **6.5.5** | **Verify that** periodic monitoring detects drift or corruption in hosted datasets. | 3 | V |
 
 ---
 
 ## C6.6 Supply Chain Attack Monitoring
 
-Detect supply‑chain threats early through CVE feeds, audit‑log analytics, and red‑team simulations.
+Detect supply‑chain threats early through vulnerability feeds, audit‑log analytics, and incident response readiness.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **6.6.1** | **Verify that** CI/CD audit logs stream to SIEM detections for anomalous package pulls or tampered build steps. | 1 | V |
-| **6.6.2** | **Verify that** incident response playbooks include rollback procedures for compromised models or libraries. | 2 | D ||
-| **6.6.3** | **Verify that** threat‑intel enrichment tags ML‑specific indicators (e.g., model‑poisoning IoCs) in alert triage. | 3 | V |
+| **6.6.1** | **Verify that** incident response playbooks include rollback procedures for compromised models or libraries. | 2 | D |
+| **6.6.2** | **Verify that** CI/CD audit logs are streamed to centralized security monitoring with detections for anomalous package pulls or tampered build steps. | 2 | V |
+| **6.6.3** | **Verify that** threat‑intelligence enrichment tags AI‑specific indicators (e.g., model‑poisoning indicators of compromise) in alert triage. | 3 | V |
 
 ---
 
-## C6.7 ML‑BOM for Model Artifacts
+## C6.7 AI BOM for Model Artifacts
 
-Generate and sign detailed ML‑specific SBOMs (ML‑BOMs) so downstream consumers can verify component integrity at deploy time.
+Generate and sign detailed AI‑specific bills of materials (AI BOMs) so downstream consumers can verify component integrity at deploy time.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **6.7.1** | **Verify that** every model artifact publishes a ML‑BOM that lists datasets, weights, hyperparameters, and licenses. | 1 | D/V |
-| **6.7.2** | **Verify that** ML‑BOM generation and Cosign signing are automated in CI and required for merge. | 1 | D/V |
-| **6.7.3** | **Verify that** ML‑BOM completeness checks fail the build if any component metadata (hash and license) is missing. | 2 | D |
-| **6.7.4** | **Verify that** downstream consumers can query ML-BOMs via API to validate imported models at deploy time. | 2 | V |
-| **6.7.5** | **Verify that** ML‑BOMs are version‑controlled and diffed to detect unauthorized modifications. | 3 | V |
+| **6.7.1** | **Verify that** every model artifact publishes an AI BOM that lists datasets, weights, hyperparameters, and licenses. | 1 | D/V |
+| **6.7.2** | **Verify that** AI BOM generation and cryptographic signing are automated in CI and required for merge. | 2 | D/V |
+| **6.7.3** | **Verify that** AI BOM completeness checks fail the build if any component metadata (hash and license) is missing. | 2 | D |
+| **6.7.4** | **Verify that** downstream consumers can query AI BOMs via API to validate imported models at deploy time. | 2 | V |
+| **6.7.5** | **Verify that** AI BOMs are version‑controlled and diffed to detect unauthorized modifications. | 3 | V |
 
 ---
 


### PR DESCRIPTION
Rebalances C06 level assignments and generalizes vendor/technology-specific terminology. Several individual controls were at the wrong level when cross-referenced with peer chapters. Also reordering after the following changes.

### Level changes

| Control | Change | Rationale |
|---------|--------|-----------|
| 6.5.2 (was 6.5.5) | L3 → L1 | PII and copyright scrubbing before training is a foundational data protection measure; C01's 1.1.2 (exclude unnecessary PII) is L1; having this at L3 was a clear outlier |
| 6.1.5 (was 6.1.3) | L2 → L3 | Adversarial evaluation of transfer-learning fine-tunes to detect hidden behaviors is a specialized, advanced testing technique; consistent with C01's 1.4.4 (adversarial training/defenses) at L3 |
| 6.2.2 | L1 → L2 | Blocking promotion on critical/high-severity vulnerabilities requires mature CI gating infrastructure; basic dependency scanning (6.2.1) is the L1 baseline |
| 6.3.3 (was 6.3.5) | L3 → L2 | Automated notifications for expired/unmaintained dependencies is a reasonable operational practice, not a niche L3 control |
| 6.3.4 (was 6.3.4) | L2 → L3 | Build attestation retention is an audit/compliance maturity step beyond basic build verification |
| 6.3.5 (was 6.3.3) | L2 → L3 | Reproducible-build hash comparison across CI runs is an advanced supply-chain integrity technique |
| 6.4.4 | L2 → L3 | Periodic repository allow-list review with business justification evidence is a governance maturity control |
| 6.5.5 (was 6.5.4) | L2 → L3 | Periodic drift/corruption monitoring on hosted datasets is an ongoing operational maturity step |
| 6.7.2 | L1 → L2 | Automated AI BOM generation with cryptographic signing in CI is a maturity step beyond basic AI BOM publishing (6.7.1) |

### Language and terminology changes

- **ML-BOM → AI BOM**: Standardized throughout to "AI BOM" for consistency with C03's MBOM/AIBOM terminology
- **C6.7 section title**: "ML‑BOM for Model Artifacts" → "AI BOM for Model Artifacts"
- **C6.6 section description**: "CVE feeds" → "vulnerability feeds"
- **6.1.1**: "source repository and commit hash" → "source, version, and integrity checksum" — generalizes beyond git-based workflows
- **6.2.2**: "CVSS ≥ 7.0" → "critical and high‑severity" — avoids hard-coding a specific scoring threshold
- **6.2.1/6.2.3/6.2.4**: "ML frameworks/libraries" → "AI frameworks/libraries" — consistent with broader scope
- **6.3.4** (was 6.3.4): "18 months" → "a period defined by organizational policy" — retention periods vary by regulatory context
- **6.3.3** (was 6.3.5): "automated PRs to update or fork" → "automated notifications to update or replace" — not all teams use PR-based workflows
- **6.4.2**: "Sigstore/Cosign signatures" → "cryptographic signatures" — removes product-specific naming
- **6.4.1**: "approved domains" → "approved sources" — not all enforcement is domain-based
- **6.4.3**: "egress proxies" → "egress controls" — not all implementations use proxies
- **6.4.4**: "quarterly" → "periodically" — review cadence varies by organization
- **6.5.1**: "poisoning risk scoring" → "poisoning risk assessment" — not all approaches produce a numeric score
- **6.6.2** (was 6.6.1): "SIEM detections" → "centralized security monitoring with detections"
- **6.6.3**: "ML‑specific indicators (e.g., model‑poisoning IoCs)" → "AI‑specific indicators (e.g., model‑poisoning indicators of compromise)" — spells out abbreviation, uses AI not ML
- **6.7.2**: "Cosign signing" → "cryptographic signing" — removes product-specific naming
- **C6.2 section description**: "ML frameworks" → "AI frameworks"
- **C6.3 section description**: "reproduce builds" → "verify builds" — reproducible builds are L3 (6.3.5), not the whole section's scope
