### PR TITLE
Revise C07 levels and terminology

### DIFF
--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -14,19 +14,19 @@ Ensure the model outputs data in a way that helps prevents injection.
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
 | **7.1.1** | **Verify that** the application validates all model outputs against a strict schema (like JSON Schema) and rejects any output that does not match. | 1 | D/V |
 | **7.1.2** | **Verify that** the system uses "stop sequences" or token limits to strictly cut off generation before it can overflow buffers or executes unintended commands. | 1 | D/V |
-| **7.1.3** | **Verify that** components processing model output treat it as untrusted input (e.g., using parameterized queries or safe de-serializers). | 2 | D/V |
-| **7.1.4** | **Verify that** the system logs the specific error type when an output is rejected for bad formatting. | 3 | V |
+| **7.1.3** | **Verify that** components processing model output treat it as untrusted input (e.g., using parameterized queries or safe de-serializers). | 1 | D/V |
+| **7.1.4** | **Verify that** the system logs the specific error type when an output is rejected for bad formatting. | 2 | D/V |
 
 ---
 
 ## C7.2 Hallucination Detection & Mitigation
 
-Detect when the model is unsure or lying, and stop that information from reaching the user.
+Detect when the model produces potentially inaccurate or fabricated content and prevent unreliable outputs from reaching users or downstream systems.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **7.2.1** | **Verify that** the system calculates a numerical confidence score (e.g., using log-probabilities) for generated answers. | 1 | D/V |
-| **7.2.2** | **Verify that** the application automatically blocks answers or switches to a fallback message if the confidence score drops below a defined threshold. | 1 | D/V |
+| **7.2.1** | **Verify that** the system assesses the reliability of generated answers using a confidence or uncertainty estimation method (e.g., confidence scoring, retrieval-based verification, or model uncertainty estimation). | 1 | D/V |
+| **7.2.2** | **Verify that** the application automatically blocks answers or switches to a fallback message if the confidence score drops below a defined threshold. | 2 | D/V |
 | **7.2.3** | **Verify that** hallucination events (low-confidence responses) are logged with input/output metadata for analysis. | 2 | D/V |
 
 ---
@@ -40,8 +40,8 @@ Technical controls to detect and scrub bad content before it is shown to the use
 | **7.3.1** | **Verify that** automated classifiers scan every response and block content that matches hate, harassment, or sexual violence categories. | 1 | D/V |
 | **7.3.2** | **Verify that** the system scans every response for PII (like credit cards or emails) and automatically redacts it before display. | 1 | D/V |
 | **7.3.3** | **Verify that** data labeled as "confidential" in the system remains blocked or redacted. | 2 | D |
-| **7.3.4** | **Verify that** the system requires a human approval step or re-authentication if the model generates high-risk content. | 3 | D/V |
-| **7.3.5** | **Verify that** safety filters can be configured differently based on the user's role or location (e.g., stricter filters for minors). | 3 | D/V |
+| **7.3.4** | **Verify that** safety filters can be configured differently based on the user's role or location (e.g., stricter filters for minors) as appropriate. | 2 | D/V |
+| **7.3.5** | **Verify that** the system requires a human approval step or re-authentication if the model generates high-risk content. | 3 | D/V |
 
 ---
 
@@ -53,7 +53,7 @@ Prevent the model from doing too much, too fast, or accessing things it should n
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
 | **7.4.1** | **Verify that** the system enforces hard limits on requests and tokens per user to prevent cost spikes and denial of service. | 1 | D |
 | **7.4.2** | **Verify that** the model cannot execute high-impact actions (like writing files, sending emails, or executing code) without explicit user confirmation. | 1 | D/V |
-| **7.4.3** | **Verify that** the agent framework explicitly configures and enforces the maximum depth of recursive calls, delegation limits, and the list of allowed external tools. | 2 | D |
+| **7.4.3** | **Verify that** the application or orchestration framework explicitly configures and enforces the maximum depth of recursive calls, delegation limits, and the list of allowed external tools. | 2 | D |
 
 ---
 
@@ -63,9 +63,9 @@ Ensure the user knows why a decision was made.
 
 | # | Description | Level | Role |
 | :-------: | ------------------------------------------------------------------------------------------------------------------------------ | :---: | :--: |
-| **7.5.1** | **Verify that** the UI displays a confidence score or "reasoning summary" to the user for critical decisions. | 2 | D/V |
-| **7.5.2** | **Verify that** explanations provided to the user are sanitized to remove system prompts or backend data. | 2 | D/V |
-| **7.5.3** | **Verify that** technical evidence of the model's decision (like attention maps) are logged.| 3 | D |
+| **7.5.1** | **Verify that** explanations provided to the user are sanitized to remove system prompts or backend data. | 1 | D/V |
+| **7.5.2** | **Verify that** the UI displays a confidence score or "reasoning summary" to the user for critical decisions. | 2 | D/V |
+| **7.5.3** | **Verify that** technical evidence of the model's decision, such as model interpretability artifacts (e.g., attention maps, feature attributions), are logged.| 3 | D |
 
 ---
 
