### PR TITLE
Add content based type detection and filename sanitization controls u…

### DIFF
--- a/1.0/en/0x10-C02-User-Input-Validation.md
+++ b/1.0/en/0x10-C02-User-Input-Validation.md
@@ -97,7 +97,6 @@ AI systems should include robust validation for non-textual inputs (images, audi
 | **2.7.6** | **Verify that** file type validation uses content-based detection (magic bytes/file headers) in addition to declared MIME types and file extensions, so that type-spoofed files (e.g., a script disguised as an image) cannot bypass modality-specific AI safety filters and reach the model pipeline unvalidated, and that mismatches between declared and detected type are rejected as potential type spoofing. | 1 | D/V |
 | **2.7.7** | **Verify that** filenames submitted to AI processing pipelines are sanitized against null byte injection, path traversal sequences, and double extension attacks (e.g., "input.jpg.exe") that could manipulate how the pipeline routes, stores, or interprets uploaded files before model ingestion. | 1 | D/V |
 
-
 ---
 
 ## C2.8 Real-Time Adaptive Threat Detection


### PR DESCRIPTION
Related to #144

Adds two controls to C2.7 (Multi Modal Input Validation) addressing AI-specific file type risks:

- C2.7.6: Content-based file type detection to prevent attackers from disguising malicious payloads as valid input modalities (e.g., a script with a .png extension bypassing image-only safety filters and reaching the model pipeline unvalidated).

- C2.7.7: Filename sanitization against null byte injection, path traversal, and double extension attacks that could manipulate how AI pipelines route, store, or process uploaded files (e.g., "prompt.jpg.exe" or "../../model_config.json").

Both are deterministic, zero-cost checks that sit at the boundary between user input and model ingestion, before any modality-specific AI safety filters are applied.

Reference implementation: https://github.com/mattijsmoens/sovereign-shield (MultiModalFilter module)