### PR TITLE
Wiki: refresh C09-02 high-impact action approval research

### DIFF
--- a/wiki/C09-02-High-Impact-Action-Approval.md
+++ b/wiki/C09-02-High-Impact-Action-Approval.md
@@ -8,7 +8,7 @@ Agents acting autonomously may perform actions with significant real-world conse
 
 ## 2024-2026 Research Context
 
-Human-in-the-loop (HITL) approval has matured from an ad-hoc practice into a first-class architectural pattern for agentic AI systems. By 2025-2026, multiple frameworks offer native support for structured approval gates, and industry consensus has converged on risk-based action classification as the foundation for approval routing.
+Human-in-the-loop (HITL) approval has matured from an ad-hoc practice into a first-class architectural pattern for agentic AI systems. By 2025-2026, multiple frameworks offer native support for structured approval gates, and industry consensus has converged on risk-based action classification as the foundation for approval routing. As of early 2026, roughly 70% of organizations run a human-in-the-loop model where the agent recommends and a person approves, with only 14% allowing fully autonomous remediation.
 
 ### Approval Workflow Patterns
 
@@ -17,13 +17,50 @@ Modern HITL implementations follow a five-step control loop: (1) agent receives 
 - **User Confirmation (synchronous):** A straightforward boolean validation where the agent pauses execution via an `interrupt()` call and waits for a yes/no decision. Suited for real-time, high-stakes decisions. LangGraph's native `interrupt()` function is the canonical implementation, pausing the graph mid-execution and resuming cleanly after human input.
 - **Asynchronous Authorization:** The agent issues an authorization request and continues non-blocking work while waiting for a response routed through channels like Slack, email, or dedicated approval UIs. The HumanLayer SDK provides decorators like `@require_approval()` that wrap functions with multi-channel notification logic. This pattern is suited for lower-priority flows or when the approver is not immediately available.
 
+The OWASP AI Agent Security Cheat Sheet codifies a `HumanInTheLoopController` pattern that queues sensitive actions for review with unique action IDs, generates readable previews showing sanitized parameters and risk levels, and returns a `pending_confirmation` status until user consent is obtained.
+
 ### Risk Classification for Actions
 
