### PR TITLE
Revise C11 levels and definitions

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -1,130 +1,136 @@
-# C11 Adversarial Robustness & Privacy Defense
+# C11 Adversarial Robustness & Attack Resistance
 
 ## Control Objective
 
-Ensure that AI models remain reliable, privacy-preserving, and abuse-resistant when facing evasion, inference, extraction, or poisoning attacks.
+Ensure that AI systems remain reliable, privacy-preserving, and abuse-resistant when facing evasion, inference, extraction, or poisoning attacks. These controls cover model alignment testing, adversarial hardening, privacy attack resistance, model theft deterrence, and security adaptation for autonomous agents.
 
 ---
 
 ## C11.1 Model Alignment & Safety
 
-Guard against harmful or policy-breaking outputs.
+Guard against harmful or policy-breaking outputs through systematic testing and guardrails.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **11.1.1** | **Verify that** an alignment test-suite (red-team prompts, jailbreak probes, disallowed content) is version-controlled and run on every model release. | 1 | D/V |
-| **11.1.2** | **Verify that** refusal and safe-completion guard-rails are enforced. | 1 | D |
-| **11.1.3** | **Verify that** an automated evaluator measures harmful-content rate and flags regressions beyond a set threshold. | 2 | D/V |
-| **11.1.4** | **Verify that** counter-jailbreak training is documented and reproducible. | 2 | D |
-| **11.1.5** | **Verify that** formal policy-compliance proofs or certified monitoring cover critical domains. | 3 | V |
+| **11.1.1** | **Verify that** refusal and safe-completion guardrails are enforced to prevent the model from generating disallowed content categories. | 1 | D |
+| **11.1.2** | **Verify that** an alignment test suite (red-team prompts, jailbreak probes, disallowed-content checks) is version-controlled and run on every model update or release. | 1 | D/V |
+| **11.1.3** | **Verify that** an automated evaluator measures harmful-content rate and flags regressions beyond a defined threshold. | 2 | D/V |
+| **11.1.4** | **Verify that** alignment and safety training procedures (e.g., RLHF, constitutional AI, or equivalent) are documented and reproducible. | 2 | D |
+| **11.1.5** | **Verify that** alignment evaluation includes assessments for evaluation awareness, where the model may behave differently when it detects it is being tested versus deployed. | 3 | V |
 
 ---
 
 ## C11.2 Adversarial-Example Hardening
 
-Increase resilience to manipulated inputs. Robust adversarial-training and benchmark scoring are the current best practice.
+Increase resilience to manipulated inputs designed to cause misclassification or policy bypass. Adversarial testing and robustness benchmarking are the current best practices.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **11.2.1** | **Verify that** project repositories include adversarial-training configurations with reproducible seeds. | 1 | D |
-| **11.2.2** | **Verify that** adversarial-example detection raises blocking alerts in production pipelines. | 2 | D/V |
-| **11.2.4** | **Verify that** certified‐robustness proofs or interval-bound certificates cover at least the top critical classes. | 3 | V |
-| **11.2.5** | **Verify that** regression tests use adaptive attacks to confirm no measurable robustness loss. | 3 | V |
+| **11.2.1** | **Verify that** models serving high-risk functions are evaluated against known adversarial attack techniques relevant to their modality (e.g., perturbation attacks for vision, token-manipulation attacks for text). | 1 | D/V |
+| **11.2.2** | **Verify that** adversarial-example detection raises alerts in production pipelines, with blocking or degraded-capability responses for high-risk endpoints or use cases. | 2 | D/V |
+| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied where feasible, with documented configurations and reproducible procedures. | 2 | D |
+| **11.2.4** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 | V |
+| **11.2.5** | **Verify that** formal robustness verification methods (e.g., certified bounds, interval-bound propagation) are applied to safety-critical model components where the model architecture supports them. | 3 | V |
 
 ---
 
 ## C11.3 Membership-Inference Mitigation
 
