### PR TITLE
Add context window flooding defense control under C2.1

### DIFF
--- a/1.0/en/0x10-C02-User-Input-Validation.md
+++ b/1.0/en/0x10-C02-User-Input-Validation.md
@@ -15,7 +15,7 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | **2.1.1** | **Verify that** any external or derived input that may steer behavior, including user prompts, RAG results, tool integration or MCP outputs, agent to agent messages, API or webhook responses, configuration or policy files, memory reads and memory writes, is treated as untrusted, made inert by quoting or tagging and active content removal, and screened by a maintained prompt injection detection ruleset or service before concatenation into prompts or execution of actions. | 1 |  D/V |
 | **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. | 1 |  D/V |
 | **2.1.3** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 | D |
-| **2.1.4** | **Verify that** input length controls account for context window limits and that the system prevents user-supplied content from exceeding a proportion of the total context window that would displace system instructions or safety directives from the model's effective attention. | 2 | D/V |
+| **2.1.4** | **Verify that** input length controls account for context window limits and that the system prevents user-supplied content from exceeding a proportion of the total context window that would displace system instructions or safety directives from the model's effective attention. | 1 | D/V |
 
 ---
 


### PR DESCRIPTION
 Related to #144

Adds a control for context window flooding, where oversized inputs push system instructions out of the model's effective attention window, causing the model to lose its safety constraints. This differs from standard prompt injection because the payload contains no injection keywords and works purely through volume. Reference implementation: https://github.com/mattijsmoens/sovereign-shield (InputFilter module, enforces max input length before prompt assembly)