### PR TITLE
C10.1: expand MCP component integrity with version pinning, manifest signing, and namespace isolation

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -12,7 +12,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | :--: | --- | :---: | :--: |
 | **10.1.1** | **Verify that** MCP server and client components are obtained only from trusted sources and verified using signatures, checksums, or secure package metadata, rejecting tampered or unsigned builds. | 1 | D/V |
 | **10.1.2** | **Verify that** MCP client and server configurations do not contain plaintext secrets (API keys, tokens, client secrets) and that credentials are injected or resolved at runtime rather than stored in configuration files, environment variables, or source code. | 1 | D/V |
-| **10.1.3** | **Verify that** packages and plugins loaded by MCP servers are sourced only from allowlisted registries and constrained to approved version ranges (e.g., pinned to major version), so that dependency confusion or substitution attacks cannot introduce unauthorized code that exposes malicious tools to the AI agent runtime. | 1 | D/V |
+| **10.1.3** | **Verify that** only allowlisted MCP server identifiers (name, version, and registry) are permitted in production and that the runtime rejects connections to unlisted or unregistered servers at load time. | 1 | D/V |
 
 ---
 


### PR DESCRIPTION
Add 10.1.2–10.1.4 to address gaps in MCP supply chain hygiene:

- 10.1.2 (L1, D/V): Version pinning and server allowlisting - MCP server dependencies pinned to exact versions; only allowlisted identifiers (name + version + registry) accepted in production; unpinned or unlisted servers rejected at load time.

- 10.1.3 (L2, D/V): Cryptographic signature verification for tool manifests - MCP capability descriptors must be signed by the server and verified by the client before being used to configure tool invocations; unsigned or tampered manifests are rejected.

- 10.1.4 (L2, D/V): Tool namespace isolation - tool names are scoped to their originating MCP server namespace and uniqueness is enforced per server by the runtime, preventing tool-name squatting attacks where a malicious server shadows a legitimate tool name.