-Limit the ability to decide whether a record was in training data. Differential privacy and confidence-score masking remain the most effective known defenses.
+Limit the ability to determine whether a specific record was in the training data. Differential privacy and output calibration are the most effective known defenses.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **11.3.1** | **Verify that** per-query entropy regularization or temperature-scaling reduces overconfident predictions. | 1 | D |
-| **11.3.2** | **Verify that** training employs ε-bounded differentially-private optimization for sensitive datasets. | 2 | D |
-| **11.3.3** | **Verify that** attack simulations (shadow-model or black-box) show attack AUC ≤ 0.60 on held-out data. | 2 | V |
+| **11.3.1** | **Verify that** model outputs are calibrated (e.g., via temperature scaling or output perturbation) to reduce overconfident predictions that facilitate membership-inference attacks. | 2 | D |
+| **11.3.2** | **Verify that** training on sensitive datasets employs differentially-private optimization (e.g., DP-SGD) with a documented privacy budget (epsilon). | 2 | D |
+| **11.3.3** | **Verify that** membership-inference attack simulations (e.g., shadow-model, likelihood-ratio, or label-only attacks) demonstrate that attack accuracy does not meaningfully exceed random guessing on held-out data. | 3 | V |
 
 ---
 
 ## C11.4 Model-Inversion Resistance
 
-Prevent reconstruction of private attributes. Recent surveys emphasize output truncation and DP guarantees as practical defenses.
+Prevent reconstruction of private training data or sensitive attributes from model outputs.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **11.4.1** | **Verify that** sensitive attributes are never directly output; where needed, use buckets or one-way transforms. | 1 | D |
-| **11.4.2** | **Verify that** query-rate limits throttle repeated adaptive queries from the same principal. | 1 | D/V |
-| **11.4.3** | **Verify that** the model is trained with privacy-preserving noise. | 2 | D |
+| **11.4.1** | **Verify that** sensitive attributes are never directly output; where needed, outputs use generalized categories (e.g., ranges, buckets) or one-way transforms. | 1 | D |
+| **11.4.2** | **Verify that** query-rate limits throttle repeated adaptive queries from the same principal to raise the cost of inversion attacks. | 1 | D/V |
+| **11.4.3** | **Verify that** models handling sensitive data are trained with privacy-preserving techniques (e.g., differential privacy, gradient clipping) to limit information leakage through outputs. | 2 | D |
 
 ---
 
 ## C11.5 Model-Extraction Defense
 
-Detect and deter unauthorized cloning. Watermarking and query-pattern analysis are recommended.
+Detect and deter unauthorized model cloning through API abuse. Rate limiting, query-pattern analysis, and watermarking are recommended defenses.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **11.5.1** | **Verify that** inference gateways enforce global and per-API-key rate limits tuned to the model's memorization threshold. | 1 | D |
-| **11.5.2** | **Verify that** query-entropy and input-plurality statistics feed an automated extraction detector. | 2 | D/V |
-| **11.5.3** | **Verify that** fragile or probabilistic watermarks can be proved with p < 0.01 in ≤ 1 000 queries against a suspected clone. | 2 | V |
-| **11.5.4** | **Verify that** watermark keys and trigger sets are stored in a hardware-security-module and rotated yearly. | 3 | D |
-| **11.5.5** | **Verify that** extraction-alert events include offending queries and are integrated with incident-response playbooks. | 3 | V |
+| **11.5.1** | **Verify that** inference endpoints enforce per-principal and global rate limits designed to make large-scale query harvesting impractical. | 1 | D |
+| **11.5.2** | **Verify that** extraction-alert events include offending query metadata and are integrated with incident-response playbooks. | 2 | V |
+| **11.5.3** | **Verify that** query-pattern analysis (e.g., query diversity, input distribution anomalies) feeds an automated extraction-attempt detector. | 2 | D/V |
+| **11.5.4** | **Verify that** model watermarking or fingerprinting techniques are applied so that unauthorized copies can be identified. | 3 | D |
+| **11.5.5** | **Verify that** watermark verification keys and trigger sets are protected with access controls equivalent to other critical cryptographic material. | 3 | D |
 
 ---
 
 ## C11.6 Inference-Time Poisoned-Data Detection
 
-Identify and neutralize backdoored or poisoned inputs.
+Identify and neutralize backdoored or poisoned inputs at inference time, particularly in systems that consume external data (e.g., RAG pipelines, tool outputs).
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **11.6.1** | **Verify that** inputs pass through an anomaly detector (e.g., STRIP, consistency-scoring) before model inference. | 1 | D |
-| **11.6.2** | **Verify that** detector thresholds are tuned on clean/poisoned validation sets to achieve less that 5% false positives. | 1 | V |
-| **11.6.3** | **Verify that** inputs flagged as poisoned trigger soft-blocking and human review workflows. | 2 | D |
-| **11.6.4** | **Verify that** detectors are stress-tested with adaptive, triggerless backdoor attacks. | 2 | V |
-| **11.6.5** | **Verify that** detection efficacy metrics are logged and periodically re-evaluated with fresh threat intel. | 3 | D |
+| **11.6.1** | **Verify that** inputs from external or untrusted sources pass through anomaly detection (e.g., statistical outlier detection, consistency scoring) before model inference. | 2 | D |
+| **11.6.2** | **Verify that** anomaly-detection thresholds are tuned on representative clean and adversarial validation sets and that the false-positive rate is measured and documented. | 2 | V |
+| **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review) appropriate to the risk level. | 2 | D |
+| **11.6.4** | **Verify that** detection methods are periodically stress-tested with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 | V |
+| **11.6.5** | **Verify that** detection efficacy metrics are logged and periodically re-evaluated against updated threat intelligence. | 3 | D/V |
 
 ---
 
