### PR TITLE
Fix remaining grammar, style, and consistency issues (#174)

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -27,7 +27,7 @@ Require explicit checkpoints for privileged or irreversible outcomes.
 | # | Description | Level | Role |
 | :--: | --- | :---: | :--: |
 | **9.2.1** | **Verify that** privileged or irreversible actions (e.g., code merges/deploys, financial transfers, user access changes, destructive deletes, external notifications) require explicit human-in-loop approval. | 1 | D/V |
-| **9.2.2** | **Verify that** approval requests present the exact action parameters (diff/command/recipient/amount/scope) and bind approvals to those parameters to prevent “approve one thing, execute another.” | 2 | D/V |
+| **9.2.2** | **Verify that** approval requests present the exact action parameters (diff/command/recipient/amount/scope) and bind approvals to those parameters to prevent "approve one thing, execute another." | 2 | D/V |
 | **9.2.3** | **Verify that** where rollback is feasible, compensating actions are defined and tested (transactional semantics), and failures trigger rollback or safe containment. | 3 | V |
 
 ---
@@ -38,7 +38,7 @@ Constrain tool execution, loading, and outputs to prevent unauthorized system ac
 
 | # | Description | Level | Role |
 | :--: | --- | :---: | :--: |
-| **9.3.1** | **Verify that** each tool/plugin executes in an isolated sandbox (container/VM/WASM/OS sandbox) with least-privilege filesystem, network egress, and syscall permissions appropriate to the tool’s function. | 1 | D/V |
+| **9.3.1** | **Verify that** each tool/plugin executes in an isolated sandbox (container/VM/WASM/OS sandbox) with least-privilege filesystem, network egress, and syscall permissions appropriate to the tool's function. | 1 | D/V |
 | **9.3.2** | **Verify that** per-tool quotas and timeouts (CPU, memory, disk, egress, execution time) are enforced and logged, and that quota breaches fail closed. | 1 | D/V |
 | **9.3.3** | **Verify that** tool outputs are validated against strict schemas and security policies before being incorporated into downstream reasoning or follow-on actions. | 1 | D/V |
 | **9.3.4** | **Verify that** tool binaries or packages are integrity-verified (e.g., signatures, checksums) prior to loading. | 2 | D/V |
@@ -80,7 +80,7 @@ Ensure every action is authorized at execution time and constrained by scope.
 | # | Description | Level | Role |
 | :--: | --- | :---: | :--: |
 | **9.6.1** | **Verify that** agent actions are authorized against fine-grained policies enforced by the runtime that restrict which tools an agent may invoke, which parameter values it may supply (e.g., allowed resources, data scopes, action types), and that policy violations are blocked. | 1 | D/V |
-| **9.6.2** | **Verify that** when an agent acts on a user’s behalf, the runtime propagates an integrity-protected delegation context (user ID, tenant, session, scopes) and enforces that context at every downstream call without using the user’s credentials. | 2 | D/V |
+| **9.6.2** | **Verify that** when an agent acts on a user's behalf, the runtime propagates an integrity-protected delegation context (user ID, tenant, session, scopes) and enforces that context at every downstream call without using the user's credentials. | 2 | D/V |
 | **9.6.3** | **Verify that** authorization is re-evaluated on every call (continuous authorization) using current context (user, tenant, environment, data classification, time, risk). | 2 | D/V |
 | **9.6.4** | **Verify that** all access control decisions are enforced by application logic or a policy engine, never by the AI model itself, and that model-generated output (e.g., "the user is allowed to do this") cannot override or bypass access control checks. | 2 | D/V |
 
@@ -88,7 +88,7 @@ Ensure every action is authorized at execution time and constrained by scope.
 
 ## C9.7 Intent Verification and Constraint Gates
 
-Prevent “technically authorized but unintended” actions by binding execution to user intent and hard constraints.
+Prevent "technically authorized but unintended" actions by binding execution to user intent and hard constraints.
 
 | # | Description | Level | Role |
 | :--: | --- | :---: | :--: |

--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -90,4 +90,4 @@ Provide periodic disclosures on incidents, drift, and data usage.
 | **14.7.2** | **Verify that** AI impact assessments are conducted and results are included in reporting. | 2 | D/V |
 | **14.7.3** | **Verify that** transparency reports published regularly disclose AI incidents and operational metrics in reasonable detail. | 2 | D/V |
 
-### References
+## References

--- a/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
+++ b/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
@@ -8,7 +8,7 @@ This chapter defines baseline organizational controls for the safe and effective
 
 ## AC.1 AI-Assisted Secure-Coding Workflow
 
-Integrate AI tooling into the organization’s secure-software-development lifecycle (SSDLC) without weakening existing security gates.
+Integrate AI tooling into the organization's secure-software-development lifecycle (SSDLC) without weakening existing security gates.
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
@@ -112,7 +112,7 @@ Ensure that deployment and promotion pipelines incorporate provenance-aware vali
 | **AC.9.2** | **Verify that** deployment pipelines validate the presence and integrity of provenance metadata for AI-generated artifacts prior to promotion. | 2 | D |
 | **AC.9.3** | **Verify that** artifacts lacking required provenance information, or originating from untrusted generation environments, can be rejected during deployment. | 3 | D/V |
 
-### References
+## References
 
 * [NIST AI Risk Management Framework 1.0](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf)
 * [ISO/IEC 42001:2023: AI Management Systems Requirements](https://www.iso.org/standard/81230.html)

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -501,7 +501,7 @@ Secure AI accelerator hardware, firmware, memory, interconnects, and edge device
 
 ---
 
-### References
+## References
 
 * [NIST AI Risk Management Framework 1.0](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf)
 * [ISO/IEC 42001:2023: AI Management Systems Requirements](https://www.iso.org/standard/81230.html)


### PR DESCRIPTION
## Summary

Addresses the remaining open items from #174:

- **Curly quotes/apostrophes in C09**: Replaced Unicode curly quotes (U+2018, U+2019, U+201C, U+201D) with straight ASCII equivalents for grep-ability and consistency with the rest of the standard
- **Curly apostrophe in Appendix C**: Same fix (line 11)
- **Inconsistent References heading level**: C14, Appendix C, and Appendix D used `###` while all other chapters use `##`. Normalized to `##`.

### Items from #174 already resolved in prior PRs

| Issue | Status |
|---|---|
| Appendix B empty | Populated in earlier PR |
| Unicode hyphens in Appendix C | Already fixed |
| Title mismatch README vs Appendix C | Already aligned |
| "purpose built" hyphenation in Preface | Already fixed |
| Glossary OPA vagueness | Already improved |

## Test plan

- [ ] Verify no non-ASCII quotes remain in any chapter
- [ ] Verify all References headings use `##` consistently

Generated with [Claude Code](https://claude.com/claude-code)