### PR TITLE
C9.4: dedup 9.4.3 - remove generic tamper-evidence clause, keep agent-specific content

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -55,7 +55,7 @@ Make every action attributable and every mutation detectable.
 | :--: | --- | :---: | :--: |
 | **9.4.1** | **Verify that** each agent instance (and orchestrator/runtime) has a unique cryptographic identity and authenticates as a first-class principal to downstream systems (no reuse of end-user credentials). | 1 | D/V |
 | **9.4.2** | **Verify that** agent-initiated actions are cryptographically bound to the execution chain (chain ID) and are signed and timestamped for non-repudiation and traceability. | 2 | D/V |
-| **9.4.3** | **Verify that** audit logs are tamper-evident (append-only/WORM/immutable log store) and include sufficient context to reconstruct who/what acted, initiating user identifier, delegation scope, authorization decision (policy/version), tool parameters, approvals (where applicable), and outcomes. | 2 | D/V |
+| **9.4.3** | **Verify that** agent action audit logs include sufficient context to reconstruct the full execution chain, including initiating user identifier, delegation scope, authorization decision with policy version, tool parameters, approval records where applicable, and outcomes, and are stored in an append-only or write-once log store. | 2 | D/V |
 | **9.4.4** | **Verify that** agent identity credentials (keys/certs/tokens) rotate on a defined schedule and on compromise indicators, with rapid revocation and quarantine on suspected compromise or spoofing attempts. | 3 | D/V |
 
 ---


### PR DESCRIPTION
9.4.3 and 14.3.2 were duplicating the tamper-evidence principle:
- 9.4.3: "audit logs are tamper-evident (append-only/WORM/immutable log store) AND ..."
- 14.3.2: "audit logs cannot be tampered with and include integrity verification mechanisms"

Fix: Remove the generic tamper-evidence opening from 9.4.3 (covered by 14.3.2 as the general principle across all AI system audit logs). Retain what is unique to 9.4.3: the rich agent-action-specific content requirements (delegation scope, authorization decision with policy version, tool parameters, approval records, outcomes) plus the specific storage requirement (append-only/write-once) which is more prescriptive than 14.3.2's general "integrity verification mechanisms".