### PR TITLE
C7.3: add system prompt exfiltration prevention control (7.3.7)

### DIFF
--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -45,7 +45,8 @@ Technical controls to detect and scrub bad content before it is shown to the use
 | **7.3.4** | **Verify that** data labeled as "confidential" in the system remains blocked or redacted. | 2 | D |
 | **7.3.5** | **Verify that** safety filters can be configured differently based on the user's role or location (e.g., stricter filters for minors) as appropriate. | 2 | D/V |
 | **7.3.6** | **Verify that** the system requires a human approval step or re-authentication if the model generates high-risk content. | 3 | D/V |
-| **7.3.7** | **Verify that** output filters detect and block responses that reproduce verbatim segments of system prompt content, and that LLM client applications restrict rendering of external URLs and images to allowlisted domains to prevent side-channel exfiltration. | 1 | D/V |
+| **7.3.7** | **Verify that** output filters detect and block responses that reproduce verbatim segments of system prompt content. | 2 | D/V |
+| **7.3.8** | **Verify that** LLM client applications prevent model-generated output from triggering automatic outbound requests (e.g., auto-rendered images, iframes, or link prefetching) to attacker-controlled endpoints, for example by disabling automatic external resource loading or restricting it to explicitly allowlisted origins as appropriate. | 2 | D/V |
 
 ---
 


### PR DESCRIPTION
System prompt content can be exfiltrated via direct reproduction (the model repeats its instructions when asked), encoding tricks (Base64, ROT13 to bypass text filters), or Markdown/image render-time side channels where injected instructions cause the model to emit a URL that the client auto-fetches, leaking data in query parameters.

Production CVEs: EchoLeak (CVE-2025-32711, Microsoft 365 Copilot), GitHub Copilot Chat prompt injection (HackerOne #2383092), CamoLeak.

New 7.3.7 (L1, D/V): requires output filters to detect verbatim system prompt reproduction and restricts LLM client URL/image rendering to allowlisted domains to close the render-time exfiltration path.