### PR TITLE
Refocus C1 on data integrity & provenance, scope bias to security risk

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Governance.md
+++ b/1.0/en/0x10-C01-Training-Data-Governance.md
@@ -1,8 +1,10 @@
-# C1 Training Data Governance & Bias Management
+# C1 Training Data Integrity & Provenance
 
 ## Control Objective
 
-Training data must be sourced, handled, and maintained in a way that preserves origin traceability, security, quality, and fairness. Doing so fulfills legal duties and reduces risks of bias, poisoning, or privacy breaches that could affect the entire AI lifecycle.
+Training data must be sourced, handled, and maintained in a way that preserves origin traceability, integrity, and quality. The core security concern is ensuring data has not been tampered with, poisoned, or corrupted. Security-relevant bias (e.g., skewed abuse-detection training data that allows attackers to bypass controls) is treated as a possible consequence of compromised or unvalidated data, not as a standalone control category.
+
+> **Scope note — bias.** AISVS addresses bias only where it introduces security risk (e.g., bypass of abuse detection, authentication heuristics, or automated trust decisions). Broader fairness governance requirements are out of scope; see ISO/IEC 42001 or the NIST AI RMF for general fairness and ethics guidance.
 
 ---
 
@@ -59,6 +61,7 @@ Combine automated validation, manual spot-checks, and logged remediation to guar
 | **1.4.3** | **Verify that** automatically generated labels (e.g., via models or weak supervision) are subject to confidence thresholds and consistency checks to detect misleading or low-confidence labels. | 2 | D/V |
 | **1.4.4** | **Verify that** appropriate defenses, such as adversarial training, data augmentation with perturbed inputs, or robust optimization techniques, are implemented and tuned for relevant models based on risk assessment. | 3 | D/V |
 | **1.4.5** | **Verify that** automated tests catch label skews on every ingest or significant data transformation. | 2 | D |
+| **1.4.6** | **Verify that** models used in security-relevant decisions (e.g., abuse detection, fraud scoring, automated trust decisions) are evaluated for systematic bias patterns that an adversary could exploit to evade controls (e.g., mimicking a trusted language style or demographic pattern to bypass detection). | 2 | D/V |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Organizations should select a target level based on the risk profile of their AI
 
 ## Requirement Chapters
 
-1. [Training Data Governance & Bias Management](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C01-Training-Data-Governance.md)
+1. [Training Data Integrity & Provenance](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C01-Training-Data-Governance.md)
 2. [User Input Validation](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C02-User-Input-Validation.md)
 3. [Model Lifecycle Management & Change Control](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C03-Model-Lifecycle-Management.md)
 4. [Infrastructure, Configuration & Deployment Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C04-Infrastructure.md)


### PR DESCRIPTION
## Summary

- **Rename C1** from "Training Data Governance & Bias Management" to "Training Data Integrity & Provenance" — foregrounds the actual security concern
- **Rewrite control objective** to frame data integrity (tampering, poisoning, corruption) as the core concern, with security-relevant bias treated as a consequence of compromised data rather than a standalone category
- **Add scope note** clarifying bias is only in-scope where it introduces security risk (e.g., evasion of abuse detection, authentication heuristics). Points to ISO/IEC 42001 and NIST AI RMF for broader fairness governance
- **Add requirement 1.4.6** — adversarial bias exploitation: verify that models used in security-relevant decisions are evaluated for systematic bias patterns an attacker could exploit to evade controls
- **Update README** chapter listing to match new title

## Rationale

Keeps AISVS focused as a security verification standard. Prevents scope creep into AI ethics/fairness governance territory while still addressing bias where it creates exploitable attack surface.

## Test plan

- [ ] Verify no broken cross-references to C1 in other chapters
- [ ] Confirm requirement numbering is consistent
- [ ] Review 1.4.6 wording for testability and level consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)