### PR TITLE
Tighten C3.6 wording for verification standard style

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -72,16 +72,16 @@ Models must be securely retired when they are no longer needed or when security 
 
 ---
 
-## C3.6 Hosted & Provider-Managed Model Controls
+## C3.6 Hosted and Provider-Managed Model Controls
 
-Provider-managed API models (e.g., hosted LLM endpoints) can change behavior behind a stable endpoint without notice. These controls ensure visibility, change detection, and fail-safe behavior when the organization does not control the model weights.
+Hosted and provider-managed models may change behavior without notice. These controls help ensure visibility, reassessment, and safe operation when the organization does not control the model weights.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **3.6.1** | **Verify that** hosted model dependencies are inventoried with provider, endpoint, exposed model identifier, API version or release identifier (if available), and fallback or router relationships. | 1 | D/V |
-| **3.6.2** | **Verify that** upstream model or routing changes (e.g., provider model updates, version deprecations, or endpoint migrations) trigger security re-evaluation before continued use in high-risk workflows. | 2 | D/V |
-| **3.6.3** | **Verify that** request logs capture the exact hosted model identifier returned by the provider, or explicitly record that the provider did not expose one. | 2 | D/V |
-| **3.6.4** | **Verify that** high-assurance deployments fail closed or require approval when the provider cannot expose sufficient model identity or change notification information to satisfy the organization's verification requirements. | 3 | D/V |
+| **3.6.1** | **Verify that** hosted model dependencies are inventoried with provider, endpoint, provider-exposed model identifier, version or release identifier when available, and fallback or routing relationships. | 1 | D/V |
+| **3.6.2** | **Verify that** provider model, version, or routing changes trigger security re-evaluation before continued use in high-risk workflows. | 2 | D/V |
+| **3.6.3** | **Verify that** logs record the exact hosted model identifier returned by the provider, or explicitly record that no such identifier was exposed. | 2 | D/V |
+| **3.6.4** | **Verify that** high-assurance deployments fail closed or require explicit approval when the provider does not expose sufficient model identity or change notification information for verification. | 3 | D/V |
 
 ---
 


### PR DESCRIPTION
## Summary

- Use prose-style heading ("Hosted and Provider-Managed" instead of ampersand)
- Shorter, more direct intro paragraph
- Tighter requirement language across all four items: clearer phrasing, removed parenthetical examples, added "explicit" before approval in 3.6.4

Follow-up to #202 based on editorial review.

## Test plan

- [ ] Verify requirements are still testable after wording changes
- [ ] Confirm no meaning was lost in the tightening

Generated with [Claude Code](https://claude.com/claude-code)