### PR TITLE
wiki: sharpen C10 MCP Security with MCPTox, OAuth bypasses, OWASP MCP Top 10

### DIFF
--- a/wiki/C10-MCP-Security.md
+++ b/wiki/C10-MCP-Security.md
@@ -28,21 +28,27 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 
 Known attacks, real-world incidents, and threat vectors relevant to this chapter:
 
-- **Tool poisoning** — malicious MCP servers providing dangerous tool definitions that embed hidden instructions in descriptions, manipulating the LLM into performing unintended actions (data exfiltration, credential theft)
-- **Rug-pull attacks** — MCP servers changing tool behavior after initial trust establishment; tool definitions shift between `tools/list` calls to exploit cached trust
-- **Cross-tenant data exposure** through shared MCP server instances that fail to enforce tenant isolation
-- **Man-in-the-middle attacks** on MCP transport, particularly stdio-based local servers and unencrypted SSE channels
-- **Context confusion** — tool descriptions manipulating the LLM's behavior via indirect prompt injection embedded in tool metadata
-- **DNS rebinding** — exploiting browser-like HTTP transport to redirect MCP requests to internal services
-- **Token relay attacks** — MCP servers forwarding user OAuth tokens to downstream APIs, violating least-privilege
+- **Tool poisoning at scale** — MCPTox benchmark (August 2025) tested 20 LLM agents across 45+ real-world MCP servers with 353 tools. o1-mini achieved a 72.8% attack success rate; Claude 3.7 Sonnet had the highest refusal rate but still under 3%. More capable models are often *more* susceptible because attacks exploit superior instruction-following. Between Jan-Feb 2026, 30+ CVEs were filed targeting MCP infrastructure — 43% were exec/shell injection.
+- **Rug-pull attacks** — MCP servers change tool definitions after initial trust establishment. Users are never re-prompted for consent. Invariant Labs demonstrated SSH key exfiltration via Cursor IDE where the confirmation dialog hid the malicious payload entirely.
+- **DNS rebinding** — CVE-2025-66414 (CVSS 8.1) affected MCP TypeScript SDK <1.24.0 with no DNS rebinding protection by default. Docker MCP Gateway and Microsoft Playwright MCP Server were also vulnerable. Remote attackers invoke any tool on localhost MCP servers from a malicious webpage.
+- **OAuth consent bypass and token relay** — Obsidian Security (January 2026) found three attack vectors: shared client ID enables consent caching bypass, URL capture bypasses MCP-layer consent entirely, cookie injection forces state validation under attacker control. Square's MCP server exposed merchant data, transactions, and banking details. Token passthrough (now explicitly forbidden in spec) creates confused deputy vulnerabilities.
+- **Cross-tool contamination** — Microsoft Developer Blog (April 2025) documented how compromised MCP servers influence legitimate tools through shared LLM context. Tool shadowing via crafted descriptions intercepts calls intended for legitimate servers.
+- **MCP sampling exploitation** — Unit 42 (December 2025) demonstrated resource theft (hidden billing), conversation hijacking (persistent session compromise), and covert tool invocation through MCP's sampling capability.
+- **Copilot RCE via MCP** — CVE-2025-53773 (CVSS 7.8) — prompt injection in source files manipulates GitHub Copilot into enabling "YOLO mode" (auto-approve all tools), achieving full RCE including MCP server injection. Wormable via infected repos.
+- **Shadow MCP servers** — 41% of servers in the official MCP registry have zero authentication as of February 2026 (518 servers scanned). OWASP MCP Top 10 lists Shadow MCP Servers (MCP09) as a top risk.
 
 ### Notable Incidents & Research
 
 | Date | Incident / Paper | Relevance | Link |
 |------|------------------|-----------|------|
