### PR TITLE
Add AC.10 Provenance Completeness and Validation controls to Appendix C

### DIFF
--- a/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
+++ b/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
@@ -114,8 +114,6 @@ Ensure that deployment and promotion pipelines incorporate provenance-aware vali
 
 ---
 
----
-
 ## AC.10 Provenance Completeness and Validation
 
 Ensure that AI-generated artifacts include complete and consistent provenance metadata, and that this metadata is validated prior to integration or deployment.
@@ -127,6 +125,8 @@ In practice, policy-based enforcement depends on the availability and quality of
 | **AC.10.1** | **Verify that** AI-generated artifacts include required provenance fields (e.g., model identity, generation context, human involvement, and session identifiers). | 1 | D/V |
 | **AC.10.2** | **Verify that** provenance metadata is validated for completeness and consistency (e.g., no missing or ambiguous fields, normalized representations). | 2 | D |
 | **AC.10.3** | **Verify that** artifacts with incomplete, inconsistent, or unverifiable provenance metadata are rejected prior to merge or deployment. | 3 | D/V |
+
+---
 
 ## References
 


### PR DESCRIPTION
This PR adds AC.10 to Appendix C, focusing on validation of provenance completeness for AI-generated artifacts.

While existing controls cover traceability, auditability, and separation of duties, this addition strengthens enforcement by ensuring that provenance metadata is:
- present
- complete
- consistent
- validated prior to merge or deployment

This helps address enforcement gaps observed when metadata is partially missing or inconsistently structured.

This change builds on AC.8 and AC.9 and aims to make provenance a first-class requirement in AI-assisted development workflows.

Happy to refine scope or wording based on feedback.

Related Issue: #207 