### PR TITLE
Revise C08 levels and terminology

### DIFF
--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -2,7 +2,7 @@
 
 ## Control Objective
 
-Embeddings and vector stores act as semi-persistent amd persistent "memory" for AI systems via Retrieval-Augmented Generation (RAG). This memory can become a high-risk data sink and data exfiltration path. This control family hardens memory pipelines and vector databases so that access is least-privilege, data is sanitized before vectorization, retention is explicit, and systems are resilient to embedding inversion, membership inference, and cross-tenant leakage.
+Embeddings and vector stores act as semi-persistent and persistent "memory" for AI systems via Retrieval-Augmented Generation (RAG). This memory can become a high-risk data sink and data exfiltration path. This control family hardens memory pipelines and vector databases so that access is least-privilege, data is sanitized before vectorization, retention is explicit, and systems are resilient to embedding inversion, membership inference, and cross-tenant leakage.
 
 ## C8.1 Access Controls on Memory & RAG Indices
 
@@ -13,7 +13,7 @@ Enforce fine-grained access controls and query-time scope enforcement for every 
 | **8.1.1** | **Verify that** vector insert, update, delete, and query operations are enforced with namespace/collection/document-tag scope controls (e.g., tenant ID, user ID, data classification labels) with default-deny. | 1 | D/V |
 | **8.1.2** | **Verify that** API credentials used for vector operations carry **scoped claims** (e.g., permitted collections, allowed verbs, tenant binding). | 1 | D/V |
 | **8.1.3** | **Verify that** cross-scope access attempts (e.g., cross-tenant similarity queries, namespace traversal, tag bypass) are detected and rejected. | 2 | D/V |
-| **8.1.4** | **Verify that** every ingested document is tagged at write time with source, writer identity (authenticated user or system principal), timestamp, batch ID, and embedding model version, and that these tags are immutable after initial write. | 1 | D/V |
+| **8.1.4** | **Verify that** every ingested document is tagged at write time with source, writer identity (authenticated user or system principal), timestamp, batch ID, and embedding model version, and that these tags are immutable after initial write. | 2 | D/V |
 
 ## C8.2 Embedding Sanitization & Validation
 
@@ -22,10 +22,10 @@ Pre-screen content before vectorization; treat memory writes as untrusted inputs
 | # | Description | Level | Role |
 | :--: | --- | :---: | :--: |
 | **8.2.1** | **Verify that** regulated data and sensitive fields are detected prior to embedding and are masked, tokenized, transformed, or dropped based on policy. | 1 | D/V |
-| **8.2.2** | **Verify that** embedding ingestion rejects or quarantines inputs that violate required content constraints (e.g., non-UTF-8, malformed encodings, oversized payloads, invisible ASCII characters, or executable content intended to poison retrieval). | 1 | D/V |
+| **8.2.2** | **Verify that** embedding ingestion rejects or quarantines inputs that violate required content constraints (e.g., non-UTF-8, malformed encodings, oversized payloads, invisible Unicode characters, or executable content intended to poison retrieval). | 1 | D/V |
 | **8.2.3** | **Verify that** vectors that fall outside normal clustering patterns are flagged and quarantined before entering production indices. | 2 | D/V |
-| **8.2.4** | **Verify that** an agent's own outputs are not automatically written back into its trusted memory without explicit validation (such as middleware hooks or store-level auth handlers that check content origin before committing writes). | 2 | D/V |
-| **8.2.5** | **Verify that** new content written to memory is checked for contradictions with what is already stored and that conflicts trigger alerts. | 2 | D/V |
+| **8.2.4** | **Verify that** an agent's own outputs are not automatically written back into its trusted memory without explicit validation (such as content-origin checks or write-authorization controls that verify provenance before committing writes). | 2 | D/V |
+| **8.2.5** | **Verify that** new content written to memory is checked for contradictions with what is already stored and that conflicts trigger alerts. | 3 | D/V |
 
 ## C8.3 Memory Expiry, Revocation & Deletion
 
@@ -37,7 +37,7 @@ Retention must be explicit and enforceable; deletions must propagate to derived 
 | **8.3.2** | **Verify that** only information required for the system's defined function is persisted in memory (such as user preferences and conversation decisions, not credentials or full conversation transcripts), and that context not needed beyond the current session is discarded at session end. | 1 | D/V |
 | **8.3.3** | **Verify that** deletion requests purge vectors, metadata, cache copies, and derivative indices within an organization-defined maximum time. | 1 | D/V |
 | **8.3.4** | **Verify that** deleted or expired vectors are removed reliably and are unrecoverable. | 2 | D |
-| **8.3.5** | **Verify that** expired vectors are excluded from retrieval results within a measured and monitored propagation windows. | 3 | D/V |
+| **8.3.5** | **Verify that** expired vectors are excluded from retrieval results within a measured and monitored propagation window. | 2 | D/V |
 | **8.3.6** | **Verify that** memory can be reset for security reasons (quarantine, selective purge, full reset) separately from retention deletion, and that quarantined content is kept for investigation but excluded from retrieval. | 2 | D/V |
 
 ## C8.4 Prevent Embedding Inversion & Leakage
@@ -57,11 +57,17 @@ Prevent cross-tenant and cross-user leakage in retrieval and prompt assembly.
 | :--: | --- | :---: | :--: |
 | **8.5.1** | **Verify that** every retrieval operation enforces scope constraints (tenant/user/classification) **in the vector engine query** and verifies them again **before prompt assembly** (post-filter). | 1 | D/V |
 | **8.5.2** | **Verify that** vector identifiers, namespaces, and metadata indexing prevent cross-scope collisions and enforce uniqueness per tenant. | 1 | D |
