### PR TITLE
C3: Add hosted and provider-managed model controls (C3.6)

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -72,6 +72,19 @@ Models must be securely retired when they are no longer needed or when security 
 
 ---
 
+## C3.6 Hosted & Provider-Managed Model Controls
+
+Provider-managed API models (e.g., hosted LLM endpoints) can change behavior behind a stable endpoint without notice. These controls ensure visibility, change detection, and fail-safe behavior when the organization does not control the model weights.
+
+| # | Description | Level | Role |
+|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
+| **3.6.1** | **Verify that** hosted model dependencies are inventoried with provider, endpoint, exposed model identifier, API version or release identifier (if available), and fallback or router relationships. | 1 | D/V |
+| **3.6.2** | **Verify that** upstream model or routing changes (e.g., provider model updates, version deprecations, or endpoint migrations) trigger security re-evaluation before continued use in high-risk workflows. | 2 | D/V |
+| **3.6.3** | **Verify that** request logs capture the exact hosted model identifier returned by the provider, or explicitly record that the provider did not expose one. | 2 | D/V |
+| **3.6.4** | **Verify that** high-assurance deployments fail closed or require approval when the provider cannot expose sufficient model identity or change notification information to satisfy the organization's verification requirements. | 3 | D/V |
+
+---
+
 ## References
 
 * [MITRE ATLAS](https://atlas.mitre.org/)


### PR DESCRIPTION
## Summary

Adds new subsection **C3.6 Hosted & Provider-Managed Model Controls** to address the gap where provider-managed API models (e.g., hosted LLM endpoints) can change behavior behind a stable endpoint without notice.

- **3.6.1** (L1): Inventory hosted model dependencies with provider, endpoint, model identifier, API version, and fallback/router relationships
- **3.6.2** (L2): Require security re-evaluation on upstream model or routing changes before continued use in high-risk workflows
- **3.6.3** (L2): Log exact hosted model identifier returned by provider (or record that provider did not expose one)
- **3.6.4** (L3): Fail closed when provider cannot expose sufficient model identity or change notification information

Closes #187

## Test plan

- [ ] Verify requirement numbering is sequential in C3
- [ ] Confirm levels are consistent with existing C3 requirements
- [ ] Check for overlap with C6 (Supply Chain) — these are complementary, not duplicative

Generated with [Claude Code](https://claude.com/claude-code)