### PR TITLE
Reword provenance to more specific language

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Governance.md
+++ b/1.0/en/0x10-C01-Training-Data-Governance.md
@@ -2,11 +2,11 @@
 
 ## Control Objective
 
-Training data must be sourced, handled, and maintained in a way that preserves provenance, security, quality, and fairness. Doing so fulfils legal duties and reduces risks of bias, poisoning, or privacy breaches that could affect the entire AI lifecycle.
+Training data must be sourced, handled, and maintained in a way that preserves origin traceability, security, quality, and fairness. Doing so fulfils legal duties and reduces risks of bias, poisoning, or privacy breaches that could affect the entire AI lifecycle.
 
 ---
 
-## C1.1 Training Data Provenance
+## C1.1 Training Data Origin & Traceability
 
 Maintain a verifiable inventory of all datasets, accept only trusted sources, and log every change for auditability.
 

--- a/1.0/en/0x10-C04-Infrastructure.md
+++ b/1.0/en/0x10-C04-Infrastructure.md
@@ -27,8 +27,8 @@ Ensure cryptographic integrity and supply chain security through reproducible bu
 | # | Description | Level | Role |
 |:--------:|--------------------------------------------------------------------------------------------|:---:|:---:|
 | **4.2.1** | **Verify that** builds are completely automated and produce a software bill of materials (SBOM). | 1 | D/V |
-| **4.2.2** | **Verify that** build artifacts are cryptographically signed with provenance metadata that can be independently verified. | 2 | D/V |
-| **4.2.3** | **Verify that** build artifact signatures and provenance metadata are validated at deployment admission, and unverified artifacts are rejected. | 2 | D/V |
+| **4.2.2** | **Verify that** build artifacts are cryptographically signed with build-origin metadata (source repository, build pipeline, commit hash) that can be independently verified. | 2 | D/V |
+| **4.2.3** | **Verify that** build artifact signatures and build-origin metadata are validated at deployment admission, and unverified artifacts are rejected. | 2 | D/V |
 | **4.2.4** | **Verify that** builds are reproducible, producing identical output from identical source inputs, enabling independent verification of build integrity. | 3 | D/V |
 
 ---

--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -12,7 +12,7 @@ Assess and authenticate third‑party model origins, licenses, and hidden behavi
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **6.1.1** | **Verify that** every third‑party model artifact includes a signed provenance record identifying its source, version, and integrity checksum. | 1 | D/V |
+| **6.1.1** | **Verify that** every third‑party model artifact includes a signed origin-and-integrity record identifying its source, version, and integrity checksum. | 1 | D/V |
 | **6.1.2** | **Verify that** models are scanned for malicious layers or Trojan triggers using automated tools before import. | 1 | D/V |
 | **6.1.3** | **Verify that** model licenses, export‑control tags, and data‑origin statements are recorded in an AI BOM entry. | 2 | V |
 | **6.1.4** | **Verify that** high‑risk models (e.g., publicly uploaded weights, unverified creators) remain quarantined until human review and sign‑off. | 2 | D/V |

--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -24,7 +24,7 @@ Pre-screen content before vectorization; treat memory writes as untrusted inputs
 | **8.2.1** | **Verify that** regulated data and sensitive fields are detected prior to embedding and are masked, tokenized, transformed, or dropped based on policy. | 1 | D/V |
 | **8.2.2** | **Verify that** embedding ingestion rejects or quarantines inputs that violate required content constraints (e.g., non-UTF-8, malformed encodings, oversized payloads, invisible Unicode characters, or executable content intended to poison retrieval). | 1 | D/V |
 | **8.2.3** | **Verify that** vectors that fall outside normal clustering patterns are flagged and quarantined before entering production indices. | 2 | D/V |
-| **8.2.4** | **Verify that** an agent's own outputs are not automatically written back into its trusted memory without explicit validation (such as content-origin checks or write-authorization controls that verify provenance before committing writes). | 2 | D/V |
+| **8.2.4** | **Verify that** an agent's own outputs are not automatically written back into its trusted memory without explicit validation (such as content-origin checks or write-authorization controls that verify the content's source before committing writes). | 2 | D/V |
 | **8.2.5** | **Verify that** new content written to memory is checked for contradictions with what is already stored and that conflicts trigger alerts. | 3 | D/V |
 
 ## C8.3 Memory Expiry, Revocation & Deletion

--- a/1.0/en/0x90-Appendix-A_Glossary.md
+++ b/1.0/en/0x90-Appendix-A_Glossary.md
@@ -196,7 +196,7 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 
 * **SIEM (Security Information and Event Management)** – A platform that aggregates, correlates, and analyzes security event data from multiple sources to detect threats, support incident response, and satisfy compliance requirements.
 
-* **SPDX (Software Package Data Exchange)** – An open standard for communicating software and AI component bill of materials information, including provenance, licensing, and security references.
+* **SPDX (Software Package Data Exchange)** – An open standard for communicating software and AI component bill of materials information, including component origin, licensing, and security references.
 
 * **SSE (Server-Sent Events)** – A web technology that enables a server to push real-time updates to a client over an HTTP connection, used as a transport mechanism in MCP.
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -125,9 +125,9 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 |---|---|
 | Cryptographic hashes for training data integrity | 1.2.4, 1.3.2 |
 | Cryptographic model signing with verification at deployment and load | 3.1.2 |
-| Signed build artifacts with provenance metadata | 4.2.2 |
+| Signed build artifacts with build-origin metadata | 4.2.2 |
 | Build signature validation at deployment | 4.2.3 |
-| Third-party model provenance verification (signed records) | 6.1.1 |
+| Third-party model origin and integrity verification (signed records) | 6.1.1 |
 | Cryptographic signature validation for packages and publishers | 6.4.2 |
 | Model watermarking and fingerprinting | 7.7.5, 11.5.4 |
 | Execution chain cryptographic signing with non-repudiation timestamps | 9.4.2 |
@@ -271,13 +271,13 @@ Control network boundaries, traffic flow, and outbound access for AI workloads.
 
 ## AD.12 Supply Chain & Artifact Integrity
 
-Verify provenance, scan dependencies, and enforce integrity of models, frameworks, datasets, and build artifacts.
+Verify origin and authenticity, scan dependencies, and enforce integrity of models, frameworks, datasets, and build artifacts.
 
 | Control / Technique | Requirement IDs |
 |---|---|
 | Model registry with AI BOM (SPDX, CycloneDX) | 3.1.1, 6.7.1 |
 | Model dependency graph tracking (services, agents, environments) | 3.1.3 |
-| Model provenance records (origin, training data checksums, authorship) | 3.1.4, 6.1.1 |
+| Model origin records (source, training data checksums, authorship) | 3.1.4, 6.1.1 |
 | Automated reproducible builds with SBOM | 4.2.1 |
 | Reproducible build hash comparison | 6.3.5 |
 | CI pipeline dependency scanning (AI frameworks, critical libraries) | 6.2.1 |


### PR DESCRIPTION
Replaces all uses of "provenance" with context-specific language that says exactly what is meant. Closes #159 .