### PR TITLE
proposal: merge duplicate parameter-binding requirement from C9.7.2 into C9.2.2

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -99,7 +99,7 @@ Prevent "technically authorized but unintended" actions by binding execution to 
 | **9.7.2** | **Verify that** post-execution checks confirm the intended outcome was achieved. | 2 | V |
 | **9.7.3** | **Verify that** post-execution checks detect unintended side effects. | 2 | V |
 | **9.7.4** | **Verify that** any mismatch between intended outcome and actual results triggers containment and, where supported, compensating actions. | 2 | V |
-| **9.7.5** | **Verify that** prompt templates and agent policy configurations are integrity-verified at load time against their approved versions (e.g., via hashes or signatures). | 3 | D/V |
+| **9.7.5** | **Verify that** prompt templates and agent policy configurations retrieved from a remote source are integrity-verified at load time against their approved versions (e.g., via hashes or signatures). | 3 | D/V |
 
 ---
 


### PR DESCRIPTION
C9.2.2 and C9.7.2 both addressed the same attack - binding approvals to exact action parameters to prevent "approve one thing, execute another" / substituted approvals. The core requirement was duplicated across two sections (C9.2 HITL approval gates, C9.7 intent verification).

Resolution:
- Enrich C9.2.2 with the unique aspects of C9.7.2 (integrity-protection of the approval itself, expiry) so all three properties live together: present parameters → integrity-protect the approval → bind to params → expire
- Remove old C9.7.2 (now covered by C9.2.2)
- Renumber C9.7.3 → C9.7.2 and C9.7.4 → C9.7.3

This is a PROPOSAL for discussion - please review whether the merged wording captures the full intent of both original controls before merging.