### PR TITLE
Add items from C13 review to C7, C8, C12

### DIFF
--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -40,9 +40,10 @@ Technical controls to detect and scrub bad content before it is shown to the use
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
 | **7.3.1** | **Verify that** automated classifiers scan every response and block content that matches hate, harassment, or sexual violence categories. | 1 | D/V |
 | **7.3.2** | **Verify that** the system scans every response for PII (like credit cards or emails) and automatically redacts it before display. | 1 | D/V |
-| **7.3.3** | **Verify that** data labeled as "confidential" in the system remains blocked or redacted. | 2 | D |
-| **7.3.4** | **Verify that** safety filters can be configured differently based on the user's role or location (e.g., stricter filters for minors) as appropriate. | 2 | D/V |
-| **7.3.5** | **Verify that** the system requires a human approval step or re-authentication if the model generates high-risk content. | 3 | D/V |
+| **7.3.3** | **Verify that** PII detection and redaction events are logged without including the redacted PII values themselves, to maintain an audit trail without creating secondary PII exposure. | 1 | D/V |
+| **7.3.4** | **Verify that** data labeled as "confidential" in the system remains blocked or redacted. | 2 | D |
+| **7.3.5** | **Verify that** safety filters can be configured differently based on the user's role or location (e.g., stricter filters for minors) as appropriate. | 2 | D/V |
+| **7.3.6** | **Verify that** the system requires a human approval step or re-authentication if the model generates high-risk content. | 3 | D/V |
 
 ---
 

--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -14,6 +14,8 @@ Enforce fine-grained access controls and query-time scope enforcement for every 
 | **8.1.2** | **Verify that** API credentials used for vector operations carry **scoped claims** (e.g., permitted collections, allowed verbs, tenant binding). | 1 | D/V |
 | **8.1.3** | **Verify that** cross-scope access attempts (e.g., cross-tenant similarity queries, namespace traversal, tag bypass) are detected and rejected. | 2 | D/V |
 | **8.1.4** | **Verify that** every ingested document is tagged at write time with source, writer identity (authenticated user or system principal), timestamp, batch ID, and embedding model version, and that these tags are immutable after initial write. | 2 | D/V |
+| **8.1.5** | **Verify that** RAG pipeline retrieval events log the query issued, the documents or chunks retrieved, similarity scores, the knowledge source, and whether retrieved content passed prompt injection scanning before being incorporated into model context. | 2 | D/V |
+| **8.1.6** | **Verify that** retrieval anomaly detection identifies embedding density outliers, repeated dominance of specific documents in similarity results, and sudden shifts in retrieval bias distribution that may indicate vector database poisoning. | 3 | D/V |
 
 ## C8.2 Embedding Sanitization & Validation
 

--- a/1.0/en/0x10-C12-Privacy.md
+++ b/1.0/en/0x10-C12-Privacy.md
@@ -32,9 +32,10 @@ Maintain rigorous privacy assurances across the entire AI lifecycle—collection
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **12.3.1** | **Verify that** privacy-loss accounting dashboards alert when cumulative ε exceeds policy thresholds. | 2 | D/V |
+| **12.3.1** | **Verify that** differential privacy budget consumption is tracked per training round (both ε and δ values) and that cumulative budget dashboards alert when ε exceeds policy thresholds. | 2 | D/V |
 | **12.3.2** | **Verify that** black-box privacy audits estimate ε̂ within 10% of declared value. | 2 | V |
 | **12.3.3** | **Verify that** formal proofs cover all post-training fine-tunes and embeddings. | 3 | V |
+| **12.3.4** | **Verify that** federated learning systems implement canary-based privacy auditing to empirically bound privacy leakage, with audit results logged and reviewed per training cycle. | 3 | V |
 
 ---
 


### PR DESCRIPTION
Surfaced by ottosulin (PR #153) as items removed from C13 that contain content not yet covered in their home chapters.

C7 - 7.3.3 (new, inserted after 7.3.2; shifted 7.3.3-7.3.5 → 7.3.4-7.3.6):
  Log PII detection and redaction events without including the redacted
  PII values, maintaining audit capability without secondary PII exposure.

C8 - 8.1.5 and 8.1.6 (appended to C8.1 Access Controls on Memory & RAG):
  8.1.5: Log RAG retrieval events including injection scan outcome for
  each retrieved chunk before context assembly.
  8.1.6: Retrieval anomaly detection for embedding density outliers,
  repeated document dominance, and sudden retrieval bias shifts as
  indicators of vector database poisoning.

C12 - 12.3.1 strengthened, 12.3.4 added (C12.3 Differential-Privacy):
  12.3.1: Extended to track per-round ε and δ values, not only cumulative ε.
  12.3.4: Canary-based privacy auditing (L3) to empirically bound
  privacy leakage per federated learning training cycle.