-## C11.7 Dynamic Security Policy Adaptation
+## C11.7 Security Policy Adaptation
 
 Real-time security policy updates based on threat intelligence and behavioral analysis.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **11.7.1** | **Verify that** security policies can be updated dynamically without agent restart while maintaining policy version integrity. | 1 | D/V |
-| **11.7.2** | **Verify that** policy updates are cryptographically signed by authorized security personnel and validated before application. | 2 | D/V |
-| **11.7.3** | **Verify that** dynamic policy changes are logged with full audit trails including justification, approval chains, and rollback procedures. | 2 | D/V |
-| **11.7.4** | **Verify that** adaptive security mechanisms adjust threat detection sensitivity based on risk context and behavioral patterns. | 3 | D/V |
-| **11.7.5** | **Verify that** policy adaptation decisions are explainable and include evidence trails for security team review. | 3 | D/V |
+| **11.7.1** | **Verify that** security policies (e.g., content filters, rate-limit thresholds, guardrail configurations) can be updated without full system redeployment, and that policy versions are tracked. | 1 | D/V |
+| **11.7.2** | **Verify that** policy updates are authorized, integrity-protected (e.g., cryptographically signed), and validated before application. | 2 | D/V |
+| **11.7.3** | **Verify that** policy changes are logged with audit trails including timestamp, author, justification, and rollback procedures. | 2 | D/V |
+| **11.7.4** | **Verify that** threat-detection sensitivity can be adjusted based on risk context (e.g., elevated threat level, incident response) with appropriate authorization. | 3 | D/V |
 
 ---
 
-## C11.8 Reflection-Based Security Analysis
+## C11.8 Agent Security Self-Assessment
 
-Security validation through agent self-reflection and meta-cognitive analysis.
+For agentic AI systems, validate that the agent's reasoning and actions are subject to security-focused review mechanisms.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **11.8.1** | **Verify that** agent reflection mechanisms include security-focused self-assessment of decisions and actions. | 1 | D/V |
-| **11.8.2** | **Verify that** reflection outputs are validated to prevent manipulation of self-assessment mechanisms by adversarial inputs. | 2 | D/V |
-| **11.8.3** | **Verify that** meta-cognitive security analysis identifies potential bias, manipulation, or compromise in agent reasoning processes. | 2 | D/V |
-| **11.8.4** | **Verify that** reflection-based security warnings trigger enhanced monitoring and potential human intervention workflows. | 3 | D/V |
-| **11.8.5** | **Verify that** continuous learning from security reflections improves threat detection without degrading legitimate functionality. | 3 | D/V |
+| **11.8.1** | **Verify that** agentic systems include a mechanism to review planned high-risk actions against security policy before execution (e.g., a secondary model, rule-based checker, or structured self-review step). | 2 | D/V |
+| **11.8.2** | **Verify that** security review mechanisms are protected against manipulation by adversarial inputs (e.g., the review step cannot be overridden or bypassed through prompt injection). | 2 | D/V |
+| **11.8.3** | **Verify that** security review warnings trigger enhanced monitoring or human intervention workflows for the affected session or task. | 3 | D/V |
 
 ---
 
-## C11.9 Evolution & Self-Improvement Security
+## C11.9 Self-Modification & Autonomous Update Security
 
