### PR TITLE
wiki: expand C10-05 outbound access & agent safety

### DIFF
--- a/wiki/C10-05-Outbound-Access-Agent-Safety.md
+++ b/wiki/C10-05-Outbound-Access-Agent-Safety.md
@@ -7,7 +7,11 @@
 
 This section ensures that MCP servers are constrained in what they can reach and how much they can do. MCP servers are code-execution endpoints — when a tool is invoked, the server runs arbitrary logic that may make outbound API calls, access databases, read files, or interact with cloud services. Without egress controls and execution limits, a compromised or manipulated MCP server becomes an unrestricted proxy into the internal network. Additionally, agentic workflows can create unbounded chains of tool invocations where a single prompt injection cascades into dozens of side-effecting operations. This section applies both network-level and execution-level constraints.
 
-The real-world severity of these risks was starkly demonstrated in 2025-2026. CVE-2026-26118 (CVSS 8.8) exposed a critical SSRF vulnerability in Azure MCP Server Tools (versions prior to 2.0.0-beta.17), where low-privileged attackers could craft malicious payloads that tricked the MCP server into leaking its managed identity token — enabling impersonation of the server's Azure identity to access storage accounts, virtual machines, and databases. CVE-2026-27826 (CVSS 8.2) in mcp-atlassian allowed unauthenticated attackers to supply arbitrary URLs via custom routing headers; in cloud deployments, pointing this at the 169.254.169.254 metadata endpoint stole IAM role credentials. A survey of MCP implementations found that 30% were vulnerable to SSRF, 43% allowed command injection, and 22% had arbitrary file read via path traversal. These are not theoretical risks — they have active proof-of-concept exploits on GitHub and have been exploited in the wild.
+The real-world severity of these risks was starkly demonstrated in 2025-2026. CVE-2026-26118 (CVSS 8.8) exposed a critical SSRF vulnerability in Azure MCP Server Tools (versions prior to 2.0.0-beta.17), where low-privileged attackers could craft malicious payloads that tricked the MCP server into leaking its managed identity token — enabling impersonation of the server's Azure identity to access storage accounts, virtual machines, and databases. CVE-2026-27826 (CVSS 8.2) in mcp-atlassian allowed unauthenticated attackers to supply arbitrary URLs via custom `X-Atlassian-Jira-Url` and `X-Atlassian-Confluence-Url` headers without any authentication requirement; in cloud deployments, pointing this at the `169.254.169.254` metadata endpoint stole IAM role credentials. The patch (commit `5cd697d`, fixed in v0.17.0) introduced `validate_url_for_ssrf()` with DNS lookahead resolution to prevent rebinding attacks and IP range validation blocking RFC 1918 and loopback addresses.
+
+As of March 2026, the MCP vulnerability landscape has grown dramatically: over 30 CVEs targeting MCP infrastructure were filed between January and February 2026 alone. Surveys of publicly available MCP server implementations show that 36.7% are exposed to SSRF, 43% contain command injection flaws (CWE-78), 67% have code injection risks (CWE-94), and 82% are vulnerable to path traversal in file operations (CWE-22). These are not theoretical risks — they have active proof-of-concept exploits on GitHub and have been exploited in the wild.
+
+The "denial of wallet" attack pattern has also emerged as a significant threat: an attacker crafts input that causes an agent to loop endlessly (via logical paradox or self-generating task chains), rapidly consuming API budgets and compute resources. The NIST AI Risk Management Framework now mandates "circuit breakers" that automatically cut off an agent's access when token budgets or API call limits are exceeded.
 
 ---
 
@@ -25,34 +29,103 @@ The real-world severity of these risks was starkly demonstrated in 2025-2026. CV
 
 | CVE / Incident | CVSS | Description | Impact |
 |---|---|---|---|