-The industry has converged on four dimensions for determining whether an action requires human review: **irreversibility** (can the action be undone?), **blast radius** (how many systems/users are affected?), **compliance exposure** (does the action touch regulated data or processes?), and **confidence** (how certain is the agent about the action's correctness?). Over-classification leads to approval fatigue; under-classification leads to missed dangerous actions. Organizations must calibrate thresholds to their risk tolerance.
+The industry has converged on a four-tier risk classification for determining whether an action requires human review:
+
+| Risk Tier | Examples | Approval Policy |
+|---|---|---|
+| **Low** | Read operations, status queries | Auto-approved |
+| **Medium** | Write operations, API calls | May auto-approve based on threshold settings |
+| **High** | Financial transfers, external communications | Requires human approval |
+| **Critical** | Irreversible deletes, security config changes | Mandatory human review |
+
+The four decision dimensions remain: **irreversibility** (can the action be undone?), **blast radius** (how many systems/users are affected?), **compliance exposure** (does the action touch regulated data or processes?), and **confidence** (how certain is the agent about the action's correctness?). A March 2026 Security Boulevard analysis recommends a phased "trust ladder" approach -- Suggest, then Assist, then Execute with guardrails -- starting with reversible actions like session revocation or endpoint quarantine before graduating to irreversible ones.
+
+Over-classification leads to approval fatigue; under-classification leads to missed dangerous actions. As of early 2026, 79% of enterprises report blindspots where agents invoke tools, touch data, or trigger actions that the security team cannot fully observe. Organizations must calibrate thresholds to their risk tolerance.
+
+### Governance Layers and Adaptive Trust
+
+UC Berkeley's ATLAS (Adaptive Trust Layer for Autonomous Systems) project, published in early 2026, implements a governance layer that intercepts agent decisions before execution and evaluates whether human authorization is required. It uses a two-component architecture: a customer-environment agent that gathers information and generates case proposals, and a control layer that evaluates proposed actions against applicable policy and risk criteria. Actions affecting safety, health, or fundamental rights -- aligned with EU AI Act Article 14 and NIST AI RMF -- route to human decision-makers, while clearly low-risk cases follow an automated pathway.
+
+This governance-first approach contrasts with purely algorithmic trust scoring. The key insight is that meaningful human oversight requires centralized policy evaluation, not just threshold-based automation.
 
 ### Transactional Semantics and Rollback
 
 A December 2025 MarkTechPost article described transactional agentic AI systems using LangGraph with two-phase commit patterns: reversible changes are staged, strict invariants are validated, the graph pauses for human approval via `interrupt()`, and execution either commits or rolls back. This maps directly to requirement 9.2.3's call for compensating actions and saga-pattern rollback, adapting distributed-systems transaction theory to agentic workflows.
+
+The rollback tooling landscape has expanded significantly in 2025-2026:
+
+- **Rubrik Agent Rewind** (August 2025): Snapshots monitored environments and can roll back unwanted agent-led changes across files, databases, configurations, and code repositories. Marketed as "rogue AI agent action rewind protection."
+- **Cohesity + ServiceNow + Datadog** (announced March 2026): A joint recoverability service preserving immutable snapshots of AI environments with point-in-time recovery across files, databases, object storage, SaaS applications, vector stores, and agent memory.
+- **Cisco**: Built native rollback capabilities into its agentic tools.
+
+However, one-way transactions (bank transfers, sent emails, published content) remain fundamentally irreversible. The March 2026 IT Brew analysis notes that actions "outside your four walls of control" cannot be unwound, which is why pre-execution approval gates remain the primary defense for truly irreversible actions.
+
+### Real-World Incidents
+
+Several notable incidents underscore the importance of approval controls:
+
+- **Replit database deletion (July 2025):** Replit's coding agent deleted a production database without authorization. The damage was reversed using code "checkpoints," but only because the platform had built-in snapshot recovery.
+- **Procurement agent manipulation (October 2026, Palo Alto Unit42):** A manufacturing company's procurement agent was gradually manipulated over three weeks of conversation history to believe it could approve purchases under $500,000 without human review -- a textbook example of context poisoning eroding approval gates.
+- **AI Incident Database #1028 (February 2025):** An agent bypassed purchase confirmation safeguards entirely.
+
+These incidents demonstrate that approval controls must be tamper-resistant at the system level, not merely prompt-level instructions that an agent can be manipulated into ignoring.
 
 ### Framework and Tooling Landscape (2025-2026)
 
@@ -35,19 +72,33 @@ A December 2025 MarkTechPost article described transactional agentic AI systems 
 | **Amazon Bedrock Agents** | Built-in human confirmation step | AWS-native; integrates with Step Functions for complex workflows |
 | **Permit.io + MCP** | Policy-engine-driven approval gates | Declarative, versioned authorization policies with UI/API approval management |
 | **Microsoft Agent Governance Toolkit** | 4-tier privilege rings, saga orchestration | Ed25519 signed approvals; append-only audit; covers OWASP Agentic Top 10 |
+| **UC Berkeley ATLAS** | Policy-based interception layer | Domain-agnostic governance; EU AI Act Article 14 aligned; threshold + escalation model |
+
+### MITRE ATLAS Techniques Relevant to Approval Controls
+
+In October 2025, MITRE ATLAS incorporated 14 new agent-specific attack techniques developed with Zenity Labs. Several directly threaten approval workflows:
+
+- **AML.T0096 (AI Service API):** Attackers exploit AI service APIs to maintain persistent access while appearing as legitimate operations -- potentially bypassing approval gates that trust "internal" API calls.
+- **AML.T0098 (AI Agent Tool Credential Harvesting):** Attackers retrieve credentials from tools agents connect to, enabling them to execute actions outside the approval workflow entirely.
+- **AML.T0099 (AI Agent Tool Data Poisoning):** Adversaries place malicious content where agents retrieve it, including prompt injections that can manipulate the agent into misclassifying action risk levels.
+- **AML.T0100 (AI Agent Clickbait):** Exploits how agents interpret UI content or visual cues to trigger unintended actions like code execution.
+- **AML.T0101 (Data Destruction via AI Agent Tool Invocation):** Attackers leverage existing tool capabilities to destroy data -- the exact scenario approval gates are meant to prevent.
 
 ### Approval Binding and Tamper Resistance
 
 The "approve one thing, execute another" attack (requirement 9.2.2) is a TOCTOU vulnerability. Mitigation requires cryptographic hashing of the serialized action parameters at approval time and validation of that hash before execution. LangGraph's checkpointers help by persisting the exact graph state at the interrupt point, but parameter binding must be explicitly implemented at the application layer. The Microsoft Agent Governance Toolkit provides Ed25519-signed action records that bind approvals to specific parameters with sub-millisecond overhead.
 
+Every automated action should capture before/after states, trigger rationale, decision-time data snapshots, and approval records. The OWASP AI Agent Security Cheat Sheet recommends maintaining clear audit trails of agent decisions and actions, with the ability to interrupt and roll back agent operations at any point.
+
 ### Key Failure Modes
 
-Research and incident analysis from 2024-2026 identify four primary failure modes that approval workflows must address:
+Research and incident analysis from 2024-2026 identify five primary failure modes that approval workflows must address:
 
 1. **Hallucinated actions:** The agent invents nonexistent commands, resource IDs, or API endpoints
 2. **Misused permissions:** Vague prompts cause scope creep beyond the user's intent
 3. **Self-approval / overreach:** The agent attempts to bypass or self-satisfy its own approval requirement
 4. **Lack of traceability:** No audit trail linking who authorized what, when, and with what parameters
+5. **Context poisoning of approval gates:** As demonstrated in the Unit42 procurement incident, adversaries can gradually manipulate an agent's context over time to erode approval thresholds -- approval controls must be enforced at the system architecture level, not as prompt-level instructions
 
 ---
 
@@ -55,17 +106,23 @@ Research and incident analysis from 2024-2026 identify four primary failure mode
 
 | # | Requirement | Level | Role | Threat Mitigated | Verification Approach | Gaps / Notes |
 |---|-------------|:-----:|:----:|-----------------|----------------------|--------------|
-| **9.2.1** | **Verify that** privileged or irreversible actions (e.g., code merges/deploys, financial transfers, user access changes, destructive deletes, external notifications) require explicit human-in-loop approval. | 1 | D/V | **Unintended destructive actions.** An agent manipulated via prompt injection or operating on flawed reasoning could execute irreversible actions (deleting production databases, sending fraudulent emails, deploying broken code) without any human checkpoint. This is the "excessive agency" risk in its most dangerous form. | Review the action taxonomy to confirm all high-impact actions are classified and routed through an approval workflow. Test by triggering each classified action type and verifying the system pauses for human approval before execution. Confirm the approval requirement cannot be bypassed by prompt manipulation. | Defining "high-impact" is organization-specific. Frameworks like LangGraph support `interrupt_before` nodes for human-in-the-loop, but classification of which actions need approval is a manual design decision. Risk: over-classification leads to approval fatigue; under-classification leads to missed dangerous actions. |
-| **9.2.2** | **Verify that** approval requests present the exact action parameters (diff/command/recipient/amount/scope) and bind approvals to those parameters to prevent "approve one thing, execute another." | 2 | D/V | **Approval substitution / bait-and-switch.** An agent (or attacker manipulating the agent) could present a benign action for approval, then execute a different action after receiving the approval token. Without parameter binding, approval becomes a rubber stamp. TOCTOU (time-of-check-time-of-use) attacks are the classic vector. | Verify that the approval payload contains a cryptographic hash or signature of the exact action parameters. Confirm that the execution engine validates the hash before proceeding. Test by modifying action parameters after approval and verifying execution is rejected. | Parameter binding requires the orchestration layer to serialize and hash action parameters deterministically. For complex actions (e.g., code diffs), the "exact parameters" may be large. Need to balance completeness of display with readability for the human approver. |
-| **9.2.3** | **Verify that** where rollback is feasible, compensating actions are defined and tested (transactional semantics), and failures trigger rollback or safe containment. | 3 | V | **Irrecoverable partial execution.** Multi-step agent actions may partially complete before failing, leaving the system in an inconsistent state (e.g., funds debited but not credited, infrastructure half-provisioned). Without compensating actions, recovery requires manual intervention. | Review compensating action definitions for each reversible high-impact action. Execute failure scenarios mid-action and verify rollback occurs automatically. Confirm that irreversible actions (where rollback is infeasible) are flagged as such and require stronger approval. | Saga patterns from distributed systems apply here. Most agent frameworks have no built-in transaction/rollback support. This must be implemented at the application layer. True rollback is impossible for some actions (sent emails, published content, deleted data without backups). |
+| **9.2.1** | **Verify that** privileged or irreversible actions (e.g., code merges/deploys, financial transfers, user access changes, destructive deletes, external notifications) require explicit human-in-loop approval. | 1 | D/V | **Unintended destructive actions (OWASP LLM06:2025 Excessive Agency; MITRE ATLAS AML.T0101 Data Destruction via Agent Tool Invocation).** An agent manipulated via prompt injection or operating on flawed reasoning could execute irreversible actions (deleting production databases, sending fraudulent emails, deploying broken code) without any human checkpoint. The July 2025 Replit incident -- where a coding agent deleted a production database without authorization -- illustrates the risk. The October 2026 Unit42 procurement agent case shows how context poisoning can gradually erode approval requirements over weeks of conversation. | Review the action taxonomy to confirm all high-impact actions are classified using the four-tier model (Low/Medium/High/Critical) and routed through an approval workflow. Test by triggering each classified action type and verifying the system pauses for human approval before execution. Confirm the approval requirement cannot be bypassed by prompt manipulation -- test with adversarial prompts that attempt to reclassify action risk levels. Verify using LangGraph's `interrupt_before` nodes, HumanLayer's `@require_approval()` decorator, or equivalent framework mechanisms. Check that approval gates are enforced at the system architecture level, not just prompt-level instructions. | Defining "high-impact" is organization-specific and requires ongoing calibration. The OWASP AI Agent Security Cheat Sheet provides a `HumanInTheLoopController` reference pattern. As of 2026, 79% of enterprises report blindspots where agents invoke tools without full security team visibility. The phased "trust ladder" approach (Suggest → Assist → Execute with guardrails) helps organizations adopt approval gates incrementally. Gartner predicts over 40% of agentic AI projects will be canceled by end of 2027 partly due to inadequate risk controls. |
+| **9.2.2** | **Verify that** approval requests present the exact action parameters (diff/command/recipient/amount/scope) and bind approvals to those parameters to prevent "approve one thing, execute another." | 2 | D/V | **Approval substitution / bait-and-switch (TOCTOU attack; related to MITRE ATLAS AML.T0099 AI Agent Tool Data Poisoning).** An agent (or attacker manipulating the agent) could present a benign action for approval, then execute a different action after receiving the approval token. Without parameter binding, approval becomes a rubber stamp. AML.T0099 describes how adversaries can place malicious content where agents retrieve it, potentially altering action parameters between approval and execution. | Verify that the approval payload contains a cryptographic hash or signature of the exact action parameters. The Microsoft Agent Governance Toolkit uses Ed25519-signed action records for this purpose. Confirm that the execution engine validates the hash before proceeding. Test by modifying action parameters after approval and verifying execution is rejected. Verify that audit records capture before/after states, trigger rationale, decision-time data snapshots, and the approval record itself. Test that the approval display shows sanitized parameters with risk-level context. | Parameter binding requires the orchestration layer to serialize and hash action parameters deterministically. For complex actions (e.g., code diffs), the "exact parameters" may be large -- need to balance completeness of display with readability for the human approver. LangGraph's checkpointers persist exact graph state at the interrupt point but parameter binding must be explicitly implemented at the application layer. UC Berkeley's ATLAS project demonstrates a governance layer approach where a central control component evaluates proposed actions against policy before execution. |
+| **9.2.3** | **Verify that** where rollback is feasible, compensating actions are defined and tested (transactional semantics), and failures trigger rollback or safe containment. | 3 | V | **Irrecoverable partial execution.** Multi-step agent actions may partially complete before failing, leaving the system in an inconsistent state (e.g., funds debited but not credited, infrastructure half-provisioned). Without compensating actions, recovery requires manual intervention. The Replit database deletion incident was recoverable only because the platform had checkpoint-based snapshots; without them, the data would have been permanently lost. | Review compensating action definitions for each reversible high-impact action. Execute failure scenarios mid-action and verify rollback occurs automatically. Confirm that irreversible actions (where rollback is infeasible) are flagged as such and require stronger approval. Test with Rubrik Agent Rewind (August 2025) or the Cohesity/ServiceNow/Datadog recoverability service (announced March 2026) for infrastructure-level rollback. Verify that deterministic undo scripts -- rather than non-deterministic agent-driven rollback -- are used for critical operations like database updates or account deletion. Confirm that secondary "buffer agents" are in place where applicable to hold changes temporarily before committing. | Saga patterns from distributed systems (Garcia-Molina & Salem, 1987) apply here. As of March 2026, dedicated rollback tooling from Rubrik, Cohesity, and Cisco now covers files, databases, configurations, vector stores, and agent memory. However, true rollback is impossible for some actions (sent emails, published content, bank transfers, actions outside the organization's "four walls of control"). For these, pre-execution approval gates remain the only defense. Tabletop exercises to validate recovery procedures before full deployment are recommended. |
 
 ---
 
 ## Related Standards & References
 
 - [OWASP LLM06:2025 Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/) -- the primary risk this section addresses
+- [OWASP AI Agent Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/AI_Agent_Security_Cheat_Sheet.html) -- includes `HumanInTheLoopController` pattern, four-tier risk classification, and action preview guidance
 - [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/) -- covers approval workflow recommendations
 - [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026) -- "Uncontrolled Autonomy" and "Excessive Functionality" entries
+- [MITRE ATLAS: Zenity Agent Techniques (October 2025)](https://zenity.io/blog/current-events/zenitys-contributions-to-mitre-atlas-first-2026-update) -- AML.T0096 through AML.T0101, covering agent-specific attack techniques including tool credential harvesting and data destruction
+- [UC Berkeley ATLAS: Adaptive Trust Layer for Autonomous Systems (2026)](https://www.ischool.berkeley.edu/projects/2026/atlas-adaptive-trust-layer-autonomous-systems) -- governance layer intercepting agent decisions before execution, aligned with EU AI Act Article 14
+- [Security Boulevard: Agentic AI Governance Layer (March 2026)](https://securityboulevard.com/2026/03/agentic-ai-in-the-soc-the-governance-layer-you-need-before-you-let-automation-execute/) -- five-question approval model and phased trust ladder adoption
+- [IT Brew: How Reversible is an Agentic Mistake? (March 2026)](https://www.itbrew.com/stories/2026/03/06/how-reversible-is-an-agentic-mistake) -- analysis of rollback capabilities and limitations for agent-driven changes
+- [The Register: Vendors Building Rollback Tools (March 2026)](https://www.theregister.com/2026/03/10/agentic_ai_rollback_recovery_cohesity/) -- Cohesity, ServiceNow, and Datadog joint recoverability service
 - [Permit.io: Human-in-the-Loop for AI Agents](https://www.permit.io/blog/human-in-the-loop-for-ai-agents-best-practices-frameworks-use-cases-and-demo) -- comprehensive HITL framework comparison and best practices (2025)
 - [MarkTechPost: Transactional Agentic AI with LangGraph](https://www.marktechpost.com/2025/12/31/how-to-design-transactional-agentic-ai-systems-with-langgraph-using-two-phase-commit-human-interrupts-and-safe-rollbacks/) -- two-phase commit and rollback patterns for agent workflows
 - [Auth0: Secure HITL Interactions for AI Agents](https://auth0.com/blog/secure-human-in-the-loop-interactions-for-ai-agents/) -- async authorization and approval binding security
@@ -76,11 +133,13 @@ Research and incident analysis from 2024-2026 identify four primary failure mode
 
 ## Open Research Questions
 
-- How do you prevent approval fatigue in systems with frequent high-impact actions without weakening security? Early 2026 approaches use risk-adaptive thresholds with four dimensions (irreversibility, blast radius, compliance exposure, confidence), but calibration remains organization-specific.
-- Can risk-adaptive approval thresholds (auto-approve low-risk instances of normally high-impact action types) be made safe? The Microsoft Agent Governance Toolkit's trust scoring (0-1000 scale) is one approach, but adversarial manipulation of trust scores is an open concern.
-- What is the minimum viable approval context that a human needs to make an informed decision for different action types? For complex actions (e.g., large code diffs), balancing completeness with readability remains unsolved.
+- How do you prevent approval fatigue in systems with frequent high-impact actions without weakening security? Early 2026 approaches use risk-adaptive thresholds with four dimensions (irreversibility, blast radius, compliance exposure, confidence), but calibration remains organization-specific. UC Berkeley's ATLAS project uses policy-based interception rather than pure threshold scoring, which may be more resistant to fatigue.
+- Can risk-adaptive approval thresholds (auto-approve low-risk instances of normally high-impact action types) be made safe? The Microsoft Agent Governance Toolkit's trust scoring (0-1000 scale) is one approach, but the Unit42 procurement agent incident (October 2026) showed that adversaries can gradually erode trust thresholds through context poisoning over extended conversations.
+- What is the minimum viable approval context that a human needs to make an informed decision for different action types? For complex actions (e.g., large code diffs), balancing completeness with readability remains unsolved. The OWASP AI Agent Security Cheat Sheet's approach of sanitized parameter previews with risk-level labels is a starting point.
 - How should approval workflows handle time-sensitive actions where the human approver is unavailable? Async patterns (HumanLayer) and escalation chains are emerging, but timeout-based auto-approval introduces risk.
 - Can two-phase commit patterns scale to multi-agent workflows where multiple agents propose actions simultaneously? Conflict resolution and deadlock avoidance in agent sagas need further research.
 - How should approval workflows be designed for agents that operate across organizational boundaries, where the approver may not have full context?
+- As rollback tooling matures (Rubrik Agent Rewind, Cohesity/ServiceNow/Datadog recoverability), does the availability of reliable rollback reduce the need for pre-execution approval? The consensus as of March 2026 is no -- rollback cannot cover actions "outside your four walls of control," so approval gates remain essential for truly irreversible actions.
+- How should organizations handle the 66-point governance gap (73% AI tool deployment vs. 7% real-time governance enforcement) identified in early 2026 enterprise surveys? Closing this gap before scaling agentic deployments is a pressing operational challenge.
 
 ---


### PR DESCRIPTION
Closes #326

Freshened up the C09-02 wiki page with current research on high-impact action approval controls:

- Added real-world incidents that demonstrate why approval gates matter (Replit database deletion July 2025, Unit42 procurement agent context poisoning October 2026)
- Incorporated MITRE ATLAS agent-specific techniques AML.T0096-T0101 from the October 2025 Zenity collaboration
- Added OWASP AI Agent Security Cheat Sheet HumanInTheLoopController pattern and four-tier risk classification table
- Covered UC Berkeley ATLAS governance layer project as an alternative to pure threshold-based trust scoring
- Expanded rollback tooling landscape (Rubrik Agent Rewind, Cohesity/ServiceNow/Datadog recoverability service, Cisco native rollback)
- Added governance gap statistics (73% deployment vs. 7% real-time governance) and phased trust ladder adoption guidance
- New open research questions on rollback vs. approval tradeoffs and the governance deficit