### PR TITLE
C5.4: dedup 5.4.1 - remove PII scanning, focus on authorization-layer enforcement

### DIFF
--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -54,7 +54,7 @@ Deploy post-processing controls to prevent unauthorized data exposure in AI-gene
 
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **5.4.1** | **Verify that** post-inference filtering mechanisms scan and redact unauthorized PII, classified information, and proprietary data before delivering content to requestors. | 1 | D/V |
+| **5.4.1** | **Verify that** post-inference filtering mechanisms prevent responses from including classified information or proprietary data that the requestor is not authorized to receive. | 1 | D/V |
 | **5.4.2** | **Verify that** citations, references, and source attributions in model outputs are validated against caller entitlements and removed if unauthorized access is detected. | 2 | D/V |
 | **5.4.3** | **Verify that** output format restrictions (sanitized documents, metadata-stripped images, approved file types) are enforced based on user permission levels and data classifications. | 2 | D |
 


### PR DESCRIPTION
5.4.1 and 7.3.2 were functionally identical on PII redaction:
- 5.4.1: scans and redacts PII, classified, proprietary data
- 7.3.2: scans every response for PII and redacts before display

Fix: Remove PII from 5.4.1 (covered by 7.3.2 in its natural home - C7 Output Safety). Refocus 5.4.1 on the access-control-layer concern unique to C5: preventing classified/proprietary data from reaching requestors who are not authorized to receive it. This aligns with C5's scope (access control) vs C7's scope (content-based safety filtering).