-| CVE-2026-26118 | 8.8 | SSRF in Azure MCP Server Tools | Managed identity token theft; impersonation of server identity to access Azure storage, VMs, databases |
-| CVE-2026-27826 | 8.2 | SSRF in mcp-atlassian | Unauthenticated URL injection; cloud metadata credential theft via 169.254.169.254 |
+| CVE-2026-26118 | 8.8 | SSRF in Azure MCP Server Tools (< 2.0.0-beta.17) | Managed identity token theft; impersonation of server identity to access Azure storage, VMs, databases |
+| CVE-2026-27826 | 8.2 | SSRF in mcp-atlassian (< 0.17.0) via custom header parsing | Unauthenticated URL injection; cloud metadata credential theft via 169.254.169.254; no Atlassian credentials required |
+| CVE-2026-25904 | 5.8 | SSRF in Pydantic-AI mcp-run-python via overly permissive Deno sandbox | Access to cloud metadata services, internal APIs, local databases (Redis, MongoDB, PostgreSQL); project is archived with no fix available |
+| CVE-2026-33060 | — | SSRF in @aborruso/ckan-mcp-server via unvalidated `base_url` parameter | Internal network scanning, cloud metadata theft via IMDS; no private IP blocking or URL validation; fixed in v0.4.85 |
+| CVE-2025-6514 | 9.6 | Command injection in `mcp-remote` package | ~437,000 compromised downloads; massive supply chain impact |
+| CVE-2025-54136 | — | Trust validation bypass in Cursor IDE MCP integration | Silent injection of malicious logic in subsequent updates without re-validation |
+| Anthropic mcp-server-git (Jan 2026) | — | Three vulnerabilities: path traversal via `git_init`, argument injection via unsanitized Git CLI args | Arbitrary filesystem access beyond configured boundaries; first-party server flaws |
 | Supabase Cursor Agent (mid-2025) | — | Privileged agent processed untrusted support tickets | SQL injection exfiltrated integration tokens via public support thread |
-| Anthropic/Microsoft MCP Server Flaws (Jan 2026) | — | Multiple flaws in first-party MCP servers | Highlighted that even vendor-maintained servers had SSRF and injection vulnerabilities |
 
 Christian Schneider's "Securing MCP: A Defense-First Architecture Guide" (2025) outlines a layered defense model: Layer 1 network egress controls block SSRF outbound requests, file system root path pinning blocks arbitrary file writes, and runtime sandboxing constrains execution. Elastic Security Labs published MCP-specific attack and defense recommendations for autonomous agents, documenting tool invocation chains where a single prompt injection cascades through 10+ tool calls before triggering any detection.
