### PR TITLE
Add safety violation feedback loop security under C11.9

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -121,6 +121,7 @@ Security controls for systems where the AI can modify its own configuration, pro
 | **11.9.2** | **Verify that** proposed self-modifications undergo security impact assessment or policy validation before taking effect. | 2 | D/V |
 | **11.9.3** | **Verify that** all self-modifications are logged, reversible, and subject to integrity verification, enabling rollback to a known-good state. | 2 | D/V |
 | **11.9.4** | **Verify that** self-modification scope is bounded (e.g., maximum change magnitude, rate limits on updates, prohibited modification targets) to prevent runaway or adversarially induced changes. | 3 | D/V |
+| **11.9.5** | **Verify that** when safety violation data (blocked inputs, filtered outputs, flagged hallucinations) is used as training signal for model improvement, the feedback pipeline includes integrity verification, poisoning detection, and human review gates to prevent adversarial manipulation of the improvement mechanism. | 3 | D/V |
 
 ---
 


### PR DESCRIPTION
Closes #144

Adds control 11.9.5 requiring security controls for the feedback loop when safety violations are used as training signal. Blocked prompt injections, caught hallucinations, and filtered policy violations are high-value training data for model improvement, but this feedback loop can be exploited through intentional violation attempts to poison the improvement pipeline. This control requires integrity verification, poisoning detection, and human review gates.

Reference implementation: https://github.com/mattijsmoens/sovereign-shield (AdaptiveShield module - learns from reported attacks with false positive validation before rule deployment)