-Security controls for agent systems capable of self-modification and evolution.
+Security controls for systems where the AI can modify its own configuration, prompts, tool access, or learned behaviors.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **11.9.1** | **Verify that** self-modification capabilities are restricted to designated safe areas with formal verification boundaries. | 1 | D/V |
-| **11.9.2** | **Verify that** evolution proposals undergo security impact assessment before implementation. | 2 | D/V |
-| **11.9.3** | **Verify that** self-improvement mechanisms include rollback capabilities with integrity verification. | 2 | D/V |
-| **11.9.4** | **Verify that** meta-learning security prevents adversarial manipulation of improvement algorithms. | 3 | D/V |
-| **11.9.5** | **Verify that** recursive self-improvement is bounded by formal safety constraints with mathematical proofs of convergence. | 3 | D/V |
+| **11.9.1** | **Verify that** any self-modification capability (e.g., prompt rewriting, tool-list changes, parameter updates) is restricted to explicitly designated areas with enforced boundaries. | 2 | D/V |
+| **11.9.2** | **Verify that** proposed self-modifications undergo security impact assessment or policy validation before taking effect. | 2 | D/V |
+| **11.9.3** | **Verify that** all self-modifications are logged, reversible, and subject to integrity verification, enabling rollback to a known-good state. | 2 | D/V |
+| **11.9.4** | **Verify that** self-modification scope is bounded (e.g., maximum change magnitude, rate limits on updates, prohibited modification targets) to prevent runaway or adversarially induced changes. | 3 | D/V |
 
 ---
 
