### PR TITLE
Wiki: freshen up C06 supply chain research

### DIFF
--- a/wiki/C06-Supply-Chain.md
+++ b/wiki/C06-Supply-Chain.md
@@ -7,7 +7,7 @@
 
 AI supply-chain attacks exploit third-party models, frameworks, or datasets to embed backdoors, bias, or exploitable code. These controls provide end-to-end traceability, vulnerability management, and monitoring to protect the entire model lifecycle.
 
-> **2025-2026 Highlights:** The AI BOM ecosystem (CycloneDX ML, SPDX AI) is gaining adoption alongside SLSA for ML pipelines. Malicious model discoveries on public registries continued to grow, reinforcing the need for model scanning and SafeTensors format enforcement as baseline controls.
+> **2025-2026 Highlights:** The AI BOM ecosystem (CycloneDX ML, SPDX AI) is gaining adoption alongside SLSA for ML pipelines. Malicious model discoveries on public registries continued to grow, reinforcing the need for model scanning and SafeTensors format enforcement as baseline controls. As of March 2026, AI agent skill marketplaces have emerged as a major new supply chain attack surface — the OpenClaw/ClawHavoc crisis (1,184 malicious skills, CVE-2026-25253) and AI-powered CI/CD attacks (Hackerbot-claw) demonstrate that supply chain threats are expanding beyond traditional package registries. IBM X-Force 2026 reports supply chain compromises have nearly quadrupled since 2020.
 
 ---
 
@@ -35,8 +35,11 @@ Known attacks, real-world incidents, and threat vectors relevant to this chapter
 - **Malicious LoRA/adapter weights** — LoRATK research showed single backdoored LoRA adapters can poison base models. CoLoRA (March 2026) distributes backdoor payloads across multiple adapters that only activate when merged — much harder to detect individually.
 - **Dataset poisoning at scale** — Researchers demonstrated poisoning LAION-400M for just $60 by re-registering expired domains. Just 250 poisoned documents can compromise LLMs regardless of total dataset size (October 2025 research).
 - **Typosquatting and dependency confusion** — 500+ malicious PyPI packages found in a single March 2024 campaign; Sonatype reports 2x year-over-year increase in repository attacks.
+- **AI agent skill marketplace poisoning** — The OpenClaw/ClawHavoc crisis (February–March 2026) saw 1,184 confirmed malicious skills on ClawHub (~20% of the registry). CVE-2026-25253 enabled RCE; attackers distributed Atomic macOS Stealer (AMOS) via prompt injection in skill descriptors, hidden reverse shells, and token exfiltration. Largest confirmed supply chain attack targeting AI agent infrastructure to date.
+- **AI-powered CI/CD exploitation** — Hackerbot-claw (tracked as "Chaos Agent" by Pillar Security, February 2026) used an LLM as an execution layer to scan for misconfigured GitHub Actions, open poisoned PRs, and exfiltrate secrets from Microsoft, Datadog, and Aqua Security repos. CVE-2026-28353 compromised the Trivy VS Code extension.
 - **Model distillation via API abuse** — Anthropic disclosed (February 2026) that DeepSeek, Moonshot AI, and MiniMax used ~24,000 fake accounts to generate 16 million conversations for training data extraction.
 - **SafeTensors conversion bot hijack** — HiddenLayer demonstrated hijacking Hugging Face's SFConvertbot (42,657+ PRs made) to submit malicious model conversions to any repository.
+- **Supply chain compromise acceleration** — IBM X-Force 2026 Threat Index (February 2026) reports supply chain and third-party compromises have nearly quadrupled since 2020, driven by exploitation of CI/CD automation and trust relationships. Vulnerability exploitation is now the leading initial access vector at 40% of observed incidents.
 
 ### Notable Incidents & Research
 
