### PR TITLE
Add tool invocation tracking for hallucination detection under C7.2

### DIFF
--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -29,6 +29,7 @@ Detect when the model produces potentially inaccurate or fabricated content and 
 | **7.2.2** | **Verify that** the application automatically blocks answers or switches to a fallback message if the confidence score drops below a defined threshold. | 2 | D/V |
 | **7.2.3** | **Verify that** hallucination events (low-confidence responses) are logged with input/output metadata for analysis. | 2 | D/V |
 | **7.2.4** | **Verify that** for responses classified as high-risk or high-impact by policy, the system performs an additional verification step through an independent mechanism, such as retrieval-based grounding against authoritative sources, deterministic rule-based validation, tool-based fact-checking, or consensus review by a separately provisioned model. | 3 | D/V |
+| **7.2.5** | **Verify that** the system tracks tool and function invocation history within a request chain and flags high-confidence factual assertions that were not preceded by relevant verification tool usage, as a practical hallucination detection signal independent of confidence scoring. | 2 | D/V |
 
 ---
 


### PR DESCRIPTION
Related to #144

Adds a control for tracking tool/function invocation history to detect hallucinations. A model asserting "the current temperature is 72F" without having called a weather API is a strong hallucination indicator regardless of confidence score. This provides a practical detection signal based on verifiable tool call chains rather than relying solely on confidence scoring.

Reference implementation: https://github.com/mattijsmoens/sovereign-shield (CoreSafety module - tool usage verification)