### PR TITLE
C3.7: add fine-tuning pipeline authorization and reward model integrity

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -91,10 +91,10 @@ Fine-tuning pipelines are high-privilege operations that can alter deployed mode
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **3.7.1** | **Verify that** initiating a fine-tuning run requires authenticated authorization from a designated approver separate from the person requesting the run, with the approval identity, timestamp, and approved training configuration recorded in an immutable audit log before pipeline execution begins. | 2 | D/V |
-| **3.7.2** | **Verify that** the reward model used in any RLHF fine-tuning stage is treated as a versioned, signed artifact subject to the same integrity verification and validation gates required of policy model artifacts before it is used in a training run. | 2 | D/V |
-| **3.7.3** | **Verify that** reward hacking is evaluated after each RLHF training stage by measuring the policy model's reward scores on a held-out probe set and comparing them to human preference scores on the same set, with the run blocked from promotion if divergence exceeds a defined threshold. | 3 | D/V |
-| **3.7.4** | **Verify that** in multi-stage fine-tuning pipelines, each stage's output checkpoint is cryptographically signed and recorded as a distinct artifact in the model registry before the next stage begins, enabling isolation and rollback of any compromised intermediate stage. | 3 | D/V |
+| **3.7.1** | **Verify that** initiating a fine-tuning or retraining run requires authorization from a person who did not request the run (separation of duties). | 3 | D/V |
+| **3.7.2** | **Verify that** reward models used in RLHF fine-tuning are versioned, cryptographically signed, and integrity-verified before use in a training run. | 2 | D/V |
+| **3.7.3** | **Verify that** RLHF training stages include automated detection of reward hacking or reward model over-optimization (e.g., held-out human-preference probe sets, divergence thresholds, or KL penalty monitoring), with the run blocked from promotion if detection thresholds are exceeded. | 3 | D/V |
+| **3.7.4** | **Verify that** in multi-stage fine-tuning pipelines, each stage's output is integrity-verified before the next stage consumes it, and intermediate checkpoints are registered as distinct artifacts enabling per-stage rollback. | 3 | D/V |
 
 ---
 


### PR DESCRIPTION
Four genuine gaps not covered by 3.1.2/3.4.3/3.4.4/11.1.4 or any other existing requirement:

- 3.7.1 fine-tuning trigger authorization: distinct from 3.4.3 (env isolation) and 3.4.4 (data validation) - governs who may initiate a run and requires separation of duty with immutable pre-execution audit log.

- 3.7.2 reward model as signed artifact: distinct from 3.1.2 (deployment- admission signing) - reward models are consumed during training, not deployed, so deployment-time integrity checks do not cover them.

- 3.7.3 reward hacking detection: distinct from 11.9.5 (feedback pipeline integrity) and 11.1.4 (RLHF reproducibility) - requires a held-out human-preference probe set and divergence gate, not a feedback loop check.

- 3.7.4 multi-stage checkpoint signing: distinct from 3.1.2 (final artifact), 3.2.3 (change audit), 3.3.3 (full rollback) - targets intra-pipeline intermediate stage artifacts to bound blast radius of a stage compromise.