### PR TITLE
Make markdown lint diff-aware

### DIFF
--- a/.github/workflows/markdown_linter.yml
+++ b/.github/workflows/markdown_linter.yml
@@ -14,13 +14,38 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
-      - name: markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@v2.0.0
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install markdownlint-cli
+        run: npm install -g markdownlint-cli
+
+      - name: Get changed markdown files
+        id: files
+        uses: tj-actions/changed-files@v46
         with:
           files: |
-            ./README.md
-            ./wiki/**/*.md
-            ./1.0/en/**/*.md
-          config_file: ".github/workflows/config/markdownlint.jsonc"
-          ignore_files: ""
+            README.md
+            wiki/**/*.md
+            1.0/en/**/*.md
+
+      - name: Run markdownlint on changed files
+        if: steps.files.outputs.any_changed == 'true'
+        run: |
+          files_string="${{ steps.files.outputs.all_changed_files }}"
+          files_string="${files_string//\\n/$'\n'}"
+          files=()
+          while IFS= read -r file; do
+            [ -n "$file" ] && files+=("$file")
+          done <<< "$files_string"
+
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No files to check."
+            exit 0
+          fi
+
+          markdownlint --config .github/workflows/config/markdownlint.jsonc "${files[@]}"


### PR DESCRIPTION
This adjusts the markdown lint workflow so it checks changed markdown files instead of trying to lint the entire docs tree on every run.

The previous expansion exposed a large backlog of existing wiki formatting issues, which is useful to know, but it made the workflow fail on unrelated historical content. This keeps the guardrail in place for new changes while we handle any broader cleanup separately.

It also avoids the oversized failure output that showed up in the Actions log.

Summary:
- switch markdown lint to changed files
- keep coverage on README.md, wiki markdown, and 1.0/en docs
- preserve the current markdownlint config