### PR TITLE
fix(C13): merge C13.3 and C13.6 into unified drift detection section

### DIFF
--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -7,14 +7,14 @@ This section provides requirements for delivering real-time and forensic visibil
 ## C13.1 Request & Response Logging
 
 | # | Description | Level | Role |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **13.1.1** | **Verify that** AI interactions are logged with security-relevant metadata (e.g. timestamp, user ID, session ID, model version, token count, input hash, system prompt version, confidence score, safety filter outcome, and safety filter decisions) without logging prompt or response content by default. | 1   | D/V |
-| **13.1.2** | **Verify that** logs are stored in secure, access-controlled repositories with appropriate retention policies and backup procedures. | 1   | D/V |
-| **13.1.3** | **Verify that** log storage systems implement encryption at rest and in transit to protect sensitive information contained in logs. | 1   | D/V |
-| **13.1.4** | **Verify that** sensitive data in prompts and outputs is automatically redacted or masked before logging, with configurable redaction rules for PII, credentials, and proprietary information. | 1   | D/V |
-| **13.1.5** | **Verify that** policy decisions and safety filtering actions are logged with sufficient detail to enable audit and debugging of content moderation systems. | 2   | D/V |
-| **13.1.6** | **Verify that** log integrity is protected through e.g. cryptographic signatures or write-only storage. | 2   | D/V |
-| **13.1.7** | **Verify that** log entries for AI inference events capture a structured, interoperable schema that includes at minimum model identifier, token usage (input and output), provider name, and operation type, to enable consistent AI observability across tools and platforms. | 2   | D/V |
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: | :---: |
+| **13.1.1** | **Verify that** AI interactions are logged with security-relevant metadata (e.g. timestamp, user ID, session ID, model version, token count, input hash, system prompt version, confidence score, safety filter outcome, and safety filter decisions) without logging prompt or response content by default. | 1 | D/V |
+| **13.1.2** | **Verify that** logs are stored in secure, access-controlled repositories with appropriate retention policies and backup procedures. | 1 | D/V |
+| **13.1.3** | **Verify that** log storage systems implement encryption at rest and in transit to protect sensitive information contained in logs. | 1 | D/V |
+| **13.1.4** | **Verify that** sensitive data in prompts and outputs is automatically redacted or masked before logging, with configurable redaction rules for PII, credentials, and proprietary information. | 1 | D/V |
+| **13.1.5** | **Verify that** policy decisions and safety filtering actions are logged with sufficient detail to enable audit and debugging of content moderation systems. | 2 | D/V |
+| **13.1.6** | **Verify that** log integrity is protected through e.g. cryptographic signatures or write-only storage. | 2 | D/V |
+| **13.1.7** | **Verify that** log entries for AI inference events capture a structured, interoperable schema that includes at minimum model identifier, token usage (input and output), provider name, and operation type, to enable consistent AI observability across tools and platforms. | 2 | D/V |
 | **13.1.8** | **Verify that** full prompt and response content is logged only when a security-relevant event is detected (e.g., safety filter trigger, prompt injection detection, anomaly flag), or when required by explicit user consent and a documented legal basis. | 2 | D/V |
 
 ---
@@ -22,17 +22,17 @@ This section provides requirements for delivering real-time and forensic visibil
 ## C13.2 Abuse Detection and Alerting
 
 | # | Description | Level | Role |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **13.2.1** | **Verify that** the system detects and alerts on known jailbreak patterns, prompt injection attempts, and adversarial inputs using signature-based detection. | 1   | D/V |
