### PR TITLE
Rename C1 to Training Data Integrity & Traceability

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -1,4 +1,4 @@
-# C1 Training Data Integrity & Provenance
+# C1 Training Data Integrity & Traceability
 
 ## Control Objective
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Organizations should select a target level based on the risk profile of their AI
 
 ## Requirement Chapters
 
-1. [Training Data Integrity & Provenance](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C01-Training-Data-Governance.md)
+1. [Training Data Integrity & Traceability](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md)
 2. [User Input Validation](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C02-User-Input-Validation.md)
 3. [Model Lifecycle Management & Change Control](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C03-Model-Lifecycle-Management.md)
 4. [Infrastructure, Configuration & Deployment Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C04-Infrastructure.md)


### PR DESCRIPTION
## Summary

- Rename chapter title from "Training Data Integrity & Provenance" to "Training Data Integrity & Traceability"
- Rename file from `0x10-C01-Training-Data-Governance.md` to `0x10-C01-Training-Data-Integrity-and-Traceability.md`
- Update README link text and URL to match

Traceability better aligns with the chapter content (C1.1 Origin & Traceability, C1.5 Data Lineage and Traceability) and is the more commonly used term in security verification standards.

## Test plan

- [ ] Verify no other files reference the old filename
- [ ] Confirm README link resolves correctly