### PR TITLE
Add research wiki with per-chapter analysis pages

### DIFF
--- a/wiki/Appendix-A-Glossary.md
+++ b/wiki/Appendix-A-Glossary.md
@@ -1,0 +1,32 @@
+# Appendix A: Glossary
+
+> **Source:** [`1.0/en/0x90-Appendix-A_Glossary.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x90-Appendix-A_Glossary.md)
+
+## Overview
+
+The glossary defines ~80 terms used throughout the AISVS, covering AI/ML concepts, security terminology, and domain-specific definitions. Terms range from "Adapter" through "Zero-Trust."
+
+## Research Notes
+
+### Terms Needing Clarification or Updates
+
+_Flag any glossary terms that are ambiguous, outdated, or missing._
+
+| Term | Issue | Proposed Change |
+|------|-------|-----------------|
+| | | |
+
+### Missing Terms
+
+_Terms used in the standard that should be added to the glossary._
+
+- [ ] _Add terms here_
+
+---
+
+## Community Notes
+
+_Discussion about glossary scope, definitions, and consistency._
+
+---
+

--- a/wiki/Appendix-B-References.md
+++ b/wiki/Appendix-B-References.md
@@ -1,0 +1,42 @@
+# Appendix B: References
+
+> **Source:** [`1.0/en/0x91-Appendix-B_References.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x91-Appendix-B_References.md)
+
+## Overview
+
+Comprehensive listing of all standards, frameworks, specifications, and publications referenced throughout AISVS.
+
+## Sections
+
+- Standards and Frameworks
+- Specifications and Protocols
+- Cryptographic Standards
+- Privacy and Data Protection
+- Policy Engines
+
+## Research Notes
+
+### References to Add
+
+_New publications, standards, or resources that should be referenced._
+
+| Resource | Category | Relevant Chapters | Link |
+|----------|----------|--------------------|------|
+| | | | |
+
+### Broken or Outdated Links
+
+_Flag any references that have moved or become unavailable._
+
+| Reference | Issue | Updated Link |
+|-----------|-------|--------------|
+| | | |
+
+---
+
+## Community Notes
+
+_Discussion about reference scope and relevance._
+
+---
+

--- a/wiki/Appendix-C-AI-Secure-Coding.md
+++ b/wiki/Appendix-C-AI-Secure-Coding.md
@@ -1,0 +1,55 @@
+# Appendix C: AI-Assisted Secure Coding
+
+> **Source:** [`1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md)
+> **Requirements:** 27 | **Sections:** 9
+
+## Overview
+
+Controls for the safe use of AI-assisted coding tools, covering workflow security, tool qualification, prompt management, code validation, and deployment controls.
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| AC.1 | AI-Assisted Secure-Coding Workflow | 3 | AC.1.1–AC.1.3 |
+| AC.2 | AI Tool Qualification & Threat Modeling | 3 | AC.2.1–AC.2.3 |
+| AC.3 | Secure Prompt & Context Management | 3 | AC.3.1–AC.3.3 |
+| AC.4 | Validation of AI-Generated Code | 3 | AC.4.1–AC.4.3 |
+| AC.5 | Explainability & Traceability of Code Suggestions | 3 | AC.5.1–AC.5.3 |
+| AC.6 | Continuous Feedback & Model Fine-Tuning | 3 | AC.6.1–AC.6.3 |
+| AC.7 | AI-Generated Infrastructure & Pipeline Artifacts | 3 | AC.7.1–AC.7.3 |
+| AC.8 | Autonomous Agent Change Control Constraints | 3 | AC.8.1–AC.8.3 |
+| AC.9 | AI Provenance-Aware Deployment Controls | 3 | AC.9.1–AC.9.3 |
+
+---
+
+## Threat Landscape
+
+- AI-generated code introducing subtle vulnerabilities (SQL injection, XSS, insecure defaults)
+- Prompt injection through repository context (malicious CLAUDE.md, .cursorrules files)
+- Over-reliance on AI-generated code without human review
+- Leaked secrets or PII in prompts sent to cloud-hosted coding assistants
+- AI-generated infrastructure-as-code with insecure defaults
+
+## Tooling & Implementation
+
+- **Coding assistants:** GitHub Copilot, Cursor, Claude Code, Amazon Q Developer
+- **Code scanning:** Semgrep, CodeQL, Snyk Code (applied to AI-generated output)
+- **Provenance tracking:** Git metadata, AI attribution in commit messages
+- **Sandbox testing:** CI/CD gates for AI-generated code, pre-commit hooks
+
+## Open Research Questions
+
+- [ ] What percentage of AI-generated code contains security vulnerabilities in practice?
+- [ ] How should organizations track and audit AI-generated vs. human-written code?
+- [ ] What constitutes adequate review of AI-generated infrastructure-as-code?
+- [ ] How do autonomous coding agents change the threat model for SDLC security?
+
+---
+
+## Community Notes
+
+_Discussion about AI-assisted coding security practices._
+
+---
+

--- a/wiki/Appendix-D-Controls-Inventory.md
+++ b/wiki/Appendix-D-Controls-Inventory.md
@@ -1,0 +1,61 @@
+# Appendix D: AI Security Controls Inventory
+
+> **Source:** [`1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md)
+
+## Overview
+
+Concise inventory of all security controls and techniques referenced throughout AISVS, organized by category. This serves as a cross-cutting reference for implementers.
+
+## Control Categories
+
+| # | Category | Description |
+|---|----------|-------------|
+| AD.1 | Authentication | Identity verification for AI components |
+| AD.2 | Authorization & Access Control | Permission enforcement |
+| AD.3 | Encryption at Rest | Data protection for stored models and data |
+| AD.4 | Encryption in Transit | Transport-level security |
+| AD.5 | Key & Secret Management | Cryptographic material lifecycle |
+| AD.6 | Cryptographic Integrity & Signing | Tamper detection |
+| AD.7 | Input Validation & Sanitization | Prompt and data validation |
+| AD.8 | Output Filtering & Safety | Response safety controls |
+| AD.9 | Rate Limiting & Resource Budgets | Abuse prevention |
+| AD.10 | Sandboxing & Process Isolation | Execution boundaries |
+| AD.11 | Network Segmentation & Egress Control | Network security |
+| AD.12 | Supply Chain & Artifact Integrity | Provenance verification |
+| AD.13 | Deployment & Lifecycle Management | Change control |
+| AD.14 | Privacy & Data Minimization | Data protection |
+| AD.15 | Adversarial Testing & Model Hardening | Robustness testing |
+| AD.16 | Logging & Audit | Observability |
+| AD.17 | Monitoring, Alerting & Incident Response | Detection and response |
+| AD.18 | Explainability & Transparency | Interpretability |
+| AD.19 | Human Oversight & Approval Gates | Human control |
+| AD.20 | Hardware & Accelerator Security | Physical/hardware security |
+
+## Research Notes
+
+### Coverage Gaps
+
+_Control areas that may be missing from the inventory._
+
+- [ ] _Identify gaps here_
+
+### Cross-Reference to Chapters
+
+_Track which chapters map to which control categories._
+
+| Control Category | Primary Chapters | Secondary Chapters |
+|-----------------|------------------|-------------------|
+| AD.1 Authentication | C5 | C10 |
+| AD.2 Authorization | C5 | C9, C10 |
+| AD.7 Input Validation | C2 | C10 |
+| AD.8 Output Filtering | C7 | C5 |
+| _... continue mapping ..._ | | |
+
+---
+
+## Community Notes
+
+_Discussion about control inventory completeness and organization._
+
+---
+

