### PR TITLE
Wiki: expand C11.10 adversarial bias exploitation defense

### DIFF
--- a/wiki/C11-10-Adversarial-Bias-Exploitation-Defense.md
+++ b/wiki/C11-10-Adversarial-Bias-Exploitation-Defense.md
@@ -30,7 +30,11 @@ The core threat model for this section is distinct from fairness or ethical bias
 
 **Canonical example -- Cylance AI Antivirus Bypass (2019, ATLAS AML.CS0003):** Skylight Cyber researchers discovered that Cylance Protect's ML malware detection model had a learned bias toward a gaming executable's string signatures. By appending those strings to malware samples, detection scores shifted from -852 (malicious) to +999 (benign). Success rate: 100% against top-10 malware, ~90% against 384 samples. The "bias" was an implicit whitelist discoverable through systematic probing.
 
-**Content moderation linguistic evasion (2024-2026):** Content moderation systems trained primarily on English show significantly weaker detection for equivalent harmful content in under-represented languages, dialects, or code-switched text. Meta's moderation systems have been specifically criticized for disproportionate under-enforcement in Global South languages. Attackers exploit this by expressing prohibited content in linguistic forms where the classifier is weakest.
+**Content moderation linguistic evasion (2024-2026):** Content moderation systems trained primarily on English show significantly weaker detection for equivalent harmful content in under-represented languages, dialects, or code-switched text. Meta's moderation systems have been specifically criticized for disproportionate under-enforcement in Global South languages. Attackers exploit this by expressing prohibited content in linguistic forms where the classifier is weakest. As of early 2026, evasion techniques have grown more sophisticated: cipher-based attacks (Base64, hexadecimal encoding, Unicode homoglyphs) bypass keyword filters by changing only the encrypted payload while keeping prompt structure static. Multi-agent frameworks like MetaCipher automate cipher selection and rotation, making manual filter updates a losing game.
+
+**ICL-Evader — zero-query black-box evasion of in-context-learning classifiers (WWW '26):** Demonstrates that LLM-based classifiers using in-context learning are vulnerable to evasion without any query access. Three attack strategies (Fake Claim, Template, Needle-in-a-Haystack) exploit inherent limitations in how LLMs process in-context prompts, achieving up to 95.3% attack success rate across sentiment analysis, toxicity detection, and illicit promotion tasks. A joint defense recipe mitigates all three attacks with less than 5% accuracy degradation. This is directly relevant to bias exploitation because the attacks are most effective against subgroups where the classifier has fewer in-context examples — a structural bias inherent in prompt construction.
+
+**AnyAttack — self-supervised adversarial attacks on vision-language models (CVPR 2025):** Pre-trained on LAION-400M without label supervision, AnyAttack generates targeted adversarial images that transfer across VLMs including CLIP, BLIP2, InstructBLIP, MiniGPT-4, and commercial systems (Gemini, Claude Sonnet, Microsoft Copilot). The attack exploits learned biases in vision encoders — perturbations that shift embeddings toward target representations work precisely because models have uneven robustness across visual concepts. This extends the bias-as-evasion pattern from traditional classifiers into the multimodal domain.
 
 ### Adversarial Training Creates Robustness Disparities
 
@@ -40,6 +44,7 @@ A key finding from 2021-2025 research is that adversarial training itself can cr
 - **Sun et al., "Towards Fairness-Aware Adversarial Learning" (2024):** Proposed the FAAL framework using distributional robust optimization (DRO) to find worst-case class-weight distributions during adversarial training. Achieves 35.7% worst-class accuracy vs. prior FRL's 33.1%, with only 2 epochs of fine-tuning.
 - **"Fairness is essential for robustness" (Frontiers of Computer Science, 2025):** Showed that identifying and augmenting "hard examples" provides fine-grained information about robustness disparities and reduces inter-class robustness gaps.
 - **ICLR 2025 spectral-norm regularization:** Developed robust generalization bounds for worst-class robust error, enabling principled measurement and optimization of per-subgroup robustness.
+- **Balagopalan (MIT PhD thesis, 2025):** "Operationalizing Reliable Machine Learning: From Data" provides a comprehensive treatment of operationalizing fairness-aware robustness in production ML systems, including practical guidance on subgroup definition, evaluation methodology, and deployment monitoring for reliability across demographic and content subgroups.
 
 ### The Accuracy-Robustness-Fairness Trilemma
 
@@ -59,8 +64,13 @@ Organizations implementing 11.10.3 must navigate a documented three-way trade-of
 | **FAAL** | Research (Sun et al.) | Min-max-max adversarial training for per-subgroup robustness | **Low** -- research code |
 | **FRL** | Research (Xu et al.) | Fair adversarial training framework | **Low** -- research code |
 | **WAT** | Research (Li & Liu) | Worst-class adversarial training via no-regret dynamics | **Low** -- research code |
+| **IBM HEART** | IBM / CDAO | Hardened Extension of ART for DoD Test & Evaluation workflows; wraps ART attacks with MAITE protocol alignment and metadata QA. Gradio-based low-code interface. | **Medium** (v0.7.0, July 2025) |
+| **NIST Dioptra** | NIST | Modular microservice platform for reproducible, trackable AI security testing — evasion, poisoning, oracle attacks. Designed around NIST AI 100-2 taxonomy. | **Medium** (v1.1.0) |
+| **Microsoft Counterfit** | Microsoft | CLI tool for automating adversarial attack generation against ML models; integrates with ART and TextAttack backends | **Medium** |
+| **ICL-Evader** | ChaseSecurity (WWW '26) | Zero-query black-box evasion attacks and defenses for in-context learning classifiers | **Low** -- research code |
+| **MLCommons AILuminate** | MLCommons | Jailbreak benchmark (v0.5, Dec 2025) for standardized evaluation of LLM safety and content filter robustness | **Medium** -- benchmark, not a defense tool |
 
-**Integration pattern for 11.10.2:** Use ART to generate adversarial examples per subgroup-filtered test set, then use Fairlearn `MetricFrame` to compute per-subgroup adversarial accuracy/FNR. No single tool provides this end-to-end.
+**Integration pattern for 11.10.2:** Use ART to generate adversarial examples per subgroup-filtered test set, then use Fairlearn `MetricFrame` to compute per-subgroup adversarial accuracy/FNR. No single tool provides this end-to-end. For DoD or government contexts, IBM HEART (v0.7.0) wraps ART with MAITE-aligned evaluation workflows and metadata tracking. NIST Dioptra (v1.1.0) provides a reproducible orchestration layer for running these evaluations at scale with full audit trails.
 
 ---
 
@@ -72,6 +82,9 @@ Organizations implementing 11.10.3 must navigate a documented three-way trade-of
 | 2024 | **Proofpoint EchoSpoofing** -- 14M spoofed emails/day exploiting trust configurations that created implicit bias in email security pipeline | Analogous pattern: exploiting a trust dimension the security system treated as a strong signal |
 | 2024-2026 | **Content moderation linguistic evasion** -- Meta and other platforms documented under-enforcement in Global South languages; attackers exploit this for prohibited content | Direct bias-as-evasion in content moderation classifiers |
 | 2025 | **Android malware GAN evasion** -- Black-box GAN attacks achieving 95%+ evasion against malware detection while preserving malicious functionality | Automated adversarial generation targeting model weaknesses |
+| 2025 | **AnyAttack against commercial VLMs (CVPR 2025)** -- Self-supervised adversarial perturbations transfer across CLIP, BLIP2, Gemini, Claude Sonnet, and Microsoft Copilot, exploiting uneven robustness across visual concept embeddings | Extends bias-as-evasion from classifiers into multimodal domain |
+| 2026 | **ICL-Evader zero-query evasion (WWW '26)** -- 95.3% attack success rate against LLM-based in-context-learning classifiers with no query access required; structural bias from uneven example coverage enables targeted evasion | Demonstrates that prompt-based classifiers inherit subgroup robustness gaps from example selection |
+| 2025-2026 | **Cipher and homoglyph evasion of content filters** -- Base64, hex encoding, and Unicode homoglyph substitution bypass keyword-based content moderation at scale; multi-agent frameworks automate cipher rotation | Keyword filters are structurally biased toward Latin-script detection, creating reliable evasion channels for encoded content |
 
 ---
 
@@ -90,6 +103,13 @@ Organizations implementing 11.10.3 must navigate a documented three-way trade-of
 - AISVS C2 (User Input Validation) -- Input-level defenses complementary to classifier-level robustness
 - AISVS C7 (Model Behavior) -- Output filtering complementary to bias-aware hardening
 - AISVS C11.2 (Adversarial-Example Hardening) -- General adversarial hardening; C11.10 adds subgroup-specific requirements
+- [NIST Cybersecurity Framework Profile for AI (Cyber AI Profile, Dec 2025)](https://nvlpubs.nist.gov/nistpubs/ir/2025/NIST.IR.8596.iprd.pdf) -- Overlays Secure/Detect/Thwart AI focus areas on CSF 2.0; adversarial robustness evaluation maps to the "Thwart" focus area
+- [NIST Dioptra](https://pages.nist.gov/dioptra/) -- Open-source platform for reproducible AI adversarial testing (v1.1.0)
+- [IBM HEART Library](https://github.com/IBM/heart-library) -- Hardened Extension of ART for T&E workflows (v0.7.0, July 2025)
+- [ICL-Evader (WWW '26)](https://github.com/ChaseSecurity/ICL-Evader) -- Zero-query black-box evasion of ICL classifiers with joint defense recipe
+- [AnyAttack (CVPR 2025)](https://arxiv.org/abs/2410.05346) -- Self-supervised adversarial attacks on vision-language models
+- [MLCommons AILuminate Jailbreak Benchmark v0.5 (Dec 2025)](https://mlcommons.org/) -- Standardized evaluation of LLM safety filter robustness
+- Balagopalan, "Operationalizing Reliable Machine Learning: From Data" (MIT PhD thesis, 2025) -- Practical guidance on fairness-aware robustness in production ML
 
 ---
 
@@ -101,5 +121,8 @@ Organizations implementing 11.10.3 must navigate a documented three-way trade-of
 - Can subgroup-robust adversarial training be adapted for LLMs, or does it remain limited to traditional classifiers?
 - What metrics best capture "meaningful behavioral change" across subgroups for security classifiers -- is adversarial FNR sufficient, or are distribution-aware metrics needed?
 - How should organizations prioritize which subgroups to evaluate when the input space is high-dimensional and subgroup definitions are not obvious?
+- Do in-context-learning classifiers inherit and amplify subgroup robustness gaps from their example selection, and can defense recipes (as in ICL-Evader) generalize across domains?
+- As vision-language models become security-relevant classifiers (content moderation, phishing detection), how should subgroup robustness evaluation extend to multimodal inputs where "subgroup" spans both visual and textual dimensions?
+- Can standardized benchmarks like MLCommons AILuminate be extended to measure per-subgroup jailbreak success rates, making bias-as-evasion a first-class evaluation dimension?
 
 ---


### PR DESCRIPTION
Closes #361

Expanded the C11.10 adversarial bias exploitation defense wiki page from 105 to 128 lines with recent research findings:

- Added ICL-Evader (WWW 26) zero-query black-box evasion of ICL classifiers
- Added AnyAttack (CVPR 2025) transferable adversarial attacks on VLMs
- Added IBM HEART v0.7.0, NIST Dioptra v1.1.0, Microsoft Counterfit, MLCommons AILuminate to tools table
- Expanded content moderation evasion section with cipher and homoglyph techniques
- Added Balagopalan MIT thesis on operationalizing fairness-aware robustness
- Added NIST Cyber AI Profile (Dec 2025) to references
- New research questions on multimodal subgroup evaluation and ICL classifier bias