### PR TITLE
fix: remove duplicate C10.1.2 (secrets not in config/source)

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -11,8 +11,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | # | Description | Level | Role |
 | :--: | --- | :---: | :--: |
 | **10.1.1** | **Verify that** MCP server and client components are obtained only from trusted sources and verified using signatures, checksums, or secure package metadata, rejecting tampered or unsigned builds. | 1 | D/V |
-| **10.1.2** | **Verify that** MCP client and server configurations do not contain plaintext secrets (API keys, tokens, client secrets) and that credentials are injected or resolved at runtime rather than stored in configuration files, environment variables, or source code. | 1 | D/V |
-| **10.1.3** | **Verify that** only allowlisted MCP server identifiers (name, version, and registry) are permitted in production and that the runtime rejects connections to unlisted or unregistered servers at load time. | 1 | D/V |
+| **10.1.2** | **Verify that** only allowlisted MCP server identifiers (name, version, and registry) are permitted in production and that the runtime rejects connections to unlisted or unregistered servers at load time. | 1 | D/V |
 
 ---
 


### PR DESCRIPTION
C10.1.2 required that MCP client and server configurations not contain plaintext secrets, and that credentials be injected at runtime rather than stored in config files, environment variables, or source code.

This is already fully covered by C4.4.3, which states the same requirement for all AI system components: secrets must be deployed via a dedicated secrets management system and must never appear in source code, configuration files, build artifacts, container images, or environment variables.

C10.1.2 was a verbatim restatement of C4.4.3 narrowed to the MCP context without adding any MCP-specific technical requirement. Implementers applying C4.4.3 already satisfy the intent. The former C10.1.3 (allowlisted MCP server identifiers) has been renumbered to C10.1.2.