### PR TITLE
wiki: freshen up C11-10 adversarial bias exploitation research

### DIFF
--- a/wiki/C11-10-Adversarial-Bias-Exploitation-Defense.md
+++ b/wiki/C11-10-Adversarial-Bias-Exploitation-Defense.md
@@ -36,6 +36,14 @@ The core threat model for this section is distinct from fairness or ethical bias
 
 **AnyAttack — self-supervised adversarial attacks on vision-language models (CVPR 2025):** Pre-trained on LAION-400M without label supervision, AnyAttack generates targeted adversarial images that transfer across VLMs including CLIP, BLIP2, InstructBLIP, MiniGPT-4, and commercial systems (Gemini, Claude Sonnet, Microsoft Copilot). The attack exploits learned biases in vision encoders — perturbations that shift embeddings toward target representations work precisely because models have uneven robustness across visual concepts. This extends the bias-as-evasion pattern from traditional classifiers into the multimodal domain.
 
+### Adversarial Data Poisoning as a Bias Weaponization Vector
+
+A distinct but related threat is adversarial data poisoning that deliberately introduces or amplifies bias in security-relevant classifiers. Chan & Tong ("Adversarial Bias: Data Poisoning Attacks on Fairness," November 2025) demonstrated that injecting a small fraction of carefully crafted adversarial data points into a training set can induce maximally unfair behavior in classifiers while preserving overall accuracy — making the attack difficult to detect via standard performance monitoring. Their Proportional Fairness Attack (PFA) leverages a surrogate model and dynamic proportional sampling to target the smallest subgroup with the least-frequent label, precisely because fair models give higher weight to under-represented distribution regions. This is directly relevant to 11.10.3: an adversary with training pipeline access could poison a security classifier to create exploitable subgroup gaps that survive standard adversarial training. Defenders must treat training data integrity (C1) and subgroup robustness monitoring (11.10.2) as complementary controls — neither alone is sufficient.
+
+### Fairness Drift as a Post-Deployment Attack Surface
+
+Even thoroughly audited models drift once deployed to production. New demographics, changing user behaviors, or seasonal patterns can unexpectedly shift error rates across subgroups, creating exploitable disparities that did not exist at evaluation time. Traditional periodic audits (monthly or quarterly) miss these shifts, leaving bias gaps undetected for weeks. As of March 2026, the emerging concept of "fairness drift" (JAMIA, 2025) frames this as a first-class maintenance concern: continuous monitoring of per-subgroup metrics — not just aggregate performance — is necessary to catch drift-induced bias before adversaries discover it through probing (11.10.1). This reinforces the non-regression testing requirement in 11.10.3: tracking per-subgroup robustness across releases is necessary but not sufficient; organizations should also monitor for inter-release drift during live deployment.
+
 ### Adversarial Training Creates Robustness Disparities
 
 A key finding from 2021-2025 research is that adversarial training itself can create or amplify subgroup robustness gaps:
@@ -53,11 +61,15 @@ Organizations implementing 11.10.3 must navigate a documented three-way trade-of
 - **"Triangular Trade-off between Robustness, Accuracy, and Fairness in DNNs" (ACM Computing Surveys, 2024):** The most comprehensive analysis showing that improving any one of accuracy, robustness, or fairness typically degrades at least one of the others. This trade-off is fundamental, not merely a tooling limitation.
 - **Practical implication:** Per-subgroup robustness constraints may reduce aggregate robust accuracy or clean accuracy. The trade-off must be documented and accepted by stakeholders. Ensemble diversity across training distributions is a more practical starting point than per-subgroup loss constraints.
 
+### Regulatory Context: EU AI Act and Adversarial Robustness
+
+The EU AI Act's Article 15 explicitly requires high-risk AI systems to be "resilient against attempts by unauthorised third parties to alter their use, outputs or performance by exploiting system vulnerabilities." As of March 2026, full enforcement of high-risk system requirements under Annex III takes effect in August 2026, with penalties up to EUR 35 million or 7% of global annual turnover. For organizations deploying security-relevant classifiers in EU markets, 11.10.2's stratified robustness evaluation and 11.10.3's non-regression testing directly support the Article 15 conformity assessment. NIST AI 100-2e2025 (March 2025) provides complementary voluntary guidance, significantly expanding the 2023 taxonomy with coverage of GenAI-specific threats, prompt injection, autonomous agent risks, and AI supply chain security. Together, these frameworks create a converging expectation that adversarial robustness evaluation must account for subgroup-specific performance — not just aggregate metrics.
+
 ### Tools Landscape
 
 | Tool | Maintainer | Use Case | Maturity |
 |------|-----------|----------|----------|
