### PR TITLE
fix: remove duplicate C14.3.2 (tamper-evident logs)

### DIFF
--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -39,7 +39,6 @@ Log operator actions and model decisions.
 | # | Description | Level | Role |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
 | **14.3.1** | **Verify that** all AI system decisions and human interventions are logged with timestamps, user identities, and decision rationale. | 1 | D/V |
-| **14.3.2** | **Verify that** audit logs cannot be tampered with and include integrity verification mechanisms. | 2 | D |
 
 ---
 


### PR DESCRIPTION
C14.3.2 required audit logs to be tamper-evident and include integrity verification mechanisms. This is already fully covered by C13.1.6, which requires log integrity protection via cryptographic signatures or write-only storage for all AI system logs.

C14.3.2 added no unique security value: it applied the identical technical requirement (immutable/tamper-evident logs) to the same artifact (audit logs) without any meaningful scope differentiation. C13.1.6 is the authoritative general control; implementers applying C13 already satisfy the intent of C14.3.2.