### PR TITLE
wiki: add C11.10 Adversarial Bias Exploitation Defense page

### DIFF
--- a/wiki/C09-Orchestration-and-Agents.md
+++ b/wiki/C09-Orchestration-and-Agents.md
@@ -1,7 +1,7 @@
 # C09: Autonomous Orchestration & Agentic Action Security
 
 > **Source:** [`1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md)
-> **Requirements:** 32 | **Sections:** 8
+> **Requirements:** 36 | **Sections:** 8
 
 ## Control Objective
 
@@ -22,7 +22,7 @@ Autonomous and multi-agent systems must execute only authorized, intended, and b
 | C9.5 | Secure Messaging and Protocol Hardening | 4 | [C09-05-Secure-Messaging](C09-05-Secure-Messaging.md) |
 | C9.6 | Authorization, Delegation, and Continuous Enforcement | 4 | [C09-06-Authorization-and-Delegation](C09-06-Authorization-and-Delegation.md) |
 | C9.7 | Intent Verification and Constraint Gates | 4 | [C09-07-Intent-Verification](C09-07-Intent-Verification.md) |
-| C9.8 | Multi-Agent Domain Isolation and Swarm Risk Controls | 2 | [C09-08-Multi-Agent-Isolation](C09-08-Multi-Agent-Isolation.md) |
+| C9.8 | Multi-Agent Domain Isolation and Swarm Risk Controls | 6 | [C09-08-Multi-Agent-Isolation](C09-08-Multi-Agent-Isolation.md) |
 
 ---
 

--- a/wiki/C11-10-Adversarial-Bias-Exploitation-Defense.md
+++ b/wiki/C11-10-Adversarial-Bias-Exploitation-Defense.md
@@ -1,0 +1,105 @@
+# C11.10: Adversarial Bias Exploitation Defense
+
+> **Chapter:** [C11 Adversarial Robustness & Attack Resistance](C11-Adversarial-Robustness)
+> **Requirements:** 3 | **IDs:** 11.10.1--11.10.3
+
+## Purpose
+
+Protect security-relevant classifiers against adversaries who systematically probe for exploitable bias patterns and weaponize discovered disparities as an evasion vector. When a classifier (abuse detection, fraud scoring, malware detection, content moderation) performs unevenly across input subgroups, an attacker who discovers the weakest subgroup gains a reliable evasion channel. This section ensures that subgroup-specific robustness gaps are measured, monitored, and hardened against adversarial exploitation.
+
+---
+
+## Requirements
+
+| # | Requirement | Level | Role | Threat Mitigated | Verification Approach | Gaps / Notes |
+|---|-------------|:-----:|:----:|-----------------|----------------------|--------------|
+| **11.10.1** | **Verify that** inference endpoints for security-relevant classifiers (e.g., abuse detection, fraud scoring) include monitoring that accounts for query patterns indicative of bias probing, such as systematic variation along a single input dimension (e.g., demographic, linguistic, stylistic) while other dimensions remain constant, and alert when such patterns are detected. | 3 | D/V | **Systematic bias discovery via structured querying** (MITRE ATLAS AML.T0006 Active Scanning). An adversary submits queries that systematically vary a single input dimension while holding others constant to map the classifier's decision boundary and identify exploitable subgroup disparities. Once a weak subgroup is discovered, all future evasion payloads exploit that gap. The Cylance bypass (AML.CS0003) is the canonical example: researchers reverse-engineered the model's bias toward a gaming executable's signatures and used it as a universal evasion vector with 100% success rate. | 1. Review query logging architecture -- confirm inference endpoints log sufficient metadata (input features/embeddings, timestamps, principal IDs, classification results) to reconstruct query patterns. 2. Check for bias-probing detection rules that flag when a principal submits queries with low variance across most dimensions but high variance along a single axis. 3. Test with synthetic probing campaigns (e.g., 50 queries varying only demographic terms in an abuse-detection classifier) and verify alerts are generated. 4. Verify integration with incident response playbooks. 5. Confirm rate limits (C11.4.2, C11.5.1) compound the cost of systematic probing. | **Tooling maturity: LOW.** No production-ready tool detects bias-probing query patterns. Must be built as custom anomaly detection on inference logging infrastructure (e.g., Splunk ML Toolkit, Elastic anomaly detection). Detection is inherently noisy -- legitimate users may submit structurally similar queries (A/B testing, research). Effective detection needs embedding-space analysis of query streams, not just string comparison. L3 is appropriate given bespoke engineering required. |
+| **11.10.2** | **Verify that** adversarial robustness evaluations for security-relevant classifiers are stratified by meaningful input subgroups (e.g., language register, content category), with per-subgroup false-negative rates under adversarial conditions measured and flagged when deviating from aggregate rates beyond a defined threshold. | 2 | D/V | **Undetected subgroup-specific robustness gaps becoming evasion vectors** (MITRE ATLAS AML.T0015 Evade ML Model). Standard adversarial evaluations report aggregate metrics that mask severe per-subgroup disparities. Xu et al. (ICML 2021) showed PGD adversarial training produces 67% robust accuracy on "automobile" but only 17% on "cat" -- a 50-point gap invisible in aggregates. Content moderation systems trained primarily on English show significantly weaker detection for equivalent harmful content in other languages. | 1. Review adversarial evaluation reports for stratification -- confirm robustness metrics are broken down by meaningful input subgroups (language, dialect, content category, demographic group). 2. Check per-subgroup false-negative rates under adversarial conditions are reported and compared against aggregate rates. 3. Verify a defined deviation threshold exists (e.g., "no subgroup's adversarial FNR may exceed 1.5x the aggregate rate"). 4. Review subgroup definition methodology for coverage of known risk dimensions. 5. Tools: IBM ART for adversarial attack generation per subgroup, Microsoft Fairlearn `MetricFrame` for per-group metric calculation, IBM AIF360 for fairness metrics. | **Tooling maturity: MEDIUM.** ART, Fairlearn, and AIF360 are individually mature but no tool provides integrated "subgroup-stratified adversarial evaluation" out of the box -- integration requires custom scripting. Subgroup definition is domain-specific and requires expertise. L2 is appropriate: underlying tools exist and methodology is well-established in research (multiple ICML/ICLR publications 2024-2025). Main barrier is organizational discipline, not technical impossibility. |
+| **11.10.3** | **Verify that** where bias-based evasion is identified as a material threat, adversarial hardening (e.g., adversarial training with per-subgroup loss constraints, ensemble diversity across training distributions) incorporates explicit subgroup robustness requirements, and that per-subgroup robustness metrics are verified not to regress across model releases. | 3 | D | **Persistent subgroup-specific evasion vectors surviving standard adversarial training** (MITRE ATLAS AML.T0015, AML.T0043 Craft Adversarial Data). Standard adversarial training optimizes for average-case robustness, which can worsen robustness disparities between subgroups. Without explicit subgroup constraints, the weakest subgroup provides a reliable evasion channel that persists across model updates. | 1. Review adversarial training configuration for per-subgroup loss constraints (worst-class robust loss, per-subgroup loss weighting, DRO-style constraints). 2. Verify documented subgroup robustness targets (e.g., "minimum 40% robust accuracy per subgroup under PGD-10"). 3. If ensemble methods are used, verify members are trained on different data distributions for improved coverage. 4. Verify non-regression testing -- per-subgroup robustness metrics tracked across releases with regressions triggering review. 5. Tools: FAAL framework (research code), ART + custom training loops, Fairlearn MetricFrame for regression testing. | **Tooling maturity: LOW.** Algorithms exist in research code (FAAL, FRL, WAT) but none are production-ready. Not directly applicable to LLMs -- applies to classifiers (CNNs, smaller transformers). Accuracy-robustness-fairness trilemma: improving worst-case subgroup robustness may reduce average robustness or clean accuracy (see ACM Computing Surveys 2024 survey). Ensemble diversity is more practically achievable than per-subgroup loss constraints. L3 is correct given tooling immaturity and the trilemma. |
+
+---
+
+## Implementation Guidance (2024--2026 Research)
+
+### The Bias-as-Evasion Attack Pattern
+
+The core threat model for this section is distinct from fairness or ethical bias concerns: it is specifically about adversaries who discover and weaponize performance disparities in security-relevant classifiers. The attack follows a reconnaissance-then-exploit pattern:
+
+1. **Probing phase** (detected by 11.10.1): The attacker submits structured queries to map the classifier's decision boundary across input subgroups, identifying where performance is weakest.
+2. **Exploitation phase** (prevented by 11.10.2/11.10.3): The attacker crafts all future evasion payloads to exploit the discovered weak subgroup, achieving higher evasion rates than generic adversarial attacks.
+
+**Canonical example -- Cylance AI Antivirus Bypass (2019, ATLAS AML.CS0003):** Skylight Cyber researchers discovered that Cylance Protect's ML malware detection model had a learned bias toward a gaming executable's string signatures. By appending those strings to malware samples, detection scores shifted from -852 (malicious) to +999 (benign). Success rate: 100% against top-10 malware, ~90% against 384 samples. The "bias" was an implicit whitelist discoverable through systematic probing.
+
+**Content moderation linguistic evasion (2024-2026):** Content moderation systems trained primarily on English show significantly weaker detection for equivalent harmful content in under-represented languages, dialects, or code-switched text. Meta's moderation systems have been specifically criticized for disproportionate under-enforcement in Global South languages. Attackers exploit this by expressing prohibited content in linguistic forms where the classifier is weakest.
+
+### Adversarial Training Creates Robustness Disparities
+
+A key finding from 2021-2025 research is that adversarial training itself can create or amplify subgroup robustness gaps:
+
+- **Xu et al., "To be Robust or to be Fair" (ICML 2021):** PGD adversarial training on CIFAR-10 produces 93% clean accuracy / 67% robust accuracy on "automobile" but only 65% / 17% on "cat" -- a 50-percentage-point robustness gap that does not appear in standard training.
+- **Sun et al., "Towards Fairness-Aware Adversarial Learning" (2024):** Proposed the FAAL framework using distributional robust optimization (DRO) to find worst-case class-weight distributions during adversarial training. Achieves 35.7% worst-class accuracy vs. prior FRL's 33.1%, with only 2 epochs of fine-tuning.
+- **"Fairness is essential for robustness" (Frontiers of Computer Science, 2025):** Showed that identifying and augmenting "hard examples" provides fine-grained information about robustness disparities and reduces inter-class robustness gaps.
+- **ICLR 2025 spectral-norm regularization:** Developed robust generalization bounds for worst-class robust error, enabling principled measurement and optimization of per-subgroup robustness.
+
+### The Accuracy-Robustness-Fairness Trilemma
+
+Organizations implementing 11.10.3 must navigate a documented three-way trade-off:
+
+- **"Triangular Trade-off between Robustness, Accuracy, and Fairness in DNNs" (ACM Computing Surveys, 2024):** The most comprehensive analysis showing that improving any one of accuracy, robustness, or fairness typically degrades at least one of the others. This trade-off is fundamental, not merely a tooling limitation.
+- **Practical implication:** Per-subgroup robustness constraints may reduce aggregate robust accuracy or clean accuracy. The trade-off must be documented and accepted by stakeholders. Ensemble diversity across training distributions is a more practical starting point than per-subgroup loss constraints.
+
+### Tools Landscape
+
+| Tool | Maintainer | Use Case | Maturity |
+|------|-----------|----------|----------|
+| **IBM Adversarial Robustness Toolbox (ART)** | LF AI & Data | Adversarial attack generation, defense evaluation across all major ML frameworks | **High** (v1.17+) |
+| **Microsoft Fairlearn** | Microsoft / Community | Per-subgroup metric calculation via `MetricFrame`, bias mitigation | **High** |
+| **IBM AI Fairness 360 (AIF360)** | LF AI & Data | 70+ fairness metrics, bias mitigation algorithms | **High** (v0.6+) |
+| **TextAttack** | QData Lab | NLP-specific adversarial attack framework for text-domain evaluation | **High** |
+| **FAAL** | Research (Sun et al.) | Min-max-max adversarial training for per-subgroup robustness | **Low** -- research code |
+| **FRL** | Research (Xu et al.) | Fair adversarial training framework | **Low** -- research code |
+| **WAT** | Research (Li & Liu) | Worst-class adversarial training via no-regret dynamics | **Low** -- research code |
+
+**Integration pattern for 11.10.2:** Use ART to generate adversarial examples per subgroup-filtered test set, then use Fairlearn `MetricFrame` to compute per-subgroup adversarial accuracy/FNR. No single tool provides this end-to-end.
+
+---
+
+## Notable Incidents
+
+| Date | Incident | Relevance |
+|------|----------|-----------|
+| 2019 | **Cylance AI Antivirus Universal Bypass** (ATLAS AML.CS0003) -- Skylight Cyber discovered learned bias toward gaming executable signatures, achieving 100% evasion against top-10 malware by appending those strings | Canonical bias-as-evasion attack; discovered through systematic probing |
+| 2024 | **Proofpoint EchoSpoofing** -- 14M spoofed emails/day exploiting trust configurations that created implicit bias in email security pipeline | Analogous pattern: exploiting a trust dimension the security system treated as a strong signal |
+| 2024-2026 | **Content moderation linguistic evasion** -- Meta and other platforms documented under-enforcement in Global South languages; attackers exploit this for prohibited content | Direct bias-as-evasion in content moderation classifiers |
+| 2025 | **Android malware GAN evasion** -- Black-box GAN attacks achieving 95%+ evasion against malware detection while preserving malicious functionality | Automated adversarial generation targeting model weaknesses |
+
+---
+
+## Related Standards & References
+
+- [MITRE ATLAS: Active Scanning (AML.T0006)](https://atlas.mitre.org/techniques/AML.T0006) -- Probing model behavior; bias probing is a specialization
+- [MITRE ATLAS: Evade ML Model (AML.T0015)](https://atlas.mitre.org/techniques/AML.T0015) -- Primary evasion technique; subgroup disparity is an enabler
+- [MITRE ATLAS: Craft Adversarial Data (AML.T0043)](https://atlas.mitre.org/techniques/AML.T0043) -- Creating inputs that exploit discovered weaknesses
+- [MITRE ATLAS Case Study: Bypass Cylance's AI Malware Detection (AML.CS0003)](https://atlas.mitre.org/studies/AML.CS0003) -- Canonical bias-based evasion
+- [NIST AI 100-2 E2025 -- Adversarial Machine Learning Taxonomy](https://csrc.nist.gov/pubs/ai/100/2/e2023/final) -- Updated taxonomy covering evasion attack variation across input distributions
+- [IBM Adversarial Robustness Toolbox (ART)](https://github.com/Trusted-AI/adversarial-robustness-toolbox) -- Attack generation and defense evaluation
+- [Microsoft Fairlearn](https://fairlearn.org/) -- Per-subgroup metric calculation
+- [IBM AI Fairness 360](https://aif360.res.ibm.com/) -- Fairness metrics and bias mitigation
+- Xu et al., "To be Robust or to be Fair: Towards Fairness in Adversarial Training" (ICML 2021) -- Foundational paper on adversarial training robustness disparities
+- Sun et al., "Towards Fairness-Aware Adversarial Learning" (2024) -- FAAL framework for subgroup-robust adversarial training
+- AISVS C2 (User Input Validation) -- Input-level defenses complementary to classifier-level robustness
+- AISVS C7 (Model Behavior) -- Output filtering complementary to bias-aware hardening
+- AISVS C11.2 (Adversarial-Example Hardening) -- General adversarial hardening; C11.10 adds subgroup-specific requirements
+
+---
+
+## Open Research Questions
+
+- Can bias-probing detection be automated reliably without unacceptable false positive rates from legitimate research or A/B testing activity?
+- What is the right granularity for subgroup definition in adversarial robustness evaluation -- too coarse misses exploitable gaps, too fine creates evaluation burden?
+- How does the accuracy-robustness-fairness trilemma scale with model size and dataset diversity -- do larger models naturally reduce subgroup disparities?
+- Can subgroup-robust adversarial training be adapted for LLMs, or does it remain limited to traditional classifiers?
+- What metrics best capture "meaningful behavioral change" across subgroups for security classifiers -- is adversarial FNR sufficient, or are distribution-aware metrics needed?
+- How should organizations prioritize which subgroups to evaluate when the input space is high-dimensional and subgroup definitions are not obvious?
+
+---

--- a/wiki/C11-Adversarial-Robustness.md
+++ b/wiki/C11-Adversarial-Robustness.md
@@ -1,7 +1,7 @@
 # C11: Adversarial Robustness & Attack Resistance
 
 > **Source:** [`1.0/en/0x10-C11-Adversarial-Robustness.md`](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C11-Adversarial-Robustness.md)
-> **Requirements:** 38 | **Sections:** 9
+> **Requirements:** 41 | **Sections:** 10
 
 ## Control Objective
 
@@ -24,6 +24,7 @@ Ensure that AI systems remain reliable, privacy-preserving, and abuse-resistant 
 | C11.7 | Security Policy Adaptation | 4 | [C11-07-Security-Policy-Adaptation](C11-07-Security-Policy-Adaptation) |
 | C11.8 | Agent Security Self-Assessment | 3 | [C11-08-Agent-Security-Self-Assessment](C11-08-Agent-Security-Self-Assessment) |
 | C11.9 | Self-Modification & Autonomous Update Security | 5 | [C11-09-Self-Modification-Autonomous-Update-Security](C11-09-Self-Modification-Autonomous-Update-Security) |
+| C11.10 | Adversarial Bias Exploitation Defense | 3 | [C11-10-Adversarial-Bias-Exploitation-Defense](C11-10-Adversarial-Bias-Exploitation-Defense) |
 
 ---
 
@@ -38,6 +39,7 @@ Known attacks, real-world incidents, and threat vectors relevant to this chapter
 - **Inference-time poisoning** via compromised RAG corpora, tool outputs, or injected context
 - **Alignment bypass** through jailbreaks, prompt manipulation, and multi-turn escalation
 - **Self-modification abuse** -- adversarially induced changes to agent behavior or configuration
+- **Adversarial bias exploitation** -- systematic probing for subgroup-specific robustness gaps in security classifiers, then weaponizing discovered disparities as evasion vectors
 
 ---
 
@@ -62,5 +64,7 @@ Known attacks, real-world incidents, and threat vectors relevant to this chapter
 | C9 Orchestration and Agents | Agent safety, tool use | C9 covers orchestration security; C11.8-C11.9 address agent self-assessment and self-modification |
 | C12 Privacy | Differential privacy, data leakage | C12 covers privacy holistically; C11.3-C11.4 focus on inference/inversion attacks specifically |
 | C13 Monitoring and Logging | Detection, alerting | C13 covers monitoring infrastructure; C11.5-C11.7 cover adversarial-specific detection and policy adaptation |
+| C2 User Input Validation | Bias probing as input pattern | C2 covers input validation; C11.10 monitors for structured probing patterns that indicate bias exploitation reconnaissance |
+| C7 Model Behavior | Output filtering and subgroup fairness | C7 covers output safety; C11.10 adds subgroup-stratified robustness evaluation for security classifiers |
 
 ---


### PR DESCRIPTION
## Summary
- Create new wiki research page for C11.10 (Adversarial Bias Exploitation Defense) — 3 requirements covering bias probing detection, subgroup-stratified adversarial evaluation, and subgroup-robust hardening
- Update C11 index page: 41 requirements, 10 sections, new C11.10 row, threat landscape entry, cross-chapter links to C2/C7
- Update C09 index page: 36 requirements (C9.8 grew from 2 to 6)

## Test plan
- [x] `grep -cE` on source files confirms 447 total requirements (C09=36, C11=41)
- [x] `ls wiki/C11-*.md | wc -l` returns 11 (index + 10 section pages)
- [x] C11 index links all 10 sections
- [x] New C11-10 page follows existing section page structure with full research content

🤖 Generated with [Claude Code](https://claude.com/claude-code)