-### References
+## References
+
+* [OWASP LLM02:2025 Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/)
+* [OWASP LLM04:2025 Data and Model Poisoning](https://genai.owasp.org/llmrisk/llm042025-data-and-model-poisoning/)
+* [OWASP LLM10:2025 Unbounded Consumption](https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/)
+* [MITRE ATLAS : Infer Training Data Membership](https://atlas.mitre.org/techniques/AML.T0024.000)
+* [MITRE ATLAS : Invert ML Model](https://atlas.mitre.org/techniques/AML.T0024.001)
+* [MITRE ATLAS : Extract ML Model](https://atlas.mitre.org/techniques/AML.T0024.002)
+* [MITRE ATLAS : Backdoor ML Model](https://atlas.mitre.org/techniques/AML.T0018)
+* [NIST AI 100-2e2023 Adversarial Machine Learning: A Taxonomy and Terminology of Attacks and Mitigations](https://csrc.nist.gov/pubs/ai/100/2/e2023/final)


### PR DESCRIPTION
Recalibrates verification levels, revises requirement details and generalizes terminology for longevity. Also added references.

While there are actual changes to proposed requirements, they more of updates to what is the state of the technology to day as far as I am aware. This comes with a disclaimer I don't claim to be an expert in adversarial robustness, rather gathered from various resources here now and generalized as much as possible so that the content would not be out of date in 6 months when new techniques come out.

## Changes by section

### Title & Control Objective
- Renamed from "Adversarial Robustness & Privacy Defense" to "Adversarial Robustness & Attack Resistance" -> privacy has its own dedicated chapter (C12); I think we should try to focus on keeping all privacy controls there. We could even shorten this to just "Adversarial Robustness".
- Expanded control objective to enumerate the sub-topics covered.

### C11.1 Model Alignment & Safety

| # | Change | Rationale |
|---|--------|-----------|
| 11.1.1 | Swapped order with old 11.1.2 so guardrails come first (foundational), then testing. Kept L1. | Guardrails are the most basic control; testing validates them. |
| 11.1.2 | Was 11.1.1. Kept L1. Minor wording clarification ("model update or release" instead of "model release"). | Covers fine-tune updates, not just full releases. |
| 11.1.4 | Was "counter-jailbreak training." Generalized to "alignment and safety training procedures (e.g., RLHF, constitutional AI, or equivalent)." Kept L2. | "Counter-jailbreak training" is narrow and may age poorly. The real requirement is that whatever alignment method is used, it is documented and reproducible. |
| 11.1.5 | Replaced "formal policy-compliance proofs or certified monitoring" with evaluation-awareness assessment. Kept L3. | Formal compliance proofs for LLM alignment don't exist in practice as far as I know - at least not yet. Evaluation awareness (model behaving differently when it detects testing vs. deployment) is a real, documented frontier concern per e.g. Anthropic's Opus 4.6 system card. This is an L3 requirement we want to see in frontier AI. |

### C11.2 Adversarial-Example Hardening

| # | Change | Rationale |
|---|--------|-----------|
| 11.2.1 | Rewritten from "project repositories include adversarial-training configurations with reproducible seeds" to evaluating models against known attack techniques. Kept L1. | The original assumed all deployers train their own models. Many teams deploy third-party or API-based models. Evaluating against adversarial attacks is the universal L1 action. |
| 11.2.2 | Kept L2. Added "blocking or degraded-capability responses" as the action. | Clarifies what "blocking alerts" means in practice. |
| 11.2.3 | New (was missing - numbering skipped from 11.2.2 to 11.2.4). Adversarial training or equivalent hardening with documented configs. L2. | Fills the gap. Adversarial training is a well-established technique but requires real commitment, appropriate for L2. |
| 11.2.4 | Was 11.2.5. Adaptive attacks for regression testing. Kept L3. | Adaptive attacks (designed to defeat the specific defenses deployed) are the gold standard but require significant expertise. |
| 11.2.5 | Was 11.2.4. Formal robustness verification. Kept L3. Added qualifier "where the model architecture supports them." | Certified robustness (IBP, randomized smoothing) is research-stage for large models and impossible for LLMs. The qualifier makes this applicable where it works (smaller classifiers, safety-critical components) without being unrealistic. |

### C11.3 Membership-Inference Mitigation

| # | Change | Rationale |
|---|--------|-----------|
| 11.3.1 | Changed from L1 to **L2**. Generalized from "per-query entropy regularization" to "output calibration (e.g., temperature scaling or output perturbation)." | Temperature scaling as a membership-inference defense is emerging but not a basic L1 control. Most teams deploying API-based models don't control this. L2 is appropriate. |
| 11.3.2 | Kept L2. Added "(e.g., DP-SGD)" and "documented privacy budget (epsilon)." | Makes the requirement more concrete and verifiable. |
| 11.3.3 | Changed from L2 to **L3**. Replaced "attack AUC <= 0.60" with "attack accuracy does not meaningfully exceed random guessing." Added example attack types. | The specific AUC threshold was arbitrary and research-stage. Shadow-model attacks with proper evaluation are sophisticated (L3). The reworded threshold is more defensible and doesn't pin the standard to a specific number that may not age well. |

### C11.4 Model-Inversion Resistance
- No level changes. Minor wording improvements for clarity.
- 11.4.3: Added examples "(e.g., differential privacy, gradient clipping)" to make "privacy-preserving techniques" concrete.

### C11.5 Model-Extraction Defense

| # | Change | Rationale |
|---|--------|-----------|
| 11.5.1 | Simplified from "tuned to the model's memorization threshold" to "designed to make large-scale query harvesting impractical." Kept L1. | "Memorization threshold" is an ill-defined concept for rate limiting. The intent is to make bulk extraction impractical. |
| 11.5.2 | Was 11.5.5 (extraction alerts in IR playbooks). Moved from L3 to **L2**. | Integrating alerts with incident response is a standard L2 operational control, not advanced. |
| 11.5.3 | Was 11.5.2 (query-pattern analysis). Kept L2. | No change needed, well-placed. |
| 11.5.4 | Was 11.5.3 (watermark provability). Changed from L2 to **L3**. Removed the specific "p < 0.01 in <= 1000 queries" threshold. | Watermark provability with specific statistical thresholds is research-stage. Watermarking itself is a reasonable L3 aspiration. The specific p-value and query count were overly prescriptive for a standard. |
| 11.5.5 | Was 11.5.4 (HSM for watermark keys). Kept L3. Generalized from "hardware-security-module" to "access controls equivalent to other critical cryptographic material." Removed "rotated yearly." | HSM for watermark keys is not standard practice. The real requirement is that watermark keys get the same protection as other critical secrets. Yearly rotation is arbitrary and may not suit all watermarking schemes. |

### C11.6 Inference-Time Poisoned-Data Detection

| # | Change | Rationale |
|---|--------|-----------|
| 11.6.1 | Changed from L1 to **L2**. Removed specific "STRIP" reference. Added context about RAG pipelines and tool outputs. | STRIP is a 2019 technique, not sure how current anymore? Inference-time anomaly detection for backdoors is an emerging thing afaik (not basic L1). Most L1 organizations won't have poisoned-input detectors that I'm willing to bet on. Scoping to external/untrusted sources makes it practical. |
| 11.6.2 | Changed from L1 to **L2**. Replaced "less than 5% false positives" with "false-positive rate is measured and documented." | The specific 5% threshold was reasonable but overly prescriptive. What matters is that the rate is known and documented, not that it hits a specific number. |
| 11.6.3 | Kept L2. Generalized "soft-blocking and human review" to "gating actions (blocking, capability degradation, or human review) appropriate to the risk level." | More flexible and applicable across different deployment contexts. |
| 11.6.4 | Kept L3 (was L2). | Stress-testing detectors with adaptive attacks is advanced work, consistent with L3 across the standard. |
| 11.6.5 | Kept L3. Added "against updated threat intelligence." | Minor clarification. |

### C11.7 Dynamic Security Policy Adaptation -> Security Policy Adaptation

| # | Change | Rationale |
|---|--------|-----------|
| Title | Renamed from "Dynamic Security Policy Adaptation" to "Security Policy Adaptation." | Simpler, less buzzwordy. |
| 11.7.1 | Replaced "without agent restart" with "without full system redeployment." Added concrete examples. Kept L1. | "Agent restart" is too narrow. The real requirement is operational: you can update guardrails without a full release cycle. |
| 11.7.2 | Generalized "cryptographically signed by authorized security personnel" to "authorized, integrity-protected (e.g., cryptographically signed)." Kept L2. | Not all policy updates need cryptographic signing (some use RBAC + audit). The core requirement is authorization and integrity. |
| 11.7.3 | Simplified. Removed "approval chains and rollback procedures" from the log requirement (rollback is operational, not a log field). Kept L2. | Logging should capture who/what/when/why. Rollback procedures are separate from audit logging. |
| 11.7.4 | Simplified. Removed 11.7.5 entirely (was "policy adaptation decisions are explainable"). Kept L3. | Explainability of policy decisions is covered by logging (11.7.3). The remaining L3 requirement covers adaptive sensitivity adjustment which is the genuinely advanced capability. |

### C11.8 Reflection-Based Security Analysis -> Agent Security Self-Assessment

| # | Change | Rationale |
|---|--------|-----------|
| Title | Renamed from "Reflection-Based Security Analysis" to "Agent Security Self-Assessment." | "Reflection" and "meta-cognitive analysis" are speculative AI-safety jargon. The practical requirement is that agentic systems have a security review step. |
| 11.8.1 | Rewritten. Changed from L1 to **L2**. Focused on reviewing planned high-risk actions against security policy before execution. | Agent self-reflection as L1 was too advanced. A pre-execution security check is a practical L2 control for agentic systems. |
| 11.8.2 | Rewritten to focus on protecting the review mechanism from adversarial bypass. Kept L2. | The core concern is real: if an attacker can manipulate the security check itself, it's useless. |
| 11.8.3 | Consolidated from 11.8.4 and 11.8.5. Security warnings trigger monitoring/intervention. Changed to L3. | The original had 5 items; 3 is sufficient. Continuous learning from reflections (old 11.8.5) was speculative and removed. |
| 11.8.3-5 (old) | Removed 11.8.3 (meta-cognitive security analysis), 11.8.5 (continuous learning from reflections). | "Meta-cognitive security analysis" is not a verifiable requirement. "Continuous learning from security reflections" is speculative and risks introducing new attack surface. |

### C11.9 Evolution & Self-Improvement Security -> Self-Modification & Autonomous Update Security

| # | Change | Rationale |
|---|--------|-----------|
| Title | Renamed from "Evolution & Self-Improvement Security" to "Self-Modification & Autonomous Update Security." | "Evolution" and "self-improvement" imply recursive self-improvement / AGI scenarios. The practical concern is systems that can modify their own configs, prompts, or tool access. |
| 11.9.1 | Changed from L1 to **L2**. Rewritten with concrete examples (prompt rewriting, tool-list changes, parameter updates). Removed "formal verification boundaries." | Self-modification controls at L1 was too advanced. Formal verification of self-modification boundaries is research-stage. L2 with practical examples is appropriate. |
| 11.9.2 | Kept L2. Simplified. | Security impact assessment before self-modification is reasonable L2. |
| 11.9.3 | Kept L2. Added "logged, reversible, and subject to integrity verification." | Combines the original rollback requirement with auditability. |
| 11.9.4 | Replaces old 11.9.4 and 11.9.5. Changed to L3. Focuses on bounding self-modification scope. | Old 11.9.4 ("meta-learning security") was vague. Old 11.9.5 ("mathematical proofs of convergence for recursive self-improvement") is speculative/theoretical and not verifiable. The replacement focuses on practical bounds: rate limits, magnitude limits, prohibited targets. |
| 11.9.5 (old) | Removed. | "Recursive self-improvement bounded by formal safety constraints with mathematical proofs of convergence" does not exist as a practical capability. Including it in a verification standard would be misleading. |

### References
- Added references section with OWASP LLM Top 10 2025, MITRE ATLAS technique IDs, and NIST AI 100-2e2023.
