### PR TITLE
wiki: flesh out C02 User Input Validation index

### DIFF
--- a/wiki/C02-User-Input-Validation.md
+++ b/wiki/C02-User-Input-Validation.md
@@ -30,21 +30,78 @@ Robust validation of user input is a first-line defense against some of the most
 
 Known attacks, real-world incidents, and threat vectors relevant to this chapter:
 
-- Direct prompt injection (overriding system instructions via user input)
-- Indirect prompt injection (injected instructions in retrieved content)
-- Unicode/encoding-based evasion (invisible characters, homoglyphs, RTL overrides)
-- Multi-modal injection (instructions hidden in images, audio, or documents)
-- Crescendo attacks (gradually escalating benign prompts toward harmful outputs)
+- **Direct prompt injection** — overriding system instructions via user input. Remains the #1 vulnerability in production LLM deployments, appearing in over 73% of assessed systems (OWASP LLM01:2025). Multi-turn jailbreak techniques now achieve 90%+ success rates against frontier models in under 60 seconds.
+- **Indirect prompt injection** — injected instructions in retrieved content (RAG results, web pages, emails, tool outputs). Research demonstrates that just five carefully crafted documents can manipulate RAG-augmented AI responses 90% of the time.
+- **Second-order prompt injection** — exploiting privilege hierarchies in multi-agent systems, where a low-privilege agent is tricked into escalating requests to a higher-privilege agent (demonstrated against ServiceNow Now Assist in 2025).
+- **Unicode and encoding smuggling** — invisible characters (zero-width joiners, Unicode tags), homoglyphs, mixed-script payloads, Base64 encoding, mathematical symbol substitution, and "glitch tokens" that bypass production guardrails from major vendors while remaining interpretable by LLMs. ASCII smuggling attacks tested across multiple LLMs in September 2025 showed broad susceptibility.
+- **Multi-modal injection** — instructions hidden in images (adversarial perturbations invisible to humans), audio (AudioJailbreak achieving 87-88% success even over speakers with room reverb, ACM CCS 2025), and documents. Cross-modal chaining (steganographic embedding + semantic manipulation) compounds attack effectiveness (Chain of Attack, CVPR 2025).
+- **Physical-environment injection** — CHAI (Command Hijacking against embodied AI) demonstrated physical-world prompt injection against embodied AI agents (January 2026, UC Santa Cruz).
+- **Crescendo and multi-turn attacks** — gradually escalating benign prompts toward harmful outputs, exploiting context window accumulation to shift model behavior over multiple turns.
+- **Token smuggling** — bypassing input filters through non-standard encodings, emoji-based code payloads, and character obfuscation techniques that evade tokenizer-level safety checks.
+
+---
+
+## Notable Incidents
+
+| Date | Incident | Relevance |
+|------|----------|-----------|
+| 2025 | GitHub Copilot RCE (CVE-2025-53773, CVSS 9.6) | Prompt injection leading to remote code execution in a widely deployed AI coding assistant |
+| 2025 | ServiceNow Now Assist second-order injection | Attackers exploited agent privilege hierarchy to exfiltrate case files via a low-privilege agent tricking a high-privilege agent |
+| 2025 | ChatGPT Windows license key exposure | Prompt injection used to extract sensitive data from model context |
+| Dec 2025 | Palo Alto Unit 42: indirect injection in ad review system | Real-world malicious indirect prompt injection designed to bypass an AI-based product advertisement review pipeline |
+| Sep 2025 | ASCII smuggling across multiple LLMs | Researchers demonstrated Unicode tag-based data exfiltration across multiple commercial LLMs; findings reported to Google |
+| Jan 2026 | CHAI physical-environment prompt injection | UC Santa Cruz researchers demonstrated physical-world prompt injection against embodied AI agents |
+
+---
+
+## Implementation Maturity Overview
+
+A chapter-level view of tooling maturity and adoption status for C02 controls:
+
+| Section | Area | Maturity | Notes |
+|---------|------|:--------:|-------|
+| C2.1 | Prompt Injection Defense | Medium-High | Commercial solutions (Lakera Guard, AWS Bedrock Guardrails) offer 98%+ detection at sub-50ms latency, but no tool guarantees complete prevention. Instruction hierarchy enforcement is provider-dependent. |
+| C2.2 | Adversarial Example Resistance | Medium | Unicode normalization is straightforward; statistical anomaly detection and adversarial training are research-grade. Zero-width character and homoglyph attacks still bypass production guardrails from major vendors. |
+| C2.3 | Prompt Character Set | High | Allow-list character filtering is well-understood and easy to implement. Logging integration varies. |
+| C2.4 | Schema & Type Validation | High | JSON Schema and Protocol Buffer validation are mature. MCP-specific schema enforcement is emerging but supported by the MCP specification. |
+| C2.5 | Content & Policy Screening | Medium-High | Content classifiers (OpenAI Moderation, Perspective API, Lakera Guard) are production-ready. Attribute-based per-user policy resolution is less mature. |
+| C2.6 | Rate Limiting & Abuse | High | Standard API gateway capabilities. Per-agent and per-task token budgets are newer but increasingly supported by orchestration frameworks. |
+| C2.7 | Multi-Modal Validation | Low-Medium | Image and audio adversarial detection remains largely research-grade. Steganography scanning tools exist but are not widely integrated into AI pipelines. Cross-modal correlation is nascent. |
+| C2.8 | Adaptive Threat Detection | Low-Medium | Real-time adaptive models are emerging. Continuous detection metric monitoring is operationally complex. Most organizations rely on static rule sets. |
+
+> **Overall:** As of March 2026, only ~20% of enterprises have mature AI governance models (Deloitte 2026 AI Report). Input validation tooling is strongest for text-based prompt injection and weakest for multi-modal and adaptive scenarios.
+
+---
+
+## Defensive Tooling Landscape
+
+Key tools and frameworks relevant across C02 sections:
+
+| Tool / Framework | Type | Coverage | Notes |
+|------------------|------|----------|-------|
+| [Lakera Guard](https://www.lakera.ai/lakera-guard) | Commercial API | Prompt injection, jailbreak, data leakage detection | 98%+ detection, sub-50ms latency, 100+ languages. Acquired by Check Point (Sep 2025) and integrated into Infinity Platform. Learns from 100K+ daily adversarial samples via Gandalf. |
+| [Rebuff](https://github.com/protectai/rebuff) | Open-source | Multi-layered prompt injection detection | Combines heuristic filtering, LLM-based analysis, vector DB of previous attacks, and canary tokens. Good for self-hosted deployments. |
+| [Guardrails AI](https://github.com/guardrails-ai/guardrails) | Open-source framework | Input/output validation, schema enforcement | Python framework with pluggable validators for PII, toxicity, schema compliance. Integrates with major LLM providers. |
+| [Amazon Bedrock Guardrails](https://docs.aws.amazon.com/prescriptive-guidance/latest/agentic-ai-security/best-practices-input-validation.html) | Cloud service | Content filtering, topic denial, PII redaction | Native AWS integration for Bedrock-hosted models. Supports custom word filters and managed policies. |
+| [Galileo Protect](https://galileo.ai/) | Commercial | Runtime guardrails for AI agents | Intercepts unsafe outputs in under 200ms. Enforces prompt injection blocking, PII redaction, hallucination prevention. |
+| [NVIDIA NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | Open-source | Programmable guardrails for LLM applications | Colang-based rail definitions for topic control, jailbreak prevention, and output safety. |
 
 ---
 
 ## Related Standards & Cross-References
 
-- [OWASP LLM01:2025 Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)
-- [LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html)
-- [MITRE ATLAS: Adversarial Input Detection](https://atlas.mitre.org/mitigations/AML.M00150)
-- [Mitigate jailbreaks and prompt injections (Anthropic)](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks)
-- [NIST AI 100-2e2025: Adversarial Machine Learning](https://csrc.nist.gov/pubs/ai/100/2/e2025/final)
+- [OWASP LLM01:2025 Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/) — Top risk for LLM applications; directly maps to C2.1 and C2.5
+- [LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html) — Practical defense patterns for developers
+- [OWASP AI Exchange (2026)](https://owaspai.org/) — Comprehensive AI security guidance; input validation covered across multiple threat categories
+- [OWASP AI Testing Guide v1 (November 2025)](https://owasp.org/www-project-ai-testing-guide/) — First comprehensive standard for AI trustworthiness testing, including input validation test cases
+- [MITRE ATLAS: Adversarial Input Detection (AML.M00150)](https://atlas.mitre.org/mitigations/AML.M00150) — Mitigation guidance for adversarial inputs
+- [MITRE ATLAS: Prompt Injection (AML.T0051)](https://atlas.mitre.org/techniques/AML.T0051) — Technique definition for prompt injection attacks
+- [MITRE ATLAS October 2025 Update](https://atlas.mitre.org/) — 14 new attack techniques and sub-techniques for AI agents and GenAI systems (collaboration with Zenity Labs)
+- [Mitigate jailbreaks and prompt injections (Anthropic)](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks) — Provider-specific guidance on instruction hierarchy and prompt hardening
+- [NIST AI 100-2e2025: Adversarial Machine Learning](https://csrc.nist.gov/pubs/ai/100/2/e2025/final) — Taxonomy of adversarial ML attacks including evasion, poisoning, and prompt-based threats
+- [CSA: How to Build AI Prompt Guardrails (December 2025)](https://cloudsecurityalliance.org/blog/2025/12/10/how-to-build-ai-prompt-guardrails-an-in-depth-guide-for-securing-enterprise-genai) — Enterprise-focused guide for DLP-first guardrail strategy
+- [AWS Prescriptive Guidance: Input Validation for Agentic AI](https://docs.aws.amazon.com/prescriptive-guidance/latest/agentic-ai-security/best-practices-input-validation.html) — Best practices for validating inputs in agentic AI systems on AWS
+- [Defending LLM Applications Against Unicode Character Smuggling (AWS, 2025)](https://aws.amazon.com/blogs/security/defending-llm-applications-against-unicode-character-smuggling/) — Practical defense patterns for encoding-based attacks
 
 ### AISVS Cross-Chapter Links
 
@@ -54,12 +111,27 @@ Known attacks, real-world incidents, and threat vectors relevant to this chapter
 | C9 Orchestration & Agents | Agent input surfaces, tool call validation | Agent chains amplify prompt injection risk across hops |
 | C10 MCP Security | MCP tool argument validation | MCP surfaces are explicit input vectors covered by C2.4 |
 | C11 Adversarial Robustness | Adversarial perturbation defense | C2.2 focuses on input-layer detection; C11 covers model-level robustness |
+| C12 Privacy | PII detection in inputs, data leakage prevention | C2 input screening should catch PII before it reaches the model; C12 governs retention and consent |
 | C13 Monitoring & Logging | Logging requirements for input validation events | C2 specifies what to log; C13 specifies how to store and alert |
+| C14 Human Oversight | HITL approval for flagged inputs | C2.7.5 and C2.8.2 require HITL escalation; C14 defines oversight governance |
 
 ---
+
+## Key Research & Further Reading
+
+- Syed et al., "Cross-Agent Multimodal Provenance-Aware Defense Framework," ICCA 2025 — combines input sanitization with output validation across agentic pipelines, establishing a provenance ledger that tracks modality, source, and trust level of every prompt.
+- Chen et al., "AudioJailbreak," ACM CCS 2025 — demonstrated 87-88% jailbreak success against 10 end-to-end audio-language models, including over-the-air attacks.
+- Xie et al., "Chain of Attack," CVPR 2025 — showed compounding effectiveness when steganographic embedding is chained with semantic manipulation across modalities.
+- "Image-based Prompt Injection: Hijacking Multimodal LLMs through Visually Embedded Adversarial Instructions," arXiv:2603.03637 (March 2026) — latest work on imperceptible adversarial perturbations in images that hijack vision-language models.
+- Palo Alto Unit 42, "Fooling AI Agents: Web-Based Indirect Prompt Injection Observed in the Wild" (December 2025) — first documented in-the-wild indirect prompt injection against a production AI ad review system.
 
 ## Community Notes
 
 _Space for contributor observations, discussion, and context that doesn't fit elsewhere._
+
+**Open questions worth tracking:**
+- No input validation tool guarantees complete prompt injection prevention. Defense-in-depth (combining multiple layers) remains the only viable strategy. How should auditors assess "sufficient" defense depth?
+- Multi-modal adversarial detection tooling is still largely research-grade. Organizations deploying vision or audio models should treat C2.7 requirements as aspirational L2/L3 targets until tooling matures.
+- The October 2025 MITRE ATLAS update added 14 agentic-specific techniques — these may drive future requirement additions to C2.1 (indirect injection via agent chains) and C2.4 (MCP argument validation).
 
 ---


### PR DESCRIPTION
## Summary
- Expanded threat landscape from 5 bullet points to 8 detailed entries covering second-order injection, unicode/encoding smuggling, multi-modal attacks, physical-environment injection, and token smuggling
- Added notable incidents table with 6 entries (CVE-2025-53773, ServiceNow second-order injection, CHAI physical-environment attack, etc.)
- Added implementation maturity overview across all 8 C02 sections
- Added defensive tooling landscape table (Lakera Guard, Rebuff, Guardrails AI, Bedrock, Galileo, NeMo)
- Expanded standards references from 5 to 12 (OWASP AI Exchange, AI Testing Guide, MITRE ATLAS Oct 2025 update, CSA guardrails guide, AWS prescriptive guidance)
- Added key research and further reading section with 5 academic references
- Enriched cross-chapter links (added C12 Privacy, C14 Human Oversight)

Closes #248

## Checklist
- [x] Requirement IDs match current source
- [x] No infrastructure references in content
- [x] Spot-check URLs resolve