@@ -51,6 +54,9 @@ Known attacks, real-world incidents, and threat vectors relevant to this chapter
 | Feb 2026 | Anthropic: 24K fake accounts used for Claude distillation | DeepSeek, Moonshot, MiniMax generated 16M conversations for training data extraction | [CNBC](https://www.cnbc.com/2026/02/24/anthropic-openai-china-firms-distillation-deepseek.html) |
 | 2024 | LAION-400M poisoning for $60 (Carlini et al.) | Web-scale dataset poisoning via expired domain re-registration; 0.00025% poison rate achieves 60% success | [arXiv 2302.10149](https://arxiv.org/abs/2302.10149) |
 | Sep 2025 | GhostAction — GitHub Actions supply chain attack | 3,325 secrets exfiltrated from 817 repos including PyPI/npm/DockerHub tokens | [GitGuardian](https://blog.gitguardian.com/protecting-your-software-supply-chain-understanding-typosquatting-and-dependency-confusion-attacks/) |
+| Feb–Mar 2026 | OpenClaw/ClawHavoc — 1,184 malicious skills on ClawHub marketplace | CVE-2026-25253 RCE; ~20% of registry malicious; Atomic macOS Stealer distributed via prompt injection in skill descriptors | [Trend Micro](https://www.trendmicro.com/en_us/research/26/b/openclaw-skills-used-to-distribute-atomic-macos-stealer.html) |
+| Feb 2026 | Hackerbot-claw ("Chaos Agent") — AI bot exploiting CI/CD pipelines | LLM-powered bot opened poisoned PRs against Microsoft, Datadog, Aqua Security repos; CVE-2026-28353 compromised Trivy VS Code extension | [Hacker News](https://thehackernews.com/2026/03/five-malicious-rust-crates-and-ai-bot.html) |
+| Feb 2026 | IBM X-Force 2026 Threat Index — supply chain compromises nearly 4x since 2020 | 44% surge in exploitation of public-facing apps; vulnerability exploitation is now leading initial access vector (40% of incidents) | [IBM Newsroom](https://newsroom.ibm.com/2026-02-25-ibm-2026-x-force-threat-index-ai-driven-attacks-are-escalating-as-basic-security-gaps-leave-enterprises-exposed) |
 
 ---
 
@@ -62,7 +68,8 @@ Current tools, frameworks, and libraries that help implement these controls:
 - **Safe serialization:** [SafeTensors](https://huggingface.co/docs/safetensors/index) (Rust-based, no code execution by design, passed external security audit; as of June 2025, native PyTorch DCP support via torchtune; adoption growing but 59% of HF models still use unsafe formats)
 - **Model signing:** [OpenSSF Model Signing v1.0](https://github.com/sigstore/model-transparency) (released April 2025, v1.1.1 Oct 2025 — signs/verifies any model format via Sigstore; NVIDIA signs all NGC models with OMS since March 2025), [Sigstore/cosign](https://www.sigstore.dev/) (keyless signing for containers and OCI artifacts)
 - **AI BOM / ML BOM:** [CycloneDX ML-BOM](https://cyclonedx.org/capabilities/mlbom/) (v1.5+ stable through v1.7/ECMA-424), [SPDX AI Profile](https://spdx.dev/) (v3.0.1 with AI and Dataset profiles), [OWASP AIBOM Generator](https://owasp.org/www-project-aibom/) (scans repos for HF model usage, generates CycloneDX AI BOMs), Dependency-Track
-- **Dependency scanning:** Dependabot, Snyk, [OSV Scanner](https://google.github.io/osv-scanner/) (Google), Grype, Trivy, [Socket.dev](https://socket.dev/) (10K+ orgs, proactive supply chain protection) — *note: no mainstream SCA tool scans model files as dependencies; model-hub references in code are invisible to these tools*
+- **AI-aware SCA platforms:** [Sonatype Lifecycle](https://help.sonatype.com/en/threats-in-ai-ml-models.html) (scans Hugging Face models for malware, pickle execution risks, license issues, and derivative model provenance — supports `.bin`, `.pt`, `.pkl`, `.pickle` formats), [Manifest](https://www.manifestcyber.com/) (continuous AI model scanning with daily HF assessments; added C/C++ SBOM generator March 2026)
+- **Dependency scanning:** Dependabot, Snyk, [OSV Scanner](https://google.github.io/osv-scanner/) (Google), Grype, Trivy, [Socket.dev](https://socket.dev/) (10K+ orgs, proactive supply chain protection) — *note: most traditional SCA tools still don't scan model files as dependencies, though Sonatype Lifecycle is closing this gap for HF-hosted models*
 - **Dataset validation:** [Cleanlab](https://github.com/cleanlab/cleanlab) (label errors, outliers, duplicates — found thousands of errors in ImageNet), [Great Expectations](https://greatexpectations.io/) (data validation framework), Presidio (PII detection)
 - **Registry security:** Hugging Face multi-layer scanning (ClamAV + PickleScan + TruffleHog + Guardian since Oct 2024), model cards, SafeTensors conversion bot
 - **Provenance & build security:** [SLSA framework](https://slsa.dev/) (L3 achievable via GitHub Actions + Sigstore), [in-toto](https://in-toto.io/), Rekor transparency log
@@ -72,11 +79,11 @@ Current tools, frameworks, and libraries that help implement these controls:
 | Control Area | Tooling Maturity | Notes |
 |--------------|:---:|-------|
 | C6.1 Pretrained Model Vetting | Maturing | Guardian scanned 4.47M model versions; Fickling's allowlist approach achieves 100% pickle detection. OpenSSF Model Signing v1.0 (April 2025) fills the signing gap. Trojan/behavioral backdoor detection remains limited. |
-| C6.2 Framework & Library Scanning | Mature | Standard SCA tools (Trivy, Snyk, Dependabot) handle ML Python deps well. Gap: no tool scans model files or CUDA native libraries as first-class artifacts. |
+| C6.2 Framework & Library Scanning | Mature | Standard SCA tools (Trivy, Snyk, Dependabot) handle ML Python deps well. Sonatype Lifecycle now scans HF model artifacts for malware and pickle risks. Gap: CUDA native libraries and custom operators still not first-class scan targets. |
 | C6.3 Dependency Pinning & Verification | Mature | pip/conda/Docker lockfile tooling is production-ready. SLSA L3 achievable via GitHub Actions + Sigstore. Reproducible builds (C6.3.5) still challenging for large training runs. |
 | C6.4 Trusted Source Enforcement | Maturing | Container signing mature (cosign); model signing now viable via OMS v1.0 (NVIDIA signs all NGC models). Egress controls and quarantine tooling are established. |
 | C6.5 Third-Party Dataset Risk | Emerging | Cleanlab handles data quality/outliers but not adversarial poisoning. LAION-400M poisoning for $60 demonstrates the practical risk. PII scrubbing via Presidio is mature; bias metrics tooling exists (Fairlearn). |
-| C6.6 Supply Chain Attack Monitoring | Emerging | AI-specific threat intelligence is very limited. No ML-focused SIEM detection rules widely available. Socket.dev provides proactive package analysis but doesn't cover model artifacts. |
+| C6.6 Supply Chain Attack Monitoring | Emerging | AI-specific threat intelligence is improving but still limited. IBM X-Force 2026 now tracks AI supply chain trends (4x increase since 2020). No ML-focused SIEM detection rules widely available. Socket.dev provides proactive package analysis; Manifest offers daily model risk assessments. The OpenClaw/ClawHavoc crisis demonstrated how fast AI agent marketplaces can become attack vectors. |
 | C6.7 AI BOM for Model Artifacts | Maturing | CycloneDX ML-BOM stable through v1.7 (ECMA-424). OWASP AIBOM Generator produces CycloneDX output from HF model references. SPDX 3.0.1 adds AI profiles. Adoption still early but tooling is real. |
 
 ---
@@ -94,6 +101,7 @@ Current tools, frameworks, and libraries that help implement these controls:
 - [SLSA Framework](https://slsa.dev/) — L3 achievable for ML packaging pipelines via GitHub Actions + Sigstore
 - [ISO/IEC 42001:2023](https://www.iso.org/standard/81230.html) — AI management systems; requires supplier risk assessment, security protocol enforcement across AI supply chain
 - [NIST AI RMF](https://airc.nist.gov/AI_RMF_Interactivity) — MAP/MEASURE/MANAGE functions address supply chain dependencies
+- [IBM X-Force 2026 Threat Intelligence Index](https://newsroom.ibm.com/2026-02-25-ibm-2026-x-force-threat-index-ai-driven-attacks-are-escalating-as-basic-security-gaps-leave-enterprises-exposed) — Quantifies supply chain/third-party compromises at nearly 4x since 2020; vulnerability exploitation now leading initial access vector (40%)
 
 ### AISVS Cross-Chapter Links
 
@@ -104,6 +112,7 @@ Current tools, frameworks, and libraries that help implement these controls:
 | [C04 Infrastructure](C04-Infrastructure.md) | Build pipeline and container security | C6.2/C6.3 pinning and scanning overlap with C04 infrastructure hardening. ATLAS AML.T0010.004 targets container registries. SLSA L2/L3 build requirements apply to C04.2 pipelines. |
 | [C07 Model Behavior](C07-Model-Behavior.md) | Behavioral impact of supply chain attacks | Compromised models (AML.T0010.003) and backdoored LoRA adapters produce malicious model behavior. OWASP LLM03 covers input-triggered backdoors. |
 | [C11 Adversarial Robustness](C11-Adversarial-Robustness.md) | Backdoors from poisoned data/models | AML.T0010.002 + .003 enable backdoor insertion. CoLoRA shows colluding adapters can bypass individual detection. EU AI Act Art 15 robustness requirements apply to supply-chain-introduced backdoors. |
+| [C09 Orchestration & Agents](C09-Orchestration-and-Agents.md) | Agent skill/plugin marketplace supply chain | OpenClaw/ClawHavoc (1,184 malicious skills) demonstrates that AI agent ecosystems create new supply chain attack surfaces beyond traditional package registries. C6.4 trusted-source controls apply to skill marketplaces. |
 | [C13 Monitoring & Logging](C13-Monitoring-and-Logging.md) | Anomaly detection and incident response | C6.6 monitoring requirements feed into C13 centralized logging. CI/CD audit logs (C6.6.2) need C13 infrastructure for detection. |
 
 ---
@@ -114,7 +123,8 @@ Current tools, frameworks, and libraries that help implement these controls:
 - [ ] **Can dataset poisoning detection scale to web-crawled datasets?** — With 250 poison samples sufficient regardless of dataset size, and LAION-scale poisoning possible for $60, current outlier detection tools may not be sufficient.
 - [ ] **Will model signing achieve critical adoption?** — OMS v1.0 exists and NVIDIA signed all NGC models, but Hugging Face hasn't adopted it natively. Until signing is the default, not the exception, supply chain integrity remains opt-in.
 - [ ] **How should AI-specific threat intelligence feeds work?** — C6.6.3 requires ML-focused IoCs but no production threat intelligence service covers model poisoning indicators, malicious adapter fingerprints, or dataset corruption signatures.
-- [ ] **What happens when SCA tools can scan model files?** — No mainstream SCA tool (Trivy, Snyk, Dependabot) treats model files as scannable dependencies. The OWASP AIBOM Generator bridges part of this gap but a full solution is needed.
+- [ ] **What happens when SCA tools can scan model files?** — Sonatype Lifecycle now scans HF models for pickle risks and malware, but most SCA tools (Trivy, Snyk, Dependabot) still don't treat model files as scannable dependencies. The OWASP AIBOM Generator bridges part of this gap but a full solution is needed.
+- [ ] **How should AI agent skill marketplaces be secured?** — The OpenClaw/ClawHavoc crisis showed that agent skill registries face the same supply chain risks as package managers, but with unique attack vectors (prompt injection in descriptors, LLM-mediated execution). No established vetting framework exists for AI agent skills yet.
 
 ---
 

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -17,7 +17,7 @@ The standard is organized into 14 chapters spanning the full AI application secu
 | C3 | Model Lifecycle Management | 24 | [C03](C03-Model-Lifecycle-Management.md) | Single | 2026-03-22 |
 | C4 | Infrastructure & Deployment Security | 46 | [C04](C04-Infrastructure.md) | [8 sections](#c4-infrastructure--deployment-security) | 2026-03-22 |
 | C5 | Access Control & Identity | 26 | [C05](C05-Access-Control.md) | Single | 2026-03-22 |
-| C6 | Supply Chain Security | 33 | [C06](C06-Supply-Chain.md) | [7 sections](#c6-supply-chain-security) | 2026-03-21 |
+| C6 | Supply Chain Security | 33 | [C06](C06-Supply-Chain.md) | [7 sections](#c6-supply-chain-security) | 2026-03-22 |
 | C7 | Model Behavior & Output Control | 33 | [C07](C07-Model-Behavior.md) | [8 sections](#c7-model-behavior--output-control) | 2026-03-22 |
 | C8 | Memory, Embeddings & Vector DB Security | 25 | [C08](C08-Memory-and-Embeddings.md) | Single | 2026-03-22 |
 | C9 | Orchestration & Agentic Action Security | 36 | [C09](C09-Orchestration-and-Agents.md) | [8 sections](#c9-orchestration--agentic-action-security) | 2026-03-21 |


### PR DESCRIPTION
Closes #409

Refreshed the C06 Supply Chain chapter page with recent incidents and tooling developments:

- **New incidents:** Added OpenClaw/ClawHavoc crisis (1,184 malicious skills on ClawHub, CVE-2026-25253), Hackerbot-claw AI-powered CI/CD exploitation (CVE-2026-28353), and IBM X-Force 2026 stats showing supply chain compromises nearly 4x since 2020
- **New tooling:** Added Sonatype Lifecycle (scans HF models for pickle risks, malware, license issues) and Manifest (continuous AI model scanning with daily assessments) to the tooling section
- **Updated maturity ratings:** C6.2 and C6.6 ratings updated to reflect new tooling and threat landscape
- **New cross-chapter link:** Added C09 Orchestration & Agents link since OpenClaw demonstrates agent skill marketplaces as new supply chain attack surfaces
- **New research question:** How should AI agent skill marketplaces be secured?
- **Updated highlights** to reflect the agent marketplace supply chain trend