-| 2024-12 | Invariant Labs: MCP tool poisoning disclosure | Demonstrated tool description manipulation leading to data exfiltration via MCP | [invariantlabs.ai](https://invariantlabs.ai/blog/mcp-security-notification-tool-poisoning-attacks) |
-| 2025-03 | MCP Specification: Authorization (OAuth 2.1) | Official MCP auth spec defining OAuth 2.1 flow for MCP servers | [spec.modelcontextprotocol.io](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) |
-| 2025-03 | MCP Specification: Streamable HTTP Transport | Replaced legacy SSE transport with streamable HTTP | [spec.modelcontextprotocol.io](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/transports/) |
+| Aug 2025 | MCPTox — first benchmark for MCP tool poisoning (45+ servers, 353 tools) | o1-mini 72.8% attack success; existing safety alignment largely ineffective against tool poisoning | [arXiv](https://arxiv.org/abs/2508.14925) |
+| Jan 2026 | Obsidian Security — MCP OAuth consent bypass (Square case) | Three attack vectors exposing merchant data via shared client IDs, URL capture, and cookie injection | [Obsidian Security](https://www.obsidiansecurity.com/blog/when-mcp-meets-oauth-common-pitfalls-leading-to-one-click-account-takeover) |
+| Dec 2025 | CVE-2025-66414 — MCP TypeScript SDK DNS rebinding (CVSS 8.1) | No DNS rebinding protection by default; remote tool invocation from malicious websites | [GitLab Advisory](https://advisories.gitlab.com/pkg/npm/@modelcontextprotocol/sdk/CVE-2025-66414/) |
+| Jun 2025 | CVE-2025-53773 — GitHub Copilot RCE via prompt injection (CVSS 7.8) | Wormable attack enabling MCP server injection and full RCE via "YOLO mode" | [Embrace The Red](https://embracethered.com/blog/posts/2025/github-copilot-remote-code-execution-via-prompt-injection/) |
+| Dec 2025 | Unit 42 — MCP sampling attack vectors | Resource theft, conversation hijacking, covert tool invocation via sampling | [Unit 42](https://unit42.paloaltonetworks.com/model-context-protocol-attack-vectors/) |
+| Apr 2025 | Invariant Labs — MCP tool poisoning + rug-pull disclosure | SSH key exfiltration via Cursor IDE; tool definitions change post-approval | [Invariant Labs](https://invariantlabs.ai/blog/mcp-security-notification-tool-poisoning-attacks) |
+| Apr 2025 | Microsoft — cross-tool contamination in MCP | Compromised servers influence legitimate tools through shared LLM context | [Microsoft Dev Blog](https://developer.microsoft.com/blog/protecting-against-indirect-injection-attacks-mcp) |
+| Dec 2025 | Agentic AI Foundation — MCP donated to Linux Foundation | Anthropic, OpenAI, Block, Google, Microsoft, AWS establish neutral governance for MCP | [Linux Foundation](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation) |
 
 ---
 
@@ -50,52 +56,59 @@ Known attacks, real-world incidents, and threat vectors relevant to this chapter
 
 Current tools, frameworks, and libraries that help implement these controls:
 
-- **MCP SDKs:** Official MCP TypeScript and Python SDKs with built-in JSON-RPC validation and transport handling
-- **Transport security:** TLS 1.3 for remote MCP (streamable HTTP), Unix domain sockets for local isolation
-- **Discovery:** MCP server registries (emerging); tool schema versioning support in SDK
-- **Auth:** OAuth 2.1 for MCP (per spec), dynamic client registration, PKCE support in official SDKs
-- **Validation:** JSON Schema validation for tool parameters, `zod` (TS) / `pydantic` (Python) for runtime enforcement
+- **MCP SDKs:** [TypeScript SDK v1.27.1](https://github.com/modelcontextprotocol/typescript-sdk) (Zod v4 for schema validation, host header validation middleware, OAuth 2.1 auth helpers, 161 contributors), [Python SDK](https://github.com/modelcontextprotocol/python-sdk) (Pydantic-based validation, `mcp.server.auth` for OAuth 2.1 RS, supports stdio/SSE/Streamable HTTP). V2 pre-alpha in development for both.
+- **MCP security gateways:** [Lasso MCP Gateway](https://github.com/lasso-security/mcp-gateway/) (open-source, April 2025 — prompt injection blocking, data leakage prevention via Presidio, server reputation vetting, tool filtering), [Enkrypt AI Secure MCP Gateway](https://www.enkryptai.com/mcp-scan) (commercial, automated static analysis)
+- **MCP security scanners:** [mcpscan.ai](https://mcpscan.ai/) (detects command injection in 23% of scanned servers, tool poisoning, rug pulls, confused deputy), [Snyk Agent Scan](https://github.com/snyk/agent-scan) (v0.4.9, auto-discovers MCP configs across Claude/Cursor/Windsurf/VS Code, 15+ security risks), [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) (open-source), [Proximity](https://github.com/fr0gger/nova-proximity) (NOVA rule engine for first-pass assessment)
+- **MCP Inspector:** [Official tool](https://github.com/modelcontextprotocol/inspector) (`npx @modelcontextprotocol/inspector`) — browser-based debugging revealing all tools/resources/prompts a server exposes. `--cli` flag for CI integration with exit codes.
+- **Auth:** MCP Authorization Specification evolved through [March](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization/), [June](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization/), and [November 2025](https://modelcontextprotocol.io/specification/2025-11-25) versions. OAuth 2.1 + PKCE (S256) mandatory, RFC 8707 Resource Indicators required, step-up authorization, token passthrough explicitly forbidden.
+- **Registries:** Official MCP registry (518 servers, 41% with zero auth). [Kong MCP Registry](https://konghq.com/) (enterprise, AI Alliance compliant). Gap: no standardized allowlisting mechanism in the protocol itself.
+- **Validation:** Zod v4 (TS) / Pydantic (Python) for strict tool argument validation. JSON-RPC 2.0 with discriminated unions for automatic routing. [OWASP MCP Cheat Sheet](https://genai.owasp.org/resource/cheatsheet-a-practical-guide-for-securely-using-third-party-mcp-servers-1-0/) provides implementation guidance.
 
 ### Implementation Maturity
 
 | Control Area | Tooling Maturity | Notes |
 |--------------|:---:|-------|
-| C10.1 Component Integrity & Supply Chain Hygiene | Low | No standardized signing for MCP packages; relies on platform package managers |
-| C10.2 Authentication & Authorization | Medium | OAuth 2.1 spec published; SDK support emerging but not universal |
-| C10.3 Secure Transport & Network Boundary Protection | Medium | Streamable HTTP well-defined; TLS enforcement depends on deployment |
-| C10.4 Schema, Message, and Input Validation | Medium | JSON Schema validation available in SDKs; schema signing not standardized |
-| C10.5 Outbound Access & Agent Execution Safety | Low | No standard framework for egress control or execution limits in MCP |
-| C10.6 Transport Restrictions & High-Risk Boundary Controls | Low | Stdio isolation is ad-hoc; no standard boundary enforcement tooling |
+| C10.1 Component Integrity & Supply Chain | Emerging | No standardized signing for MCP packages. Snyk Agent Scan and Cisco MCP Scanner can detect supply chain risks. 41% of registry servers have zero auth. OWASP MCP04 (Supply Chain Attacks) is a top-10 risk. |
+| C10.2 Authentication & Authorization | Maturing | OAuth 2.1 spec evolved through 3 versions (Mar/Jun/Nov 2025). Both SDKs support auth. But Square OAuth bypass shows real-world implementation gaps. Step-up authorization and CIMD are new. |
+| C10.3 Secure Transport & Network Protection | Maturing | Streamable HTTP well-defined; TLS mandatory for auth endpoints. CVE-2025-66414 DNS rebinding (CVSS 8.1) showed default-insecure localhost. Fixed in SDK v1.24.0+. Docker and Playwright servers also affected. |
+| C10.4 Schema, Message, and Input Validation | Maturing | Zod v4 (TS) and Pydantic (Python) provide strong validation. MCPTox showed 72.8% tool poisoning success despite validation — the attack surface is in *descriptions*, not *schemas*. Tool definition change detection (rug-pull) remains an open problem. |
+| C10.5 Outbound Access & Agent Execution Safety | Emerging | Lasso MCP Gateway provides proxy-level filtering. MCP sampling attacks (Unit 42) show egress and execution risks. No standard framework for per-tool execution limits in MCP spec. |
+| C10.6 Transport Restrictions & Boundary Controls | Emerging | Stdio isolation is ad-hoc. Host header validation middleware added to SDK. DNS rebinding protections now available but require explicit opt-in. No standard boundary enforcement tooling beyond SDK middleware. |
 
 ---
 
 ## Open Research Questions
 
-- [ ] How should MCP server trust be established and maintained over time — is a registry-of-record model viable?
-- [ ] What is the right granularity for OAuth scopes in MCP — per-tool, per-resource, or per-action?
-- [ ] How do you prevent tool description manipulation from affecting model behavior when descriptions are inherently consumed by the LLM?
-- [ ] What transport security is adequate for local (stdio) vs. remote (streamable HTTP) MCP servers?
-- [ ] How should MCP servers handle token exchange for downstream API calls — on-behalf-of vs. client credentials?
-- [ ] Can formal verification or runtime monitoring detect rug-pull attacks on tool definitions?
+- [x] **How should MCP servers handle token exchange?** — The November 2025 spec explicitly forbids token passthrough and mandates separate tokens for downstream APIs. On-behalf-of (OBO) or client credentials flows are the documented patterns. But Obsidian Security's Square analysis shows real implementations still get this wrong.
+- [ ] **How do you prevent tool description manipulation when descriptions are LLM-consumed?** — MCPTox showed 72.8% attack success even on capable models. The fundamental tension: tool descriptions must be informative enough for the LLM to use tools correctly, but this makes them a first-class prompt injection surface. Lasso Gateway scans descriptions, but no solution is comprehensive.
+- [ ] **Can rug-pull attacks be reliably detected?** — Tool definitions changing between `tools/list` calls exploit cached trust. Invariant Labs' `mcp-scan` provides detection, but real-time monitoring of definition changes during active sessions has no standard solution.
+- [ ] **Will MCP registry security improve?** — 41% of official registry servers have zero auth. Kong MCP Registry adds governance for enterprise, but the open ecosystem lacks signing, reputation scoring, or mandatory security baselines. OWASP MCP09 (Shadow Servers) highlights the risk.
+- [ ] **How should the auth spec evolve for regulated environments?** — AAIF's financial sector emphasis suggests compliance-specific extensions are coming. The spec's evolution from 3 versions in 9 months shows rapid iteration but creates adoption risk for implementers targeting moving specifications.
+- [ ] **Is MCP's security model adequate for multi-tenant deployments?** — Cross-tool contamination through shared LLM context, namespace collisions, and tool shadowing all exploit multi-server scenarios. The spec doesn't address namespace isolation or tool provenance verification at the protocol level.
 
 ---
 
 ## Related Standards & Cross-References
 
-- [Model Context Protocol (MCP) Specification](https://modelcontextprotocol.io/)
-- [MCP Authorization Spec (OAuth 2.1)](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/)
-- [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final)
-- [OAuth 2.1 (draft-ietf-oauth-v2-1)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12)
-- [OWASP ASVS v4 — Session Management, Access Control](https://owasp.org/www-project-application-security-verification-standard/)
+- [MCP Specification (November 2025)](https://modelcontextprotocol.io/specification/2025-11-25) — Current spec version with OAuth 2.1, PKCE, step-up authorization, CIMD, token passthrough prohibition
+- [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/) (v0.1 Beta) — MCP01-MCP10 covering token mismanagement, scope creep, tool poisoning, supply chain, command injection, intent flow subversion, insufficient auth, audit gaps, shadow servers, context over-sharing
+- [OWASP MCP Cheat Sheet](https://genai.owasp.org/resource/cheatsheet-a-practical-guide-for-securely-using-third-party-mcp-servers-1-0/) — Practical implementation guide for secure third-party MCP server usage
+- [Agentic AI Foundation (AAIF)](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation) (December 2025) — Linux Foundation governance for MCP; founding members: Anthropic, OpenAI, Block, Google, Microsoft, AWS
+- [CSA MAESTRO Framework](https://cloudsecurityalliance.org/blog/2025/02/06/agentic-ai-threat-modeling-framework-maestro) — 7-layer threat model for agentic AI with [MCP-specific primer](https://e.cloudsecurityalliance.org/l/908632/2025-06-25/p7xpy)
+- [NIST AI Agent Standards Initiative](https://www.nist.gov/caisi/ai-agent-standards-initiative) (February 2026) — Concept paper on Agent Identity and Authorization explicitly references MCP, OAuth 2.1, SPIFFE
+- [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final) — Agents as untrusted entities requiring continuous verification
+- [OAuth 2.1 (draft-ietf-oauth-v2-1-13)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13) — Mandated by MCP spec with PKCE + Resource Indicators (RFC 8707)
 
 ### AISVS Cross-Chapter Links
 
 | Related Chapter | Overlap Area | Notes |
 |-----------------|--------------|-------|
-| C2 User Input Validation | Input validation for tool arguments | C10.4 extends C2 principles to MCP-specific message framing |
-| C5 Access Control | Authorization enforcement | C10.2 applies access control at the MCP layer specifically |
-| C6 Supply Chain | Component integrity | C10.1 is supply-chain hygiene scoped to MCP components |
-| C9 Orchestration and Agents | Agent execution safety | C10.5 complements C9 agent controls with MCP-specific limits |
+| [C02 User Input Validation](C02-User-Input-Validation.md) | Tool argument validation | OWASP MCP05 (Command Injection) — agents construct commands from untrusted input. MCP06 (Intent Flow Subversion) — malicious context hijacks behavior. MCP10 (Context Over-Sharing). All tool arguments are untrusted input requiring validation. |
+| [C04 Infrastructure](C04-Infrastructure.md) | Transport and network security | All MCP auth endpoints MUST use HTTPS. CVE-2025-66414 DNS rebinding shows localhost transport risks. Protected Resource Metadata discovery requires secure DNS and TLS. |
+| [C05 Access Control](C05-Access-Control.md) | OAuth and authorization | MCP spec mandates OAuth 2.1 with audience-bound tokens (RFC 8707). OWASP MCP02 (Scope Creep) and MCP07 (Insufficient Auth) map to access control failures. Step-up authorization for elevated operations. Token passthrough forbidden. |
+| [C06 Supply Chain](C06-Supply-Chain.md) | MCP component integrity | OWASP MCP04 (Supply Chain Attacks) — compromised dependencies introduce backdoors. MCP03 (Tool Poisoning) includes rug pulls and schema poisoning. MCP09 (Shadow Servers) — unapproved deployments. 10,000+ published servers create massive supply chain surface. |
+| [C09 Orchestration & Agents](C09-Orchestration-and-Agents.md) | Agent protocol integration | MCP is the de facto agent-to-tool protocol; AAIF governs both MCP and agent frameworks. MAESTRO specifically models multi-agent MCP threat scenarios. MCP sampling enables covert tool invocation. |
+| [C13 Monitoring & Logging](C13-Monitoring-and-Logging.md) | MCP audit and telemetry | OWASP MCP08 (Lack of Audit and Telemetry) — limited logging impedes investigation. MCP tool invocation events need C13 logging infrastructure. OpenTelemetry GenAI conventions cover tool calls. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Updated threat landscape with 8 incidents (MCPTox 72.8% attack success, Square OAuth consent bypass, DNS rebinding CVE-2025-66414, Copilot RCE CVE-2025-53773, MCP sampling attacks, tool poisoning/rug pulls, cross-tool contamination, AAIF formation)
- Expanded tooling with URLs: MCP security scanners (mcpscan.ai, Snyk Agent Scan, Cisco, Proximity), Lasso MCP Gateway, MCP Inspector, SDK auth support
- Updated maturity ratings with CVE evidence and MCPTox results
- Added OWASP MCP Top 10 (MCP01-MCP10), AAIF governance, MAESTRO MCP primer, NIST Agent Standards
- Expanded cross-chapter links from 4 to 6 with OWASP MCP mapping
- Updated research questions (1 answered, 5 updated with current evidence)

Closes #262

## Checklist
- [x] Section structure matches source (6 sections, 34 reqs)
- [x] No infrastructure references
- [x] URLs from authoritative sources