-| **8.5.3** | **Verify that** retrieval results that match similarity criteria but fail scope checks are discarded. | 2 | D/V |
+| **8.5.3** | **Verify that** retrieval results that match similarity criteria but fail scope checks are discarded. | 1 | D/V |
 | **8.5.4** | **Verify that** multi-tenant tests simulate adversarial retrieval attempts (prompt-based and query-based) and demonstrate zero out-of-scope document inclusion in prompts and outputs. | 2 | V |
-| **8.5.5** | **Verify that** encryption keys and access policies are segregated per tenant for memory/vector storage, providing cryptographic isolation in shared infrastructure. | 3 | D/V |
-| **8.5.6** | **Verify that** in multi-agent systems, each agent's memory namespace is isolated and enforced through access control (such as scoped auth handlers or middleware validation), not just organizational naming conventions. | 2 | D/V |
+| **8.5.5** | **Verify that** in multi-agent systems, each agent's memory namespace is isolated and enforced through access control, not just organizational naming conventions. | 2 | D/V |
+| **8.5.6** | **Verify that** encryption keys and access policies are segregated per tenant for memory/vector storage, providing cryptographic isolation in shared infrastructure. | 3 | D/V |
 
-## References (recommended additions)
+## References
 
-* OWASP Foundation. **OWASP Top 10 for Large Language Model Applications (LLM) 2025**. https://owasp.org/www-project-top-10-for-large-language-model-applications/assets/PDF/OWASP-Top-10-for-LLMs-v2025.pdf
+* [OWASP LLM08:2025 Vector and Embedding Weaknesses](https://genai.owasp.org/llmrisk/llm082025-vector-and-embedding-weaknesses/)
+* [OWASP LLM04:2025 Data and Model Poisoning](https://genai.owasp.org/llmrisk/llm042025-data-and-model-poisoning/)
+* [OWASP LLM02:2025 Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/)
+* [MITRE ATLAS : RAG Poisoning](https://atlas.mitre.org/techniques/AML.T0070)
+* [MITRE ATLAS : False RAG Entry Injection](https://atlas.mitre.org/techniques/AML.T0071)
+* [MITRE ATLAS : Infer Training Data Membership](https://atlas.mitre.org/techniques/AML.T0024.000)
+* [MITRE ATLAS : Invert AI Model](https://atlas.mitre.org/techniques/AML.T0024.001)


### PR DESCRIPTION
# Revise levels and terminology for C08

Rebalances C08 level assignments and fixes terminology issues. C08 was generally well-balanced but had a few controls at the wrong level when compared to peer chapters, plus minor terminology improvements. Controls within C8.5 reordered after level changes.

## Level changes

| Control | Change | Rationale |
|---------|--------|-----------|
| 8.1.4 | L1 → L2 | Immutable provenance tagging with five specific metadata fields goes beyond basic access control; consistent with C3's 3.2.3 (immutable audit records with timestamp, actor, change type, before/after states) at L2 |
| 8.2.5 | L2 → L3 | Automated semantic contradiction detection across stored content is technically complex and situational; closer to C7's 7.2.4 (independent verification for high-risk responses) at L3 than to typical L2 controls |
| 8.3.5 | L3 → L2 | Verifying that expired vectors are excluded from retrieval is a correctness check, not a niche technique; it validates that 8.3.1 (retention times, L1) actually works; consistent with C13's 13.3.2 (automated alerting on metric degradation) at L2 |
| 8.5.3 | L2 → L1 | Discarding retrieval results that fail scope checks is critical to scope enforcement, not an advanced control; equivalent to "if authorization fails, deny access" which is always L1; consistent with C5's 5.3.2 (failed auth aborts query) at L1 |

## Language and terminology changes

- Few typos fixed
- **8.2.2**: "invisible ASCII characters" → "invisible Unicode characters" (technically correct; the concern is Unicode control characters, not ASCII)
- **8.2.4**: "middleware hooks or store-level auth handlers that check content origin" → "content-origin checks or write-authorization controls that verify provenance" (generalizes away from specific implementation patterns)
- **8.3.5**: "propagation windows" → "propagation window" (grammar fix, singular)
- **8.5.5** (was 8.5.6): removed implementation-specific parenthetical "(such as scoped auth handlers or middleware validation)" to keep the requirement technology-neutral

## References update

- **OWASP LLM08:2025 Vector and Embedding Weaknesses** - the directly mapped LLM Top 10 entry for this chapter
- **OWASP LLM04:2025 Data and Model Poisoning** - covers RAG/embedding poisoning as a form of data poisoning
- **OWASP LLM02:2025 Sensitive Information Disclosure** - covers embedding inversion and cross-tenant leakage risks
- **MITRE ATLAS : RAG Poisoning (AML.T0070)** - injecting malicious content into RAG-indexed data; maps to C8.2 sanitization controls
- **MITRE ATLAS : False RAG Entry Injection (AML.T0071)** - introducing false entries into RAG databases; maps to C8.1 access controls and C8.2 validation
- **MITRE ATLAS : Infer Training Data Membership (AML.T0024.000)** - membership inference attacks against embeddings; maps to C8.4 leakage prevention
- **MITRE ATLAS : Invert AI Model (AML.T0024.001)** - reconstructing source data from embeddings; maps to C8.4 inversion resistance