### PR TITLE
Expand C3.5: add consumer notification, session drain, artifact cleanup and post-retirement verification

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -75,7 +75,6 @@ Hosted and provider-managed models may change behavior without notice. These con
 
 ---
 
-
 ## References
 
 * [MITRE ATLAS](https://atlas.mitre.org/)


### PR DESCRIPTION
C3.5 had only 2 requirements covering artifact erasure and event logging. Four additions close the remaining gaps:

- 3.5.3 (L1): Downstream consumer notification and migration acknowledgement before retirement is finalized
- 3.5.4 (L2): Graceful session draining to a fallback before retirement completes, preventing silent in-flight failures
- 3.5.5 (L2): Cleanup of derivative artifacts (RAG entries, cached embeddings, agent memory) tagged to the retired model
- 3.5.6 (L3): Post-retirement verification across all inference paths with results logged in the decommissioning audit record