### PR TITLE
C3.2: add safety re-validation after model compression control (3.2.5)

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -31,7 +31,7 @@ Models must pass defined security and safety validations before deployment.
 | **3.2.2** | **Verify that** security testing covers agent workflows, tool and MCP integrations, RAG and memory interactions, multimodal inputs, and guardrails (safety models or detection services) using a versioned evaluation harness. | 2 | D/V |
 | **3.2.3** | **Verify that** all model changes (deployment, configuration, retirement) generate immutable audit records including a timestamp, an authenticated actor identity, a change type, and before/after states, with trace metadata (environment and consuming services/agents) and a model identifier (version/digest/signature). | 2 | V |
 | **3.2.4** | **Verify that** validation failures automatically block model deployment unless an explicit override approval from pre-designated authorized personnel with documented business justifications. | 3 | D/V |
-| **3.2.5** | **Verify that** models subjected to post-training quantization, pruning, or distillation are re-evaluated against the full safety and alignment test suite on the compressed artifact before deployment, and that the resulting safety evaluation artifacts are separately signed and stored. | 2 | D/V |
+| **3.2.5** | **Verify that** models subjected to post-training quantization, pruning, or distillation are re-evaluated against the same safety and alignment test suite on the compressed artifact before deployment, and that evaluation results are retained as distinct records linked to the compressed artifact's version or digest. | 2 | D/V |
 
 ---
 


### PR DESCRIPTION
Quantization, pruning, and distillation alter weight distributions in ways that disproportionately degrade safety-critical parameters, since alignment guardrails do not reside in the highest-magnitude weights that compression algorithms prioritize preserving.

Two distinct threat models:
1. Incidental regression: standard INT4/AWQ/GPTQ quantization silently degrades refusal behavior (demonstrated across 24 settings, arXiv:2502.15799).
2. Adversarial supply chain: attackers embed dormant backdoors in full-precision models that only activate post-quantization, making safety evaluations on the base model meaningless for the deployed artifact (arXiv:2405.18137).

New 3.2.5 (L2, D/V): treats every compressed model as a distinct artifact requiring independent safety and alignment validation with separately signed evaluation artifacts.