+
+Endor Labs' research (early 2026) emphasized that indirect prompt injection is the primary attack vector for MCP SSRF — an attacker does not need direct access to the victim's system. Instead, malicious instructions embedded in documents, web content, or design files processed by the LLM can compel it to invoke vulnerable MCP tools with attacker-controlled arguments. This means egress controls and input validation must assume all tool arguments are adversarial, regardless of source.
+
+---
+
+## Defensive Tools and MCP Gateways
+
+As of March 2026, several purpose-built tools have emerged for enforcing egress controls, execution limits, and tool safety at the MCP layer:
+
+| Tool / Framework | Key Capabilities | Notes |
+|---|---|---|
+| **Lasso Security MCP Gateway** | Plugin-based gateway with PII masking (Presidio), tool reputation scoring (threshold-based blocking at score 30), tool description scanning for hidden instructions, real-time prompt injection detection | Open source; 2024 Gartner Cool Vendor for AI Security; supports SQLite/DuckDB audit logging via Xetrack plugin |
+| **IBM MCP Context Forge** | Centralized registry and proxy for MCP/A2A/REST/gRPC; unified endpoint with discovery, guardrails, and management | Supports plugin architecture for custom security policies |
+| **mcp-scan** | CLI vulnerability scanner for MCP server implementations; detects common patterns like unvalidated URL parameters, missing egress restrictions, command injection surfaces | Recommended as immediate action by security researchers after the 30-CVE wave |
+| **Docker MCP Gateway** | Containerized MCP execution with strict resource limits (CPU, memory caps), no host filesystem access, limited network access by default | Provides infrastructure-level isolation; does not address application-layer SSRF |
+| **Kubernetes Network Policies** | Namespace-scoped egress rules; can restrict MCP server pods to specific CIDR blocks and ports; blocks metadata endpoints (169.254.169.254/32) | Requires CNI plugin support (Calico, Cilium); does not inspect application-layer URLs |
+| **Istio/Envoy Service Mesh** | Egress gateway with domain-level allowlists, mTLS enforcement, per-service rate limiting | Adds latency; most complete network-level control for service-to-service MCP traffic |
+
+The `MCP_ALLOWED_URL_DOMAINS` configuration variable (introduced in the mcp-atlassian v0.17.0 patch) represents an emerging pattern where MCP servers expose domain allowlists as configuration. This application-layer validation should supplement, not replace, network-level egress controls.
+
+---
+
+## Implementation Guidance
+
+### Egress Control Architecture (10.5.1)
+
+Defense-in-depth requires enforcement at multiple layers:
+
+1. **Network layer:** Security groups, Kubernetes NetworkPolicies, or service mesh egress gateways restrict outbound traffic to approved CIDR blocks. Explicitly deny `169.254.169.254/32` (cloud metadata), `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16` unless specifically required. On AWS, enforce IMDSv2 (hop-limited PUT request with token) to mitigate SSRF even if the metadata endpoint is reachable.
+
+2. **Application layer:** MCP servers and gateways should validate all outbound URLs against domain allowlists. The validation must include DNS lookahead resolution (resolve the hostname before making the request) to prevent DNS rebinding attacks, and must block `file://`, `gopher://`, and other non-HTTP schemes. The mcp-atlassian v0.17.0 `validate_url_for_ssrf()` function is a good reference implementation.
+
+3. **Identity scoping:** Run each MCP server with a minimal-privilege identity. Avoid broad service principals — use per-tool or per-session managed identities where possible. CVE-2026-26118 succeeded because the Azure MCP server had an over-privileged managed identity with access to storage, VMs, and databases.
+
+### Execution Limits and Circuit Breakers (10.5.2)
+
+Execution limits must be enforced at three layers simultaneously:
+
+1. **MCP server:** Per-tool timeouts (kill the operation, not just log a warning), maximum response size limits, and concurrency caps per session.
+
+2. **Orchestrator/agent framework:** Maximum tool calls per turn, maximum total calls per session, recursion depth limits, and cost ceilings. The OWASP Agentic Security Initiative (ASI) calls this the "least agency" principle — agents should receive only the minimum autonomy required for their authorized task.
+
+3. **Infrastructure:** Request timeouts at the load balancer, pod resource limits in Kubernetes, and API gateway rate limiting. Circuit breakers should trip automatically when an agent exceeds token budgets or attempts unauthorized API calls, as mandated by the NIST AI Risk Management Framework's agentic AI profile.
+
+The "denial of wallet" attack is the financial instantiation of unbounded execution: an attacker-crafted input causes the agent to loop, consuming API credits. Organizations should set hard cost ceilings per session and per agent, with automatic termination — not just alerting — when limits are hit.
+
+### Human-in-the-Loop for Destructive Actions (10.5.3)
+
+The MCP spec's `annotations` field (2025-03-26 revision) includes `destructiveHint` and `readOnlyHint`, but these are self-reported by the server and could be manipulated by a malicious server. A robust implementation requires:
+
+1. **Client-maintained classification:** The MCP client or gateway maintains its own tool risk taxonomy, independent of server-provided annotations. Operations involving data deletion, financial transactions, system configuration changes, credential rotation, or external communications should be tagged as high-risk.
+
+2. **Confirmation UX:** When a high-risk tool is invoked, the orchestrator must pause execution and present the user with the tool name, full argument payload, and a clear description of the expected side effects. The confirmation prompt must not be bypassable by the model.
+
+3. **Autonomous fallback:** In fully autonomous workflows (batch processing, scheduled tasks, CI/CD pipelines) where no human is present, high-risk operations should either be queued for deferred human approval, sandboxed for dry-run execution, or rejected outright with an alert to the operations team.
 
 ## Related Standards & References
 
 - [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
+- [OWASP Top 10 for Agentic Applications (2026)](https://goteleport.com/blog/owasp-top-10-agentic-applications/) — unbounded consumption, agent goal hijack, human-in-the-loop requirements
 - [AWS IMDSv2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) — mitigating metadata endpoint SSRF
 - [MCP Tool Annotations (2025-03-26 spec)](https://spec.modelcontextprotocol.io/specification/2025-03-26/server/tools/) — `destructiveHint`, `readOnlyHint` annotations
 - [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final) — least-privilege network access
+- [NIST AI Risk Management Framework — Agentic AI Profile](https://www.nist.gov/artificial-intelligence) — circuit breaker mandates for autonomous agents
 - [Blueinfy: SSRF in Azure MCP Server Tools](https://blog.blueinfy.com/2026/03/ssrf-in-azure-mcp-server-tools.html) — CVE-2026-26118 analysis
+- [SentinelOne: CVE-2026-25904 Pydantic-AI MCP SSRF](https://www.sentinelone.com/vulnerability-database/cve-2026-25904/) — Deno sandbox SSRF in archived project
+- [Endor Labs: Classic Vulnerabilities Meet AI Infrastructure](https://www.endorlabs.com/learn/classic-vulnerabilities-meet-ai-infrastructure-why-mcp-needs-appsec) — indirect prompt injection as SSRF vector
 - [Elastic Security Labs: MCP Tools Attack Vectors and Defense](https://www.elastic.co/security-labs/mcp-tools-attack-defense-recommendations) — agent execution chain analysis
 - [Christian Schneider: Securing MCP Defense-First Architecture](https://christian-schneider.net/blog/securing-mcp-defense-first-architecture/) — layered defense model
+- [MCP Security 2026: 30 CVEs in 60 Days](https://www.heyuan110.com/posts/ai/2026-03-10-mcp-security-2026/) — vulnerability landscape analysis
+- [Lasso Security MCP Gateway](https://github.com/lasso-security/mcp-gateway) — open-source MCP security gateway with tool reputation scoring
 - [Checkmarx: 11 Emerging AI Security Risks with MCP](https://checkmarx.com/zero-post/11-emerging-ai-security-risks-with-mcp-model-context-protocol/) — comprehensive risk taxonomy
 - [AuthZed: Timeline of MCP Security Breaches](https://authzed.com/blog/timeline-mcp-breaches) — breach chronology
+- [Pluto Security: MCPwnfluence — SSRF to RCE in mcp-atlassian](https://pluto.security/blog/mcpwnfluence-cve-2026-27825-critical/) — attack chain analysis
+- [Dark Reading: Microsoft & Anthropic MCP Servers at Risk](https://www.darkreading.com/application-security/microsoft-anthropic-mcp-servers-risk-takeovers) — first-party server vulnerabilities
 
 ---
 
 ## Open Research Questions
 
-- [ ] How should tool risk classification be standardized — is the MCP `annotations` approach sufficient, or does it need a more formal taxonomy?
-- [ ] Can execution limits be specified declaratively in the MCP protocol (e.g., server-advertised rate limits or timeout hints)?
-- [ ] How should human-in-the-loop confirmation work in fully autonomous agent workflows where no user is present (e.g., batch processing, scheduled tasks)?
-- [ ] Should MCP servers expose their egress allowlist as metadata, allowing clients to assess the server's network reach before connecting?
+- [ ] How should tool risk classification be standardized — is the MCP `annotations` approach sufficient, or does it need a formal taxonomy backed by a registry (similar to CWE for weaknesses)?
+- [ ] Can execution limits be specified declaratively in the MCP protocol (e.g., server-advertised rate limits, timeout hints, or cost-per-invocation metadata)?
+- [ ] How should human-in-the-loop confirmation work in fully autonomous agent workflows where no user is present (e.g., batch processing, scheduled tasks)? Deferred approval queues and dry-run sandboxing are candidates but lack standardization.
+- [ ] Should MCP servers expose their egress allowlist as metadata, allowing clients to assess the server's network reach before connecting? The `MCP_ALLOWED_URL_DOMAINS` pattern in mcp-atlassian v0.17.0 is a step in this direction.
 - [ ] Given that CVE-2026-26118 exploited over-privileged managed identities, should MCP deployment standards mandate identity scoping (e.g., per-tool or per-session managed identities rather than broad service principals)?
-- [ ] How should MCP gateways enforce egress policies — at the network layer (security groups), application layer (URL allowlists in the gateway), or both?
+- [ ] The mcp-scan tool and Lasso Gateway's reputation scoring represent early attempts at automated MCP security assessment — how should these capabilities be standardized for CI/CD integration?
+- [ ] With 30+ MCP CVEs filed in two months (Jan-Feb 2026) and the CVE-2026-25904 project being archived without a fix, how should organizations handle abandoned MCP servers with known vulnerabilities?
+- [ ] What enforcement mechanisms (not just visibility) should be standard for preventing "denial of wallet" attacks in agentic systems — hard cost ceilings, automatic session termination, or both?
 
 ---


### PR DESCRIPTION
## Summary

Significant expansion of the C10.5 Outbound Access & Agent Execution Safety research page:

- Added 4 new CVEs to the incidents table (CVE-2026-25904 Pydantic-AI Deno sandbox SSRF, CVE-2026-33060 CKAN MCP server SSRF, CVE-2025-6514 mcp-remote command injection with 437K compromised downloads, CVE-2025-54136 Cursor IDE trust validation bypass)
- New **Defensive Tools and MCP Gateways** section covering Lasso Security MCP Gateway, IBM Context Forge, mcp-scan, Docker/K8s/Istio controls
- New **Implementation Guidance** section with layered egress control architecture, circuit breaker patterns, and human-in-the-loop design for destructive actions
- Added "denial of wallet" attack pattern and NIST AI RMF circuit breaker mandate coverage
- Expanded references from 9 to 17, including OWASP Agentic Top 10, Endor Labs indirect prompt injection research, and Pluto Security MCPwnfluence analysis
- Updated open research questions to reflect current tooling landscape

Page grew from 85 to 131 lines with 82 insertions and 9 deletions.