### PR TITLE
C9.5: add inter-agent content trust control (9.5.5)

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -70,6 +70,7 @@ Protect agent-to-agent and agent-to-tool communications from hijacking, injectio
 | **9.5.2** | **Verify that** all messages are strictly schema-validated; unknown fields, malformed payloads, and oversized frames are rejected. | 1 | D/V |
 | **9.5.3** | **Verify that** message integrity covers the full payload including tool parameters, and that replay protections (nonces/sequence numbers/timestamp windows) are enforced. | 2 | D/V |
 | **9.5.4** | **Verify that** agent outputs propagated to downstream agents are validated against semantic constraints (e.g., value ranges, logical consistency) in addition to schema validation. | 2 | D/V |
+| **9.5.5** | **Verify that** messages received from peer agents or orchestrators are processed as untrusted data and subjected to the same prompt injection detection as end-user input, regardless of the sending agent's authenticated identity. | 1 | D/V |
 
 ---
 


### PR DESCRIPTION
Existing C9.5 secures the channel (mutual auth, encryption, schema validation, replay protection) but does not address the trust level assigned to message content. Safety training is optimized for human-to-model interaction and does not generalize to agent-to-agent communication.

ICLR 2025 (Agent Security Bench) found 82.4% of LLMs that refuse identical injection payloads from human users will execute them when the same payload arrives from a peer agent — authenticated channel trust is implicitly promoted to content trust by the model. Agent Smith (ICML 2024) demonstrated that a single injected image can propagate a jailbreak exponentially across a million-agent network in O(log N) steps via peer-to-peer message forwarding.

New 9.5.5 (L1, D/V): requires inter-agent message content to be treated as untrusted data and scanned for prompt injection regardless of the sending agent's authenticated identity, closing the gap between channel security and content trust.