@@ -76,22 +76,22 @@ Ensure the application sends the right signals for security teams to watch.
 | # | Description | Level | Role |
 | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :--: |
 | **7.6.1** | **Verify that** the system logs real-time metrics for safety violations (e.g., "Hallucination Detected", "PII Blocked").| 1 | D |
-| **7.6.2** | **Verify that** the system triggers an alert if safety violation rates exceed a defined threshold within a specific time window. | 1 | V |
+| **7.6.2** | **Verify that** the system triggers an alert if safety violation rates exceed a defined threshold within a specific time window. | 2 | D/V |
 | **7.6.3** | **Verify that** logs include the specific model version and other details necessary to investigate potential abuse. | 2 | V |
 
 ---
 
-## 7.7 Generative Media Safeguards
+## C7.7 Generative Media Safeguards
 
 Prevent the creation of illegal or fake media.
 
 | # | Description | Level | Role |
 | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :--: |
-| **7.7.1** | **Verify that** the system refuses to generate media (images/audio) that depicts real people without verified consent. | 1 | D/V |
-| **7.7.2** | **Verify that** input filters block prompts requesting explicit or deepfake content before the model processes them. | 2 | D/V  |
+| **7.7.1** | **Verify that** input filters block prompts requesting explicit or non-consensual synthetic content before the model processes them. | 1 | D/V |
+| **7.7.2** | **Verify that** the system refuses to generate media (images/audio) that depicts real people without verified consent. | 2 | D/V |
 | **7.7.3** | **Verify that** the system checks generated content for copyright violations before releasing it. | 2 | V |
-| **7.7.4** | **Verify that** all generated media includes an invisible watermark or cryptographic signature to prove it was AI-generated. | 3 | D/V  |
-| **7.7.5** | **Verify that** attempts to bypass filters are detected and logged as security events. | 3 | V |
+| **7.7.4** | **Verify that** attempts to bypass filters are detected and logged as security events. | 2 | D/V |
+| **7.7.5** | **Verify that** all generated media includes an invisible watermark or cryptographic signature to prove it was AI-generated. | 3 | D/V  |
 
 ## References
 


### PR DESCRIPTION
Rebalances C07 level assignments and generalizes technique-specific terminology. Several controls were at the wrong level when compared to other chapters (C02, C09, C12, C13) and OWASP LLM Top 10.

### Level changes

| Control | Change | Rationale |
|---------|--------|-----------|
| 7.1.3 | L2 → L1 | Treating model output as untrusted (parameterized queries, safe deserializers) is OWASP LLM05's primary prevention strategy; C02's 2.1.1 treats inputs as untrusted at L1 also |
| 7.1.4 | L3 → L2 | Logging rejection error types is a reasonable operational practice and consistent with C12's structured event logging at L2 |
| 7.2.2 | L1 → L2 | Threshold-based auto-blocking requires careful tuning, mirrors C13.6.2 (uncertainty thresholds trigger review) at L2; having scores is L1, acting on thresholds is L2 |
| 7.3.4 (was 7.3.5) | L3 → L2 | Role/location-based filter configuration mirrors C02's 2.5.3 (user-specific screening policies) at L2; same concept, different direction |
| 7.5.1 (was 7.5.2) | L2 → L1 | Preventing system prompt or backend data leakage in should be basics, is also OWASP LLM07:2025 (System Prompt Leakage) |
| 7.6.2 | L1 → L2 | Threshold-based alerting requires baselines and integration infrastructure; consistent with C12.2.5 (real-time alerting) at L2 |
| 7.7.1 (was 7.7.2) | L2 → L1 | Blocking harmful generation requests is basic content safety and consistent with C02's 2.5.1–2.5.2 (content classification + policy enforcement) at L1 |
| 7.7.2 (was 7.7.1) | L1 → L2 | "Verified consent" for real-person depictions requires identity detection plus consent management infrastructure, this is a bit beyond basic stuff |
| 7.7.4 (was 7.7.5) | L3 → L2 | Detecting and logging filter bypass attempts is normal security monitoring; C12.2.1 (detect jailbreak patterns) and C02.2.2 (quarantine adversarial inputs) are both L1 |

### Language and terminology changes

- **C7.2 section description**: "unsure or lying" → "produces potentially inaccurate or fabricated content" - I think we should avoid anthropomorphizing language
- **7.2.1**: "using log-probabilities" → "confidence scoring, retrieval-based verification, or model uncertainty estimation" - log-probabilities are one technique and not all model APIs expose them
- **7.4.3**: "agent framework" → "application or orchestration framework" - C09 covers agentic scenarios whereas C07 should apply broadly
- **7.5.3**: "like attention maps" → "such as model interpretability artifacts (e.g., attention maps, feature attributions)" - generalizes also outside of transformer-specific techniques
- **7.7.1** (was 7.7.2): "deepfake content" → "non-consensual synthetic content" - more general and specific terminology 
- **7.1.4, 7.6.2**: Role changed from V to D/V - consistent with C12 logging/alerting patterns where both developer and verifier are involved