-| **13.2.2** | **Verify that** the system integrates with existing Security Information and Event Management (SIEM) platforms using standard log formats and protocols. | 1   | D/V |
-| **13.2.3** | **Verify that** enriched security events include AI-specific context such as model identifiers, confidence scores, and safety filter decisions. | 2   | D/V |
-| **13.2.4** | **Verify that** behavioral anomaly detection identifies unusual conversation patterns, excessive retry attempts, or systematic probing behaviors. | 2   | D/V |
-| **13.2.5** | **Verify that** real-time alerting mechanisms notify security teams when potential policy violations or attack attempts are detected. | 2   | D/V |
-| **13.2.6** | **Verify that** custom rules are included to detect AI-specific threat patterns including coordinated jailbreak attempts, prompt injection campaigns, and model extraction attacks. | 2   | D/V |
-| **13.2.7** | **Verify that** automated incident response workflows can isolate compromised models, block malicious users, and escalate critical security events. | 3   | D/V |
-| **13.2.8** | **Verify that** session-level conversation trajectory analysis detects multi-turn jailbreak patterns where no individual turn is overtly malicious in isolation but the aggregate conversation exhibits attack indicators. | 3   | D/V |
-| **13.2.9** | **Verify that** per-user and per-session token consumption is tracked, with anomaly detection alerting when consumption exceeds defined thresholds. | 2   | D/V |
-| **13.2.10** | **Verify that** LLM API traffic is monitored for covert channel indicators, including Base64-encoded payloads, structured non-human query patterns, and communication signatures consistent with malware command-and-control activity using LLM endpoints. | 3   | D/V |
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: | :---: |
+| **13.2.1** | **Verify that** the system detects and alerts on known jailbreak patterns, prompt injection attempts, and adversarial inputs using signature-based detection. | 1 | D/V |
+| **13.2.2** | **Verify that** the system integrates with existing Security Information and Event Management (SIEM) platforms using standard log formats and protocols. | 1 | D/V |
+| **13.2.3** | **Verify that** enriched security events include AI-specific context such as model identifiers, confidence scores, and safety filter decisions. | 2 | D/V |
+| **13.2.4** | **Verify that** behavioral anomaly detection identifies unusual conversation patterns, excessive retry attempts, or systematic probing behaviors. | 2 | D/V |
+| **13.2.5** | **Verify that** real-time alerting mechanisms notify security teams when potential policy violations or attack attempts are detected. | 2 | D/V |
+| **13.2.6** | **Verify that** custom rules are included to detect AI-specific threat patterns including coordinated jailbreak attempts, prompt injection campaigns, and model extraction attacks. | 2 | D/V |
+| **13.2.7** | **Verify that** automated incident response workflows can isolate compromised models, block malicious users, and escalate critical security events. | 3 | D/V |
+| **13.2.8** | **Verify that** session-level conversation trajectory analysis detects multi-turn jailbreak patterns where no individual turn is overtly malicious in isolation but the aggregate conversation exhibits attack indicators. | 3 | D/V |
+| **13.2.9** | **Verify that** per-user and per-session token consumption is tracked, with anomaly detection alerting when consumption exceeds defined thresholds. | 2 | D/V |
+| **13.2.10** | **Verify that** LLM API traffic is monitored for covert channel indicators, including Base64-encoded payloads, structured non-human query patterns, and communication signatures consistent with malware command-and-control activity using LLM endpoints. | 3 | D/V |
 
 ---
 
@@ -41,7 +41,7 @@ This section provides requirements for delivering real-time and forensic visibil
 Monitor and detect drift and degradation across model outputs, input distributions, and data schemas to identify quality regressions and security-relevant behavioral shifts.
 
 | # | Description | Level | Role |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: | :---: |
 | **13.3.1** | **Verify that** model performance metrics (accuracy, precision, recall, F1 score, confidence scores, latency, and error rates) are continuously monitored across model versions and time periods and compared against documented baselines. | 1 | D/V |
 | **13.3.2** | **Verify that** baseline performance profiles are formally documented and version-controlled, and are reviewed at a defined frequency or after any model or data pipeline change. | 2 | D/V |
 | **13.3.3** | **Verify that** automated alerting triggers when performance metrics exceed predefined degradation thresholds or deviate significantly from baselines, and that alerts initiate model retraining or replacement workflows. | 2 | D/V |
@@ -57,22 +57,22 @@ Monitor and detect drift and degradation across model outputs, input distributio
 ## C13.4 Performance & Behavior Telemetry
 
 | # | Description | Level | Role |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **13.4.1** | **Verify that** operational metrics including request latency, token consumption, memory usage, and throughput are continuously collected and monitored. | 1   | D/V |