-| **IBM Adversarial Robustness Toolbox (ART)** | LF AI & Data | Adversarial attack generation, defense evaluation across all major ML frameworks | **High** (v1.17+) |
+| **IBM Adversarial Robustness Toolbox (ART)** | LF AI & Data | Adversarial attack generation, defense evaluation across all major ML frameworks; v1.20.0 adds GREAT Score for generative-model-based robustness evaluation | **High** (v1.20.0) |
 | **Microsoft Fairlearn** | Microsoft / Community | Per-subgroup metric calculation via `MetricFrame`, bias mitigation | **High** |
 | **IBM AI Fairness 360 (AIF360)** | LF AI & Data | 70+ fairness metrics, bias mitigation algorithms | **High** (v0.6+) |
 | **TextAttack** | QData Lab | NLP-specific adversarial attack framework for text-domain evaluation | **High** |
@@ -84,6 +96,7 @@ Organizations implementing 11.10.3 must navigate a documented three-way trade-of
 | 2025 | **Android malware GAN evasion** -- Black-box GAN attacks achieving 95%+ evasion against malware detection while preserving malicious functionality | Automated adversarial generation targeting model weaknesses |
 | 2025 | **AnyAttack against commercial VLMs (CVPR 2025)** -- Self-supervised adversarial perturbations transfer across CLIP, BLIP2, Gemini, Claude Sonnet, and Microsoft Copilot, exploiting uneven robustness across visual concept embeddings | Extends bias-as-evasion from classifiers into multimodal domain |
 | 2026 | **ICL-Evader zero-query evasion (WWW '26)** -- 95.3% attack success rate against LLM-based in-context-learning classifiers with no query access required; structural bias from uneven example coverage enables targeted evasion | Demonstrates that prompt-based classifiers inherit subgroup robustness gaps from example selection |
+| 2025 | **EchoLeak zero-click prompt injection (CVE-2025-32711)** -- Poisoned email with encoded character substitutions forced Microsoft 365 Copilot to exfiltrate sensitive business data to an external URL, bypassing safety filters via character-level evasion | Character substitution exploits structural bias in safety filter tokenization — filters trained on standard character sets miss encoded equivalents |
 | 2025-2026 | **Cipher and homoglyph evasion of content filters** -- Base64, hex encoding, and Unicode homoglyph substitution bypass keyword-based content moderation at scale; multi-agent frameworks automate cipher rotation | Keyword filters are structurally biased toward Latin-script detection, creating reliable evasion channels for encoded content |
 
 ---
@@ -94,7 +107,7 @@ Organizations implementing 11.10.3 must navigate a documented three-way trade-of
 - [MITRE ATLAS: Evade ML Model (AML.T0015)](https://atlas.mitre.org/techniques/AML.T0015) -- Primary evasion technique; subgroup disparity is an enabler
 - [MITRE ATLAS: Craft Adversarial Data (AML.T0043)](https://atlas.mitre.org/techniques/AML.T0043) -- Creating inputs that exploit discovered weaknesses
 - [MITRE ATLAS Case Study: Bypass Cylance's AI Malware Detection (AML.CS0003)](https://atlas.mitre.org/studies/AML.CS0003) -- Canonical bias-based evasion
-- [NIST AI 100-2 E2025 -- Adversarial Machine Learning Taxonomy](https://csrc.nist.gov/pubs/ai/100/2/e2023/final) -- Updated taxonomy covering evasion attack variation across input distributions
+- [NIST AI 100-2 E2025 -- Adversarial Machine Learning Taxonomy](https://csrc.nist.gov/pubs/ai/100/2/e2025/final) -- March 2025 revision expanding coverage to GenAI threats, prompt injection, autonomous agents, and AI supply chain risks; supersedes e2023
 - [IBM Adversarial Robustness Toolbox (ART)](https://github.com/Trusted-AI/adversarial-robustness-toolbox) -- Attack generation and defense evaluation
 - [Microsoft Fairlearn](https://fairlearn.org/) -- Per-subgroup metric calculation
 - [IBM AI Fairness 360](https://aif360.res.ibm.com/) -- Fairness metrics and bias mitigation
@@ -110,6 +123,9 @@ Organizations implementing 11.10.3 must navigate a documented three-way trade-of
 - [AnyAttack (CVPR 2025)](https://arxiv.org/abs/2410.05346) -- Self-supervised adversarial attacks on vision-language models
 - [MLCommons AILuminate Jailbreak Benchmark v0.5 (Dec 2025)](https://mlcommons.org/) -- Standardized evaluation of LLM safety filter robustness
 - Balagopalan, "Operationalizing Reliable Machine Learning: From Data" (MIT PhD thesis, 2025) -- Practical guidance on fairness-aware robustness in production ML
+- Chan & Tong, "Adversarial Bias: Data Poisoning Attacks on Fairness" (November 2025) -- Demonstrates small poisoning injections can induce maximally unfair classifier behavior while preserving accuracy
+- [EU AI Act Article 15: Accuracy, Robustness and Cybersecurity](https://artificialintelligenceact.eu/article/15/) -- High-risk AI systems must demonstrate resilience against adversarial manipulation; full enforcement August 2026
+- "Fairness Drift as the Next Dimension of Model Maintenance" (JAMIA, 2025) -- Frames post-deployment bias shift as a first-class maintenance and security concern
 
 ---
 
@@ -124,5 +140,7 @@ Organizations implementing 11.10.3 must navigate a documented three-way trade-of
 - Do in-context-learning classifiers inherit and amplify subgroup robustness gaps from their example selection, and can defense recipes (as in ICL-Evader) generalize across domains?
 - As vision-language models become security-relevant classifiers (content moderation, phishing detection), how should subgroup robustness evaluation extend to multimodal inputs where "subgroup" spans both visual and textual dimensions?
 - Can standardized benchmarks like MLCommons AILuminate be extended to measure per-subgroup jailbreak success rates, making bias-as-evasion a first-class evaluation dimension?
+- How should organizations detect and defend against adversarial data poisoning that deliberately introduces subgroup bias (as in Chan & Tong 2025) versus bias that emerges organically from data collection?
+- As fairness drift becomes recognized as a maintenance concern, what monitoring cadence and threshold sensitivity are needed to catch drift-induced exploitable disparities before adversaries discover them?
 
 ---


### PR DESCRIPTION
Closes #568

Refreshed the C11.10 Adversarial Bias Exploitation Defense page with recent findings:

- **New section on adversarial data poisoning as a bias weaponization vector** — Chan & Tong (Nov 2025) showed that small poisoning injections can induce maximally unfair classifier behavior while preserving overall accuracy, making it hard to detect via standard metrics. Their Proportional Fairness Attack targets the smallest subgroup, which is exactly the kind of gap 11.10.2 and 11.10.3 are designed to catch.

- **Fairness drift as a post-deployment attack surface** — Even thoroughly audited models drift in production. Added coverage of how changing demographics and behaviors create exploitable subgroup gaps between audit cycles.

- **EU AI Act Article 15 regulatory context** — Article 15 requires high-risk systems to be resilient against adversarial manipulation, with full Annex III enforcement in August 2026. This maps well to our 11.10.2/11.10.3 evaluation requirements.

- **NIST AI 100-2e2025** — Updated the reference from the 2023 edition. The March 2025 revision substantially expands coverage to GenAI threats, prompt injection, and AI supply chain risks.

- **ART v1.20.0** — Updated version reference; adds GREAT Score for generative-model-based robustness evaluation.

- **EchoLeak incident (CVE-2025-32711)** — Zero-click prompt injection in Microsoft 365 Copilot using character substitutions that bypass safety filters, illustrating how tokenization-level bias creates evasion channels.

Also added two new open research questions on defending against deliberate fairness poisoning and monitoring cadence for drift-induced bias.