--- a/wiki/C01-Training-Data.md
+++ b/wiki/C01-Training-Data.md
@@ -1,0 +1,95 @@
+# C01: Training Data Integrity & Traceability
+
+> **Source:** [`1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md)
+> **Requirements:** 24 | **Sections:** 5
+
+## Control Objective
+
+Training data must be sourced, handled, and maintained in a way that preserves origin traceability, integrity, and quality. The core security concern is ensuring data has not been tampered with, poisoned, or corrupted.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C1.1 | Training Data Origin & Traceability | 4 | 1.1.1–1.1.4 |
+| C1.2 | Training Data Security & Integrity | 7 | 1.2.1–1.2.7 |
+| C1.3 | Data Labeling and Annotation Security | 4 | 1.3.1–1.3.4 |
+| C1.4 | Training Data Quality and Security Assurance | 6 | 1.4.1–1.4.6 |
+| C1.5 | Data Lineage and Traceability | 3 | 1.5.1–1.5.3 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Data poisoning attacks (backdoor injection via mislabeled samples)
+- Training data extraction / memorization attacks
+- Supply chain compromise of public datasets (e.g., Common Crawl manipulation)
+- Label-flipping attacks on crowdsourced annotation pipelines
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Data provenance:** DVC (Data Version Control), MLflow data tracking, LakeFS
+- **Poisoning detection:** Cleanlab, Aqua Data Centric AI, statistical outlier detection
+- **Data integrity:** Cryptographic hashing (SHA-256), Sigstore for dataset signing
+- **Lineage:** Apache Atlas, Amundsen, DataHub
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C1.1 Training Data Origin & Traceability | _TBD_ | |
+| C1.2 Training Data Security & Integrity | _TBD_ | |
+| C1.3 Data Labeling and Annotation Security | _TBD_ | |
+| C1.4 Training Data Quality and Security Assurance | _TBD_ | |
+| C1.5 Data Lineage and Traceability | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] How do you verify data integrity for datasets too large to hash in full?
+- [ ] What's the state of automated poisoning detection for multimodal datasets?
+- [ ] How should organizations handle training data provenance for foundation models they didn't train?
+- [ ] What constitutes adequate label quality assurance for adversarial-risk-sensitive domains?
+
+---
+
+## Related Standards & Cross-References
+
+- [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
+- [EU AI Act: Article 10: Data & Data Governance](https://artificialintelligenceact.eu/article/10/)
+- [CISA Advisory: Securing Data for AI Systems](https://www.cisa.gov/news-events/cybersecurity-advisories/aa25-142a)
+- [OpenAI Privacy Center: Data Deletion Controls](https://privacy.openai.com/policies?modal=take-control)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C02-User-Input-Validation.md
+++ b/wiki/C02-User-Input-Validation.md
@@ -1,0 +1,102 @@
+# C02: User Input Validation
+
+> **Source:** [`1.0/en/0x10-C02-User-Input-Validation.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C02-User-Input-Validation.md)
+> **Requirements:** 33 | **Sections:** 8
+
+## Control Objective
+
+Robust validation of user input is a first-line defense against some of the most damaging attacks on AI systems. Prompt injection attacks can override system instructions, leak sensitive data, or steer the model toward behavior that is not allowed.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C2.1 | Prompt Injection Defense | 4 | 2.1.1–2.1.4 |
+| C2.2 | Adversarial-Example Resistance | 5 | 2.2.1–2.2.5 |
+| C2.3 | Prompt Character Set | 2 | 2.3.1–2.3.2 |
+| C2.4 | Schema, Type & Length Validation | 5 | 2.4.1–2.4.5 |
+| C2.5 | Content & Policy Screening | 4 | 2.5.1–2.5.4 |
+| C2.6 | Input Rate Limiting & Abuse Prevention | 4 | 2.6.1–2.6.4 |
+| C2.7 | Multi-Modal Input Validation | 5 | 2.7.1–2.7.5 |
+| C2.8 | Real-Time Adaptive Threat Detection | 4 | 2.8.1–2.8.4 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Direct prompt injection (overriding system instructions via user input)
+- Indirect prompt injection (injected instructions in retrieved content)
+- Unicode/encoding-based evasion (invisible characters, homoglyphs, RTL overrides)
+- Multi-modal injection (instructions hidden in images, audio, or documents)
+- Crescendo attacks (gradually escalating benign prompts toward harmful outputs)
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Prompt injection detection:** Rebuff, Prompt Guard (Meta), LLM Guard, Lakera Guard
+- **Input validation:** JSON Schema, Pydantic, Zod (for structured input validation)
+- **Content filtering:** OpenAI Moderation API, Anthropic content filtering, Azure AI Content Safety
+- **Rate limiting:** API gateway rate limiting (Kong, AWS API Gateway), custom token-bucket implementations
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C2.1 Prompt Injection Defense | _TBD_ | |
+| C2.2 Adversarial-Example Resistance | _TBD_ | |
+| C2.3 Prompt Character Set | _TBD_ | |
+| C2.4 Schema, Type & Length Validation | _TBD_ | |
+| C2.5 Content & Policy Screening | _TBD_ | |
+| C2.6 Input Rate Limiting & Abuse Prevention | _TBD_ | |
+| C2.7 Multi-Modal Input Validation | _TBD_ | |
+| C2.8 Real-Time Adaptive Threat Detection | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] Is there a reliable automated benchmark for prompt injection defense effectiveness?
+- [ ] How do you balance input filtering strictness with usability for legitimate multi-language users?
+- [ ] What's the current best practice for defending against indirect prompt injection in RAG pipelines?
+- [ ] How should multi-modal input validation differ from text-only validation?
+
+---
+
+## Related Standards & Cross-References
+
+- [OWASP LLM01:2025 Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)
+- [LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html)
+- [MITRE ATLAS: Adversarial Input Detection](https://atlas.mitre.org/mitigations/AML.M00150)
+- [Mitigate jailbreaks and prompt injections (Anthropic)](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C03-Model-Lifecycle-Management.md
+++ b/wiki/C03-Model-Lifecycle-Management.md
@@ -1,0 +1,97 @@
+# C03: Model Lifecycle Management & Change Control
+
+> **Source:** [`1.0/en/0x10-C03-Model-Lifecycle-Management.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C03-Model-Lifecycle-Management.md)
+> **Requirements:** 23 | **Sections:** 6
+
+## Control Objective
+
+AI systems must implement change control processes that prevent unauthorized or unsafe model modifications from reaching production. Only authorized, validated models reach production by employing controlled processes that maintain integrity, traceability, and recoverability.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C3.1 | Model Authorization & Integrity | 4 | 3.1.1–3.1.4 |
+| C3.2 | Model Validation & Testing | 4 | 3.2.1–3.2.4 |
+| C3.3 | Controlled Deployment & Rollback | 5 | 3.3.1–3.3.5 |
+| C3.4 | Secure Development Practices | 4 | 3.4.1–3.4.4 |
+| C3.5 | Model Retirement & Decommissioning | 2 | 3.5.1–3.5.2 |
+| C3.6 | Hosted and Provider-Managed Model Controls | 4 | 3.6.1–3.6.4 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Model tampering during training or fine-tuning pipeline
+- Unauthorized model deployment bypassing validation gates
+- Model supply chain attacks (compromised checkpoints on Hugging Face, etc.)
+- Stale or vulnerable models remaining in production without rotation
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **MLOps platforms:** MLflow, Weights & Biases, Kubeflow, SageMaker
+- **Model signing:** Sigstore/cosign for model artifacts, in-toto attestations
+- **Deployment:** Seldon Core, BentoML, TorchServe with canary/blue-green strategies
+- **Testing:** Giskard, Deepchecks, Great Expectations (for data validation in pipeline)
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C3.1 Model Authorization & Integrity | _TBD_ | |
+| C3.2 Model Validation & Testing | _TBD_ | |
+| C3.3 Controlled Deployment & Rollback | _TBD_ | |
+| C3.4 Secure Development Practices | _TBD_ | |
+| C3.5 Model Retirement & Decommissioning | _TBD_ | |
+| C3.6 Hosted and Provider-Managed Model Controls | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] What's the right cadence for model re-validation in production (drift vs. cost)?
+- [ ] How do hosted model providers (OpenAI, Anthropic, Google) handle versioning transparency?
+- [ ] What constitutes 'adequate' pre-deployment security testing for fine-tuned models?
+- [ ] How should organizations manage rollback for models with stateful fine-tuning?
+
+---
+
+## Related Standards & Cross-References
+
+- [MITRE ATLAS](https://atlas.mitre.org/)
+- [MLOps Principles](https://ml-ops.org/content/mlops-principles)
+- [Reinforcement fine-tuning (OpenAI)](https://platform.openai.com/docs/guides/reinforcement-fine-tuning)
+- [What is AI adversarial robustness? (IBM Research)](https://research.ibm.com/blog/securing-ai-workflows-with-adversarial-robustness)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C04-Infrastructure.md
+++ b/wiki/C04-Infrastructure.md
@@ -1,0 +1,105 @@
+# C04: Infrastructure, Configuration & Deployment Security
+
+> **Source:** [`1.0/en/0x10-C04-Infrastructure.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C04-Infrastructure.md)
+> **Requirements:** 46 | **Sections:** 8
+
+## Control Objective
+
+AI infrastructure must be hardened against privilege escalation, supply chain tampering, and lateral movement through secure configuration, runtime isolation, trusted deployment pipelines, and comprehensive monitoring.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C4.1 | Runtime Environment Isolation | 5 | 4.1.1–4.1.5 |
+| C4.2 | Secure Build & Deployment Pipelines | 4 | 4.2.1–4.2.4 |
+| C4.3 | Network Security & Access Control | 5 | 4.3.1–4.3.5 |
+| C4.4 | Secrets & Cryptographic Key Management | 5 | 4.4.1–4.4.5 |
+| C4.5 | AI Workload Sandboxing & Validation | 7 | 4.5.1–4.5.7 |
+| C4.6 | AI Infrastructure Resource Management, Backup and Recovery | 3 | 4.6.1–4.6.3 |
+| C4.7 | AI Hardware Security | 8 | 4.7.1–4.7.8 |
+| C4.8 | Edge & Distributed AI Security | 9 | 4.8.1–4.8.9 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- GPU side-channel attacks (leaking model weights or data from shared GPU memory)
+- Container escape from AI workloads gaining host access
+- Supply chain compromise of ML framework dependencies (PyTorch, TensorFlow packages)
+- Lateral movement from compromised inference endpoints to training infrastructure
+- Edge device tampering or model extraction from on-device deployments
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Container isolation:** gVisor, Kata Containers, Firecracker for AI workloads
+- **GPU security:** NVIDIA MIG (Multi-Instance GPU), Confidential Computing (AMD SEV, Intel TDX)
+- **Secrets management:** HashiCorp Vault, AWS Secrets Manager, Azure Key Vault
+- **Network security:** Cilium, Calico for Kubernetes network policies
+- **Edge deployment:** ONNX Runtime with TEE, TFLite with attestation
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C4.1 Runtime Environment Isolation | _TBD_ | |
+| C4.2 Secure Build & Deployment Pipelines | _TBD_ | |
+| C4.3 Network Security & Access Control | _TBD_ | |
+| C4.4 Secrets & Cryptographic Key Management | _TBD_ | |
+| C4.5 AI Workload Sandboxing & Validation | _TBD_ | |
+| C4.6 AI Infrastructure Resource Management, Backup and Recovery | _TBD_ | |
+| C4.7 AI Hardware Security | _TBD_ | |
+| C4.8 Edge & Distributed AI Security | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] What's the maturity of confidential computing for GPU workloads?
+- [ ] How do you isolate multi-tenant GPU workloads without significant performance overhead?
+- [ ] What are the best practices for securing AI inference at the edge with limited compute?
+- [ ] How should hardware security requirements differ for training vs. inference infrastructure?
+
+---
+
+## Related Standards & Cross-References
+
+- [NIST Cybersecurity Framework 2.0](https://www.nist.gov/cyberframework)
+- [CIS Controls v8](https://www.cisecurity.org/controls/v8)
+- [Kubernetes Security Best Practices](https://kubernetes.io/docs/concepts/security/)
+- [Cloud Security Alliance: Cloud Controls Matrix](https://cloudsecurityalliance.org/research/cloud-controls-matrix/)
+- [ENISA: Secure Infrastructure Design](https://www.enisa.europa.eu/topics/critical-information-infrastructures-and-services)
+- [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C05-Access-Control.md
+++ b/wiki/C05-Access-Control.md
@@ -1,0 +1,97 @@
+# C05: Access Control & Identity for AI Components & Users
+
+> **Source:** [`1.0/en/0x10-C05-Access-Control-and-Identity.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C05-Access-Control-and-Identity.md)
+> **Requirements:** 26 | **Sections:** 6
+
+## Control Objective
+
+Effective access control for AI systems requires robust identity management, context-aware authorization, and runtime enforcement following zero-trust principles.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C5.1 | Identity Management & Authentication | 3 | 5.1.1–5.1.3 |
+| C5.2 | Authorization & Policy | 8 | 5.2.1–5.2.8 |
+| C5.3 | Query-Time Security Enforcement | 4 | 5.3.1–5.3.4 |
+| C5.4 | Output Filtering & Data Loss Prevention | 3 | 5.4.1–5.4.3 |
+| C5.5 | Multi-Tenant Isolation | 4 | 5.5.1–5.5.4 |
+| C5.6 | Autonomous Agent Authorization | 4 | 5.6.1–5.6.4 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Privilege escalation through prompt injection causing the model to act with elevated permissions
+- Cross-tenant data leakage in shared AI infrastructure
+- Agent identity spoofing in multi-agent systems
+- Confused deputy attacks where AI tools act with the user's credentials beyond intended scope
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Policy engines:** OPA (Open Policy Agent), Cedar (AWS), Casbin
+- **Identity:** SPIFFE/SPIRE for workload identity, OAuth 2.0 for user-facing AI apps
+- **DLP:** Google DLP API, Microsoft Purview, custom regex/NER-based PII filters
+- **Multi-tenant isolation:** Kubernetes namespaces, database row-level security
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C5.1 Identity Management & Authentication | _TBD_ | |
+| C5.2 Authorization & Policy | _TBD_ | |
+| C5.3 Query-Time Security Enforcement | _TBD_ | |
+| C5.4 Output Filtering & Data Loss Prevention | _TBD_ | |
+| C5.5 Multi-Tenant Isolation | _TBD_ | |
+| C5.6 Autonomous Agent Authorization | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] How should authorization policies account for the non-deterministic nature of AI outputs?
+- [ ] What's the right model for agent identity in multi-agent orchestration?
+- [ ] How do you enforce query-time access control in vector databases that lack native RBAC?
+- [ ] Should AI systems have their own identity distinct from the calling user?
+
+---
+
+## Related Standards & Cross-References
+
+- [NIST SP 800-162: Guide to ABAC](https://csrc.nist.gov/pubs/sp/800/162/final)
+- [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)
+- [NIST SP 800-63-3: Digital Identity Guidelines](https://csrc.nist.gov/pubs/sp/800/63/3/final)
+- [NIST IR 8360: ML for Access Control Policy Verification](https://csrc.nist.gov/pubs/ir/8360/final)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C06-Supply-Chain.md
+++ b/wiki/C06-Supply-Chain.md
@@ -1,0 +1,100 @@
+# C06: Supply Chain Security for Models, Frameworks & Data
+
+> **Source:** [`1.0/en/0x10-C06-Supply-Chain.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C06-Supply-Chain.md)
+> **Requirements:** 33 | **Sections:** 7
+
+## Control Objective
+
+AI supply-chain attacks exploit third-party models, frameworks, or datasets to embed backdoors, bias, or exploitable code. These controls provide end-to-end traceability, vulnerability management, and monitoring.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C6.1 | Pretrained Model Vetting & Origin Integrity | 5 | 6.1.1–6.1.5 |
+| C6.2 | Framework & Library Scanning | 5 | 6.2.1–6.2.5 |
+| C6.3 | Dependency Pinning & Verification | 5 | 6.3.1–6.3.5 |
+| C6.4 | Trusted Source Enforcement | 5 | 6.4.1–6.4.5 |
+| C6.5 | Third-Party Dataset Risk Assessment | 5 | 6.5.1–6.5.5 |
+| C6.6 | Supply Chain Attack Monitoring | 3 | 6.6.1–6.6.3 |
+| C6.7 | AI BOM for Model Artifacts | 5 | 6.7.1–6.7.5 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Backdoored pretrained models on Hugging Face or Model Zoo
+- Pickle deserialization attacks in model weight files
+- Typosquatting attacks on PyPI/npm packages used in ML pipelines
+- Compromised training datasets from third-party sources
+- Malicious model adapters/LoRA weights with embedded backdoors
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Model scanning:** ModelScan (Protect AI), Fickling (pickle analysis), safetensors format
+- **SBOM/MLBOM:** CycloneDX ML extension, SPDX AI profile
+- **Dependency scanning:** Dependabot, Snyk, OSV Scanner, Socket.dev
+- **Registry security:** Hugging Face model cards, model signing (emerging)
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C6.1 Pretrained Model Vetting & Origin Integrity | _TBD_ | |
+| C6.2 Framework & Library Scanning | _TBD_ | |
+| C6.3 Dependency Pinning & Verification | _TBD_ | |
+| C6.4 Trusted Source Enforcement | _TBD_ | |
+| C6.5 Third-Party Dataset Risk Assessment | _TBD_ | |
+| C6.6 Supply Chain Attack Monitoring | _TBD_ | |
+| C6.7 AI BOM for Model Artifacts | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] What constitutes an adequate AI Bill of Materials (AI-BOM)?
+- [ ] How do you verify model integrity when you can't reproduce the training run?
+- [ ] What's the state of model signing standards (equivalent of code signing for models)?
+- [ ] How should organizations assess risk of closed-source API-accessed models?
+
+---
+
+## Related Standards & Cross-References
+
+- [OWASP LLM03:2025 Supply Chain](https://genai.owasp.org/llmrisk/llm032025-supply-chain/)
+- [MITRE ATLAS: Supply Chain Compromise](https://atlas.mitre.org/techniques/AML.T0010)
+- [SBOM Overview: CISA](https://www.cisa.gov/sbom)
+- [CycloneDX: Machine Learning BOM](https://cyclonedx.org/capabilities/mlbom/)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C07-Model-Behavior.md
+++ b/wiki/C07-Model-Behavior.md
@@ -1,0 +1,100 @@
+# C07: Model Behavior, Output Control & Safety Assurance
+
+> **Source:** [`1.0/en/0x10-C07-Model-Behavior.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C07-Model-Behavior.md)
+> **Requirements:** 30 | **Sections:** 8
+
+## Control Objective
+
+This control category ensures that model outputs are technically constrained, validated, and monitored so that unsafe, malformed, or high-risk responses cannot reach users or downstream systems.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C7.1 | Output Format Enforcement | 4 | 7.1.1–7.1.4 |
+| C7.2 | Hallucination Detection & Mitigation | 4 | 7.2.1–7.2.4 |
+| C7.3 | Output Safety & Privacy Filtering | 6 | 7.3.1–7.3.6 |
+| C7.4 | Output & Action Limiting | 3 | 7.4.1–7.4.3 |
+| C7.5 | Explainability & Transparency | 3 | 7.5.1–7.5.3 |
+| C7.6 | Monitoring Integration | 3 | 7.6.1–7.6.3 |
+| C7.7 | Generative Media Safeguards | 5 | 7.7.1–7.7.5 |
+| C7.8 | Source Attribution & Citation Integrity | 2 | 7.8.1–7.8.2 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Hallucination leading to incorrect medical, legal, or financial advice
+- Output containing executable code (XSS, SQL injection) passed to downstream systems
+- PII leakage in model responses from memorized training data
+- Deepfake generation and synthetic media misuse
+- Citation fabrication (fake references that appear legitimate)
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Output validation:** Guardrails AI, NeMo Guardrails (NVIDIA), LLM Guard
+- **Hallucination detection:** Vectara HHEM, Lynx, RAGAS faithfulness metrics
+- **Structured output:** JSON mode, function calling, constrained decoding (Outlines, Guidance)
+- **Content safety:** C2PA for media provenance, SynthID for watermarking
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C7.1 Output Format Enforcement | _TBD_ | |
+| C7.2 Hallucination Detection & Mitigation | _TBD_ | |
+| C7.3 Output Safety & Privacy Filtering | _TBD_ | |
+| C7.4 Output & Action Limiting | _TBD_ | |
+| C7.5 Explainability & Transparency | _TBD_ | |
+| C7.6 Monitoring Integration | _TBD_ | |
+| C7.7 Generative Media Safeguards | _TBD_ | |
+| C7.8 Source Attribution & Citation Integrity | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] What hallucination rate is acceptable for different risk domains?
+- [ ] How do you validate citation accuracy at scale without human review?
+- [ ] What's the best approach for output filtering that doesn't degrade model utility?
+- [ ] How should generative media safeguards adapt as generation quality improves?
+
+---
+
+## Related Standards & Cross-References
+
+- [OWASP LLM05:2025 Improper Output Handling](https://genai.owasp.org/llmrisk/llm052025-improper-output-handling/)
+- [OWASP LLM06:2025 Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C08-Memory-and-Embeddings.md
+++ b/wiki/C08-Memory-and-Embeddings.md
@@ -1,0 +1,99 @@
+# C08: Memory, Embeddings & Vector Database Security
+
+> **Source:** [`1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md)
+> **Requirements:** 25 | **Sections:** 5
+
+## Control Objective
+
+Embeddings and vector stores act as semi-persistent and persistent 'memory' for AI systems via RAG. This memory can become a high-risk data sink and data exfiltration path. This control family hardens memory pipelines and vector databases.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C8.1 | Access Controls on Memory & RAG Indices | 6 | 8.1.1–8.1.6 |
+| C8.2 | Embedding Sanitization & Validation | 5 | 8.2.1–8.2.5 |
+| C8.3 | Memory Expiry, Revocation & Deletion | 6 | 8.3.1–8.3.6 |
+| C8.4 | Prevent Embedding Inversion & Leakage | 2 | 8.4.1–8.4.2 |
+| C8.5 | Scope Enforcement for User-Specific Memory | 6 | 8.5.1–8.5.6 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- RAG poisoning — injecting malicious content into knowledge bases retrieved at inference time
+- Embedding inversion attacks — reconstructing original text from embedding vectors
+- Cross-tenant data leakage through shared vector indices
+- Memory persistence attacks — injecting instructions that persist across conversations
+- PII accumulation in vector stores without adequate deletion mechanisms
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Vector databases:** Pinecone (with namespaces), Weaviate (with RBAC), Qdrant, Milvus
+- **Embedding security:** embedding dimensionality reduction, perturbation-based privacy
+- **RAG frameworks:** LlamaIndex, LangChain (with metadata filtering for access control)
+- **Data cleanup:** TTL-based expiration, tombstone-based deletion in vector stores
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C8.1 Access Controls on Memory & RAG Indices | _TBD_ | |
+| C8.2 Embedding Sanitization & Validation | _TBD_ | |
+| C8.3 Memory Expiry, Revocation & Deletion | _TBD_ | |
+| C8.4 Prevent Embedding Inversion & Leakage | _TBD_ | |
+| C8.5 Scope Enforcement for User-Specific Memory | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] How do you enforce RBAC in vector databases that don't natively support it?
+- [ ] What's the practical risk of embedding inversion for modern high-dimensional embeddings?
+- [ ] How should memory expiry policies differ for conversation memory vs. knowledge base memory?
+- [ ] What sanitization is adequate for content entering RAG pipelines?
+
+---
+
+## Related Standards & Cross-References
+
+- [OWASP LLM08:2025 Vector and Embedding Weaknesses](https://genai.owasp.org/llmrisk/llm082025-vector-and-embedding-weaknesses/)
+- [OWASP LLM04:2025 Data and Model Poisoning](https://genai.owasp.org/llmrisk/llm042025-data-and-model-poisoning/)
+- [OWASP LLM02:2025 Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/)
+- [MITRE ATLAS: RAG Poisoning](https://atlas.mitre.org/techniques/AML.T0070)
+- [MITRE ATLAS: False RAG Entry Injection](https://atlas.mitre.org/techniques/AML.T0071)
+- [MITRE ATLAS: Infer Training Data Membership](https://atlas.mitre.org/techniques/AML.T0024.000)
+- [MITRE ATLAS: Invert AI Model](https://atlas.mitre.org/techniques/AML.T0024.001)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C09-Orchestration-and-Agents.md
+++ b/wiki/C09-Orchestration-and-Agents.md
@@ -1,0 +1,103 @@
+# C09: Autonomous Orchestration & Agentic Action Security
+
+> **Source:** [`1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md)
+> **Requirements:** 32 | **Sections:** 8
+
+## Control Objective
+
+Autonomous and multi-agent systems must execute only authorized, intended, and bounded actions. This control family reduces risk from tool misuse, privilege escalation, uncontrolled recursion/cost growth, protocol manipulation, and cross-agent or cross-tenant interference.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C9.1 | Execution Budgets, Loop Control, and Circuit Breakers | 5 | 9.1.1–9.1.5 |
+| C9.2 | High-Impact Action Approval and Irreversibility Controls | 3 | 9.2.1–9.2.3 |
+| C9.3 | Tool and Plugin Isolation and Safe Integration | 6 | 9.3.1–9.3.6 |
+| C9.4 | Agent and Orchestrator Identity, Signing, and Tamper-Evident Audit | 4 | 9.4.1–9.4.4 |
+| C9.5 | Secure Messaging and Protocol Hardening | 4 | 9.5.1–9.5.4 |
+| C9.6 | Authorization, Delegation, and Continuous Enforcement | 4 | 9.6.1–9.6.4 |
+| C9.7 | Intent Verification and Constraint Gates | 4 | 9.7.1–9.7.4 |
+| C9.8 | Multi-Agent Domain Isolation and Swarm Risk Controls | 2 | 9.8.1–9.8.2 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Recursive agent loops causing unbounded API spend or compute consumption
+- Tool misuse — agent calling dangerous tools (rm -rf, DROP TABLE) via prompt injection
+- Privilege escalation through tool chaining (combining benign tools for malicious effect)
+- Agent impersonation in multi-agent systems
+- Confused deputy — agent acting with human's credentials beyond intended delegation scope
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Agent frameworks:** LangGraph, CrewAI, AutoGen, Claude Agent SDK (with built-in guardrails)
+- **Sandboxing:** E2B, Modal, Firecracker for code execution sandboxes
+- **Budget controls:** Token/cost limits in API calls, timeout-based circuit breakers
+- **Approval workflows:** Human-in-the-loop gating via Slack/webhook integrations
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C9.1 Execution Budgets, Loop Control, and Circuit Breakers | _TBD_ | |
+| C9.2 High-Impact Action Approval and Irreversibility Controls | _TBD_ | |
+| C9.3 Tool and Plugin Isolation and Safe Integration | _TBD_ | |
+| C9.4 Agent and Orchestrator Identity, Signing, and Tamper-Evident Audit | _TBD_ | |
+| C9.5 Secure Messaging and Protocol Hardening | _TBD_ | |
+| C9.6 Authorization, Delegation, and Continuous Enforcement | _TBD_ | |
+| C9.7 Intent Verification and Constraint Gates | _TBD_ | |
+| C9.8 Multi-Agent Domain Isolation and Swarm Risk Controls | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] What's the right granularity for tool permissions in agentic systems?
+- [ ] How do you prevent indirect prompt injection from causing tool misuse in multi-step agents?
+- [ ] What budget/cost controls are adequate for autonomous agents?
+- [ ] How should multi-agent trust boundaries be defined and enforced?
+
+---
+
+## Related Standards & Cross-References
+
+- [OWASP LLM06:2025 Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/)
+- [OWASP LLM10:2025 Unbounded Consumption](https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/)
+- [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
+- [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final)
+- [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C10-MCP-Security.md
+++ b/wiki/C10-MCP-Security.md
@@ -1,0 +1,96 @@
+# C10: Model Context Protocol (MCP) Security
+
+> **Source:** [`1.0/en/0x10-C10-MCP-Security.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C10-MCP-Security.md)
+> **Requirements:** 33 | **Sections:** 6
+
+## Control Objective
+
+Ensure secure discovery, authentication, authorization, transport, and use of MCP-based tool and resource integrations to prevent context confusion, unauthorized tool invocation, or cross-tenant data exposure.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C10.1 | Component Integrity & Supply Chain Hygiene | 2 | 10.1.1–10.1.2 |
+| C10.2 | Authentication & Authorization | 12 | 10.2.1–10.2.12 |
+| C10.3 | Secure Transport & Network Boundary Protection | 5 | 10.3.1–10.3.5 |
+| C10.4 | Schema, Message, and Input Validation | 8 | 10.4.1–10.4.8 |
+| C10.5 | Outbound Access & Agent Execution Safety | 3 | 10.5.1–10.5.3 |
+| C10.6 | Transport Restrictions & High-Risk Boundary Controls | 3 | 10.6.1–10.6.3 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Tool poisoning — malicious MCP servers providing dangerous tool definitions
+- Rug-pull attacks — MCP servers changing tool behavior after initial trust establishment
+- Cross-tenant data exposure through shared MCP server instances
+- Man-in-the-middle attacks on MCP transport (especially stdio-based local servers)
+- Context confusion — tool descriptions manipulating the LLM's behavior
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **MCP SDKs:** Official MCP TypeScript/Python SDKs with built-in validation
+- **Transport security:** TLS for remote MCP, Unix domain sockets for local
+- **Discovery:** MCP server registries (emerging), tool schema validation
+- **Auth:** OAuth 2.0 for MCP, API key management
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C10.1 Component Integrity & Supply Chain Hygiene | _TBD_ | |
+| C10.2 Authentication & Authorization | _TBD_ | |
+| C10.3 Secure Transport & Network Boundary Protection | _TBD_ | |
+| C10.4 Schema, Message, and Input Validation | _TBD_ | |
+| C10.5 Outbound Access & Agent Execution Safety | _TBD_ | |
+| C10.6 Transport Restrictions & High-Risk Boundary Controls | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] How should MCP server trust be established and maintained over time?
+- [ ] What's the right auth model for MCP in enterprise environments?
+- [ ] How do you prevent tool description manipulation from affecting model behavior?
+- [ ] What transport security is adequate for local (stdio) vs. remote (SSE/HTTP) MCP servers?
+
+---
+
+## Related Standards & Cross-References
+
+- [Model Context Protocol (MCP) Specification](https://modelcontextprotocol.io/)
+- [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C11-Adversarial-Robustness.md
+++ b/wiki/C11-Adversarial-Robustness.md
@@ -1,0 +1,109 @@
+# C11: Adversarial Robustness & Attack Resistance
+
+> **Source:** [`1.0/en/0x10-C11-Adversarial-Robustness.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C11-Adversarial-Robustness.md)
+> **Requirements:** 38 | **Sections:** 9
+
+## Control Objective
+
+Ensure that AI systems remain reliable, privacy-preserving, and abuse-resistant when facing evasion, inference, extraction, or poisoning attacks.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C11.1 | Model Alignment & Safety | 5 | 11.1.1–11.1.5 |
+| C11.2 | Adversarial-Example Hardening | 5 | 11.2.1–11.2.5 |
+| C11.3 | Membership-Inference Mitigation | 3 | 11.3.1–11.3.3 |
+| C11.4 | Model-Inversion Resistance | 3 | 11.4.1–11.4.3 |
+| C11.5 | Model-Extraction Defense | 5 | 11.5.1–11.5.5 |
+| C11.6 | Inference-Time Poisoned-Data Detection | 5 | 11.6.1–11.6.5 |
+| C11.7 | Security Policy Adaptation | 4 | 11.7.1–11.7.4 |
+| C11.8 | Agent Security Self-Assessment | 3 | 11.8.1–11.8.3 |
+| C11.9 | Self-Modification & Autonomous Update Security | 5 | 11.9.1–11.9.5 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Adversarial examples causing misclassification (image perturbations, text paraphrases)
+- Membership inference — determining if specific data was in the training set
+- Model inversion — reconstructing training data from model outputs
+- Model extraction — stealing model weights through API queries
+- Poisoning at inference time via compromised RAG or context
+- Alignment bypass through jailbreaks and prompt manipulation
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Adversarial testing:** ART (IBM), Adversarial Robustness Toolbox, TextAttack, Garak
+- **Privacy:** Opacus (differential privacy for PyTorch), TensorFlow Privacy
+- **Model extraction defense:** API rate limiting, output perturbation, watermarking
+- **Alignment:** RLHF toolkits, Constitutional AI approaches, red-teaming frameworks
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C11.1 Model Alignment & Safety | _TBD_ | |
+| C11.2 Adversarial-Example Hardening | _TBD_ | |
+| C11.3 Membership-Inference Mitigation | _TBD_ | |
+| C11.4 Model-Inversion Resistance | _TBD_ | |
+| C11.5 Model-Extraction Defense | _TBD_ | |
+| C11.6 Inference-Time Poisoned-Data Detection | _TBD_ | |
+| C11.7 Security Policy Adaptation | _TBD_ | |
+| C11.8 Agent Security Self-Assessment | _TBD_ | |
+| C11.9 Self-Modification & Autonomous Update Security | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] How do you quantify adversarial robustness in a meaningful way for LLMs?
+- [ ] What's the practical risk of model extraction for API-served models?
+- [ ] How should alignment testing evolve as models become more capable?
+- [ ] What self-modification capabilities are safe for autonomous AI systems?
+
+---
+
+## Related Standards & Cross-References
+
+- [OWASP LLM02:2025 Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/)
+- [OWASP LLM04:2025 Data and Model Poisoning](https://genai.owasp.org/llmrisk/llm042025-data-and-model-poisoning/)
+- [OWASP LLM10:2025 Unbounded Consumption](https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/)
+- [MITRE ATLAS: Infer Training Data Membership](https://atlas.mitre.org/techniques/AML.T0024.000)
+- [MITRE ATLAS: Invert ML Model](https://atlas.mitre.org/techniques/AML.T0024.001)
+- [MITRE ATLAS: Extract ML Model](https://atlas.mitre.org/techniques/AML.T0024.002)
+- [MITRE ATLAS: Backdoor ML Model](https://atlas.mitre.org/techniques/AML.T0018)
+- [NIST AI 100-2e2023 Adversarial Machine Learning](https://csrc.nist.gov/pubs/ai/100/2/e2023/final)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C12-Privacy.md
+++ b/wiki/C12-Privacy.md
@@ -1,0 +1,100 @@
+# C12: Privacy Protection & Personal Data Management
+
+> **Source:** [`1.0/en/0x10-C12-Privacy.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C12-Privacy.md)
+> **Requirements:** 23 | **Sections:** 6
+
+## Control Objective
+
+Maintain rigorous privacy assurances across the entire AI lifecycle (collection, training, inference, and incident response) so that personal data is only processed with clear consent, minimum necessary scope, provable erasure, and formal privacy guarantees.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C12.1 | Anonymization & Data Minimization | 4 | 12.1.1–12.1.4 |
+| C12.2 | Right-to-be-Forgotten & Deletion Enforcement | 4 | 12.2.1–12.2.4 |
+| C12.3 | Differential-Privacy Safeguards | 4 | 12.3.1–12.3.4 |
+| C12.4 | Purpose-Limitation & Scope-Creep Protection | 4 | 12.4.1–12.4.4 |
+| C12.5 | Consent Management & Lawful-Basis Tracking | 3 | 12.5.1–12.5.3 |
+| C12.6 | Federated Learning with Privacy Controls | 4 | 12.6.1–12.6.4 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Training data memorization leaking PII in model outputs
+- Re-identification attacks on anonymized training data
+- Inability to truly 'forget' data already learned by a trained model (machine unlearning gap)
+- Scope creep — data collected for one purpose being used for model training
+- Cross-border data transfer violations in distributed training setups
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Differential privacy:** Opacus, TensorFlow Privacy, Google DP Library
+- **PII detection:** Presidio (Microsoft), spaCy NER, Google DLP API
+- **Machine unlearning:** SISA training, approximate unlearning methods (research-stage)
+- **Federated learning:** PySyft, TensorFlow Federated, Flower
+- **Consent management:** OneTrust, TrustArc (integrated with ML pipelines)
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C12.1 Anonymization & Data Minimization | _TBD_ | |
+| C12.2 Right-to-be-Forgotten & Deletion Enforcement | _TBD_ | |
+| C12.3 Differential-Privacy Safeguards | _TBD_ | |
+| C12.4 Purpose-Limitation & Scope-Creep Protection | _TBD_ | |
+| C12.5 Consent Management & Lawful-Basis Tracking | _TBD_ | |
+| C12.6 Federated Learning with Privacy Controls | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] Is machine unlearning practical at scale, or is retraining the only reliable option?
+- [ ] What epsilon values for differential privacy provide meaningful protection without destroying model utility?
+- [ ] How should GDPR Article 17 (right to erasure) apply to foundation models?
+- [ ] What constitutes adequate anonymization for AI training data?
+
+---
+
+## Related Standards & Cross-References
+
+- [OWASP LLM02:2025 Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/)
+- [General Data Protection Regulation (GDPR)](https://gdpr-info.eu/)
+- [California Consumer Privacy Act (CCPA)](https://oag.ca.gov/privacy/ccpa)
+- [EU Artificial Intelligence Act](https://artificialintelligenceact.eu/)
+- [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C13-Monitoring-and-Logging.md
+++ b/wiki/C13-Monitoring-and-Logging.md
@@ -1,0 +1,102 @@
+# C13: Monitoring, Logging & Anomaly Detection
+
+> **Source:** [`1.0/en/0x10-C13-Monitoring-and-Logging.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C13-Monitoring-and-Logging.md)
+> **Requirements:** 47 | **Sections:** 8
+
+## Control Objective
+
+This section provides requirements for delivering real-time and forensic visibility into what the model and other AI components see, do, and return, so threats can be detected, triaged, and learned from.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C13.1 | Request & Response Logging | 8 | 13.1.1–13.1.8 |
+| C13.2 | Abuse Detection and Alerting | 10 | 13.2.1–13.2.10 |
+| C13.3 | Model Drift Detection | 5 | 13.3.1–13.3.5 |
+| C13.4 | Performance & Behavior Telemetry | 5 | 13.4.1–13.4.5 |
+| C13.5 | AI Incident Response Planning & Execution | 3 | 13.5.1–13.5.3 |
+| C13.6 | AI Performance Degradation Detection | 6 | 13.6.1–13.6.6 |
+| C13.7 | DAG Visualization & Workflow Security | 5 | 13.7.1–13.7.5 |
+| C13.8 | Proactive Security Behavior Monitoring | 5 | 13.8.1–13.8.5 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Undetected model drift leading to degraded or biased outputs over time
+- Abuse pattern escalation (testing boundaries before launching full attack)
+- Log injection or log poisoning to hide attack traces
+- Insufficient logging of AI-specific events (tool calls, RAG retrievals, agent actions)
+- Alert fatigue from overly broad anomaly detection
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **LLM observability:** LangSmith, Langfuse, Arize AI, WhyLabs, Helicone
+- **Drift detection:** Evidently AI, NannyML, Great Expectations
+- **SIEM integration:** Splunk AI, Elastic AI Assistant, custom OpenTelemetry exporters
+- **Incident response:** PagerDuty, Opsgenie with AI-specific runbooks
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C13.1 Request & Response Logging | _TBD_ | |
+| C13.2 Abuse Detection and Alerting | _TBD_ | |
+| C13.3 Model Drift Detection | _TBD_ | |
+| C13.4 Performance & Behavior Telemetry | _TBD_ | |
+| C13.5 AI Incident Response Planning & Execution | _TBD_ | |
+| C13.6 AI Performance Degradation Detection | _TBD_ | |
+| C13.7 DAG Visualization & Workflow Security | _TBD_ | |
+| C13.8 Proactive Security Behavior Monitoring | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] What's the right granularity for logging AI interactions (full prompts vs. metadata only)?
+- [ ] How do you balance logging completeness with privacy (PII in prompts/responses)?
+- [ ] What AI-specific SIEM rules are most effective for detecting attacks?
+- [ ] How should model drift detection thresholds be calibrated?
+
+---
+
+## Related Standards & Cross-References
+
+- [OWASP Top 10 for LLM Applications 2025](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- [MITRE ATLAS](https://atlas.mitre.org/)
+- [NIST AI Risk Management Framework](https://www.nist.gov/system/files/documents/2023/01/26/AI%20RMF%201.0.pdf)
+- [NIST AI 100-1](https://doi.org/10.6028/NIST.AI.100-1)
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/C14-Human-Oversight.md
+++ b/wiki/C14-Human-Oversight.md
@@ -1,0 +1,97 @@
+# C14: Human Oversight, Accountability & Governance
+
+> **Source:** [`1.0/en/0x10-C14-Human-Oversight.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C14-Human-Oversight.md)
+> **Requirements:** 25 | **Sections:** 7
+
+## Control Objective
+
+This chapter provides requirements for maintaining human oversight and clear accountability chains in AI systems, ensuring explainability, transparency, and ethical stewardship throughout the AI lifecycle.
+
+---
+
+## Section Breakdown
+
+| Section | Title | Reqs | IDs |
+|---------|-------|:----:|-----|
+| C14.1 | Kill-Switch & Override Mechanisms | 4 | 14.1.1–14.1.4 |
+| C14.2 | Human-in-the-Loop Decision Checkpoints | 4 | 14.2.1–14.2.4 |
+| C14.3 | Chain of Responsibility & Auditability | 2 | 14.3.1–14.3.2 |
+| C14.4 | Explainable-AI Techniques | 4 | 14.4.1–14.4.4 |
+| C14.5 | Model Cards & Usage Disclosures | 4 | 14.5.1–14.5.4 |
+| C14.6 | Uncertainty Quantification | 4 | 14.6.1–14.6.4 |
+| C14.7 | User-Facing Transparency Reports | 3 | 14.7.1–14.7.3 |
+
+---
+
+## Threat Landscape
+
+Known attacks, real-world incidents, and threat vectors relevant to this chapter:
+
+- Automation bias — humans over-trusting AI outputs without adequate review
+- Kill-switch failures in autonomous systems operating at high speed
+- Accountability gaps when AI systems make consequential errors
+- Opaque AI decision-making in regulated domains (healthcare, finance, criminal justice)
+- Model cards that are incomplete or misleading about model limitations
+
+### Notable Incidents & Research
+
+_Add links to CVEs, published attacks, blog posts, and academic papers relevant to this chapter._
+
+| Date | Incident / Paper | Relevance | Link |
+|------|------------------|-----------|------|
+| | | | |
+
+---
+
+## Tooling & Implementation
+
+Current tools, frameworks, and libraries that help implement these controls:
+
+- **Explainability:** SHAP, LIME, Captum (PyTorch), InterpretML
+- **Model cards:** Model Card Toolkit (Google), Hugging Face model card template
+- **Uncertainty:** Conformal prediction, MC Dropout, ensemble methods
+- **Human-in-the-loop:** Label Studio, Prodigy, custom approval workflows
+
+### Implementation Maturity
+
+| Control Area | Tooling Maturity | Notes |
+|--------------|:---:|-------|
+| C14.1 Kill-Switch & Override Mechanisms | _TBD_ | |
+| C14.2 Human-in-the-Loop Decision Checkpoints | _TBD_ | |
+| C14.3 Chain of Responsibility & Auditability | _TBD_ | |
+| C14.4 Explainable-AI Techniques | _TBD_ | |
+| C14.5 Model Cards & Usage Disclosures | _TBD_ | |
+| C14.6 Uncertainty Quantification | _TBD_ | |
+| C14.7 User-Facing Transparency Reports | _TBD_ | |
+
+---
+
+## Open Research Questions
+
+- [ ] What level of explainability is adequate for different risk domains?
+- [ ] How do you design kill-switches that work for real-time AI systems?
+- [ ] What should model cards include for foundation models with broad use cases?
+- [ ] How should uncertainty quantification be communicated to non-technical stakeholders?
+
+---
+
+## Related Standards & Cross-References
+
+_No references listed yet._
+
+### AISVS Cross-Chapter Links
+
+_Which other AISVS chapters have related or overlapping requirements?_
+
+| Related Chapter | Overlap Area | Notes |
+|-----------------|--------------|-------|
+| | | |
+
+---
+
+## Community Notes
+
+_Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+---
+

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,54 @@
+# AISVS Research Wiki
+
+**OWASP AI Security Verification Standard — Research & Analysis Hub**
+
+This wiki provides per-chapter research pages for the AISVS 1.0 standard. Each page contains the chapter's control objective, section breakdown, research notes, and open questions to guide community contribution and ongoing development.
+
+> **Standard source:** [`1.0/en/`](https://github.com/OWASP/AISVS/tree/main/1.0/en) in the main repository
+
+---
+
+## Chapters
+
+| # | Chapter | Requirements | Page |
+|---|---------|:---:|------|
+| C1 | Training Data Integrity & Traceability | 24 | [C01 Training Data](C01-Training-Data.md) |
+| C2 | User Input Validation | 33 | [C02 User Input Validation](C02-User-Input-Validation.md) |
+| C3 | Model Lifecycle Management | 23 | [C03 Model Lifecycle Management](C03-Model-Lifecycle-Management.md) |
+| C4 | Infrastructure & Deployment Security | 46 | [C04 Infrastructure](C04-Infrastructure.md) |
+| C5 | Access Control & Identity | 26 | [C05 Access Control](C05-Access-Control.md) |
+| C6 | Supply Chain Security | 33 | [C06 Supply Chain](C06-Supply-Chain.md) |
+| C7 | Model Behavior & Output Control | 30 | [C07 Model Behavior](C07-Model-Behavior.md) |
+| C8 | Memory, Embeddings & Vector DB Security | 25 | [C08 Memory and Embeddings](C08-Memory-and-Embeddings.md) |
+| C9 | Orchestration & Agentic Action Security | 32 | [C09 Orchestration and Agents](C09-Orchestration-and-Agents.md) |
+| C10 | MCP Security | 33 | [C10 MCP Security](C10-MCP-Security.md) |
+| C11 | Adversarial Robustness | 38 | [C11 Adversarial Robustness](C11-Adversarial-Robustness.md) |
+| C12 | Privacy Protection | 23 | [C12 Privacy](C12-Privacy.md) |
+| C13 | Monitoring, Logging & Anomaly Detection | 47 | [C13 Monitoring and Logging](C13-Monitoring-and-Logging.md) |
+| C14 | Human Oversight & Accountability | 25 | [C14 Human Oversight](C14-Human-Oversight.md) |
+| | **Total** | **438** | |
+
+## Appendices
+
+| Appendix | Page |
+|----------|------|
+| A: Glossary | [Appendix A Glossary](Appendix-A-Glossary.md) |
+| B: References | [Appendix B References](Appendix-B-References.md) |
+| C: AI-Assisted Secure Coding (27 reqs) | [Appendix C AI Secure Coding](Appendix-C-AI-Secure-Coding.md) |
+| D: AI Security Controls Inventory | [Appendix D Controls Inventory](Appendix-D-Controls-Inventory.md) |
+
+## How to Use This Wiki
+
+Each chapter page follows a consistent structure:
+
+1. **Overview** — Control objective and chapter scope
+2. **Section Breakdown** — Each section with requirement count and IDs
+3. **Threat Landscape** — Known attacks, CVEs, and real-world incidents relevant to the chapter
+4. **Tooling & Implementation** — Current tools, frameworks, and libraries that help implement these controls
+5. **Open Research Questions** — Gaps in tooling, unresolved debates, areas needing more research
+6. **Related Standards** — Cross-references to NIST, MITRE ATLAS, OWASP Top 10 for LLMs, EU AI Act, etc.
+7. **Community Notes** — Space for contributor observations and discussion
+
+---
+
+_This wiki is maintained alongside the [AISVS repository](https://github.com/OWASP/AISVS). Contributions welcome._


### PR DESCRIPTION
## Summary
- Adds `wiki/` directory with 19 research pages (14 chapters + 4 appendices + README index)
- Each chapter page includes: control objective, section breakdown with requirement IDs, threat landscape, tooling & implementation maturity tracking, open research questions (as checklists), related standards cross-references, and community notes
- Designed as a living research hub for community contributors to track threats, tooling gaps, and open questions per chapter

## Test plan
- [ ] Verify all relative links between wiki pages resolve correctly on GitHub
- [ ] Review a sample chapter page (e.g., C02) for accuracy against the source chapter
- [ ] Confirm requirement counts match the standard

🤖 Generated with [Claude Code](https://claude.com/claude-code)