-| **13.4.2** | **Verify that** success and failure rates are tracked with categorization of error types and their root causes. | 1   | D/V |
-| **13.4.3** | **Verify that** resource utilization monitoring includes GPU/CPU usage, memory consumption, and storage requirements with alerting on threshold breaches. | 2   | D/V |
-| **13.4.4** | **Verify that** token usage is tracked at granular attribution levels including per user, per session, per feature endpoint, and per team or workspace. | 2   | D/V |
-| **13.4.5** | **Verify that** output-to-input token ratio anomalies are detected and alerted. | 2   | D/V |
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: | :---: |
+| **13.4.1** | **Verify that** operational metrics including request latency, token consumption, memory usage, and throughput are continuously collected and monitored. | 1 | D/V |
+| **13.4.2** | **Verify that** success and failure rates are tracked with categorization of error types and their root causes. | 1 | D/V |
+| **13.4.3** | **Verify that** resource utilization monitoring includes GPU/CPU usage, memory consumption, and storage requirements with alerting on threshold breaches. | 2 | D/V |
+| **13.4.4** | **Verify that** token usage is tracked at granular attribution levels including per user, per session, per feature endpoint, and per team or workspace. | 2 | D/V |
+| **13.4.5** | **Verify that** output-to-input token ratio anomalies are detected and alerted. | 2 | D/V |
 
 ---
 
 ## C13.5 AI Incident Response Planning & Execution
 
 | # | Description | Level | Role |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
-| **13.5.1** | **Verify that** incident response plans specifically address AI-related security events including model compromise, data poisoning, adversarial attacks, model inversion, prompt injection campaigns, and model extraction, with specific containment and investigation steps for each scenario. | 1   | D/V |
-| **13.5.2** | **Verify that** incident response teams have access to AI-specific forensic tools and expertise to investigate model behavior and attack vectors. | 2   | D/V |
-| **13.5.3** | **Verify that** post-incident analysis includes model retraining considerations, safety filter updates, and lessons learned integration into security controls. | 3   | D/V |
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: | :---: |
+| **13.5.1** | **Verify that** incident response plans specifically address AI-related security events including model compromise, data poisoning, adversarial attacks, model inversion, prompt injection campaigns, and model extraction, with specific containment and investigation steps for each scenario. | 1 | D/V |
+| **13.5.2** | **Verify that** incident response teams have access to AI-specific forensic tools and expertise to investigate model behavior and attack vectors. | 2 | D/V |
+| **13.5.3** | **Verify that** post-incident analysis includes model retraining considerations, safety filter updates, and lessons learned integration into security controls. | 3 | D/V |
 
 ---
 
@@ -81,7 +81,7 @@ Monitor and detect drift and degradation across model outputs, input distributio
 Protect workflow visualization systems from information leakage and manipulation attacks.
 
 | # | Description | Level | Role |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: | :---: |
 | **13.6.1** | **Verify that** DAG visualization data is sanitized to remove sensitive information before storage or transmission. | 1 | D/V |
 | **13.6.2** | **Verify that** workflow visualization access controls ensure only authorized users can view agent decision paths and reasoning traces. | 1 | D/V |
 | **13.6.3** | **Verify that** DAG data integrity is protected through cryptographic signatures and tamper-evident storage mechanisms. | 2 | D/V |
@@ -95,7 +95,7 @@ Protect workflow visualization systems from information leakage and manipulation
 Detection and prevention of security threats through proactive agent behavior analysis.
 
 | # | Description | Level | Role |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|:---:|
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: | :---: |
 | **13.7.1** | **Verify that** proactive agent behaviors are security-validated before execution with risk assessment integration. | 1 | D/V |
 | **13.7.2** | **Verify that** autonomous initiative triggers include security context evaluation and threat landscape assessment. | 2 | D/V |
 | **13.7.3** | **Verify that** proactive behavior patterns are analyzed for potential security implications and unintended consequences. | 2 | D/V |


### PR DESCRIPTION
C13.3 (Model Drift Detection) and C13.6 (AI Performance Degradation Detection) substantially overlapped, causing scoring ambiguity where the same monitoring evidence could satisfy both sections:

- 13.3.1 (track perf metrics) vs 13.6.1 (monitor accuracy/F1/recall)
- 13.3.2 (alert on threshold breach) vs 13.6.4 (alert + trigger retraining)
- 13.3.4 (schema drift) vs 13.6.2 (data distribution drift)

Resolution: merge both sections into C13.3 "Model, Data, and Performance Drift Detection" with distinct controls for each drift sub-type:
- model performance metrics (merged 13.3.1 + 13.6.1)
- baseline documentation (13.6.6)
- alerting + remediation workflows (merged 13.3.2 + 13.6.4)
- hallucination tracking (13.3.3, unchanged)
- data distribution drift (13.6.2)
- schema drift (13.3.4)
- concept drift (13.6.3)
- root cause analysis (13.6.5)
- sudden vs gradual drift / security escalation (13.3.5)

Former C13.7 and C13.8 renumbered to C13.6 and C13.7 to close the gap.

Fixes #580