### PR TITLE
feat(C10): add 5 MCP security requirements from #598 (rebased, lint-fixed)

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -9,7 +9,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ## C10.1 Component Integrity & Supply Chain Hygiene
 
 | # | Description | Level |
-| :--: | --- | :---:|
+| :--: | --- | :---: |
 | **10.1.1** | **Verify that** MCP server and client components are obtained only from trusted sources and verified using signatures, checksums, or secure package metadata, rejecting tampered or unsigned builds. | 1 |
 | **10.1.2** | **Verify that** only allowlisted MCP server identifiers (name, version, and registry) are permitted in production and that the runtime rejects connections to unlisted or unregistered servers at load time. | 1 |
 
@@ -18,7 +18,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ## C10.2 Authentication & Authorization
 
 | # | Description | Level |
-| :--: | --- | :---:|
+| :--: | --- | :---: |
 | **10.2.1** | **Verify that** MCP clients authenticate to MCP servers using the OAuth 2.1 authorization framework and present a valid OAuth access token for each request, and that the MCP server validates the token according to OAuth 2.1 resource server requirements. | 1 |
 | **10.2.2** | **Verify that** MCP servers validate OAuth access tokens including issuer, audience, expiration, and scope claims, ensuring that tokens were issued for the specific MCP server before allowing tool invocation. | 1 |
 | **10.2.3** | **Verify that** MCP servers are registered through a controlled technical onboarding mechanism requiring explicit owner, environment, and resource definitions; unregistered or undiscoverable servers must not be callable in production. | 1 |
@@ -38,7 +38,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ## C10.3 Secure Transport & Network Boundary Protection
 
 | # | Description | Level |
-| :--: | --- | :---:|
+| :--: | --- | :---: |
 | **10.3.1** | **Verify that** authenticated, encrypted streamable-HTTP is used as the primary MCP transport in production environments and that alternate transports (e.g., stdio or SSE) are restricted to local or tightly controlled environments with explicit justification. | 2 |
 | **10.3.2** | **Verify that** streamable-HTTP MCP transports use authenticated, encrypted channels (TLS 1.3 or later) with certificate validation. | 2 |
 | **10.3.3** | **Verify that** SSE-based MCP transports are used only within private, authenticated internal channels and enforce TLS, authentication, schema validation, payload size limits, and rate limiting; SSE endpoints must not be exposed to the public internet. | 2 |
@@ -50,7 +50,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ## C10.4 Schema, Message, and Input Validation
 
 | # | Description | Level |
-| :--: | --- | :---:|
+| :--: | --- | :---: |
 | **10.4.1** | **Verify that** MCP tool responses are validated before being injected into the model context to prevent prompt injection, malicious tool output, or context manipulation. | 1 |
 | **10.4.2** | **Verify that** MCP tool and resource schemas (e.g., JSON schemas or capability descriptors) are validated for authenticity and integrity using signatures to prevent schema tampering or malicious parameter modification. | 2 |
 | **10.4.3** | **Verify that** all MCP transports enforce message-framing integrity, strict schema validation, maximum payload sizes, and rejection of malformed, truncated, or interleaved frames to prevent desynchronization or injection attacks. | 2 |
@@ -68,7 +68,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ## C10.5 Outbound Access & Agent Execution Safety
 
 | # | Description | Level |
-| :--: | --- | :---:|
+| :--: | --- | :---: |
 | **10.5.1** | **Verify that** MCP servers may only initiate outbound requests to approved internal or external destinations following least-privilege egress policies and cannot access arbitrary network targets or internal cloud metadata services. | 2 |
 | **10.5.2** | **Verify that** outbound MCP actions implement execution limits (e.g., timeouts, recursion limits, concurrency caps, or circuit breakers) to prevent unbounded agent-driven tool invocation or chained side effects. | 2 |
 | **10.5.3** | **Verify that** MCP tool invocations classified as high-risk or destructive (e.g., data deletion, financial transactions, system configuration changes) require explicit user confirmation before execution. | 2 |
@@ -78,7 +78,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ## C10.6 Transport Restrictions & High-Risk Boundary Controls
 
 | # | Description | Level |
-| :--: | --- | :---:|
+| :--: | --- | :---: |
 | **10.6.1** | **Verify that** stdio-based MCP transports are limited to co-located, single-process development scenarios and isolated from shell execution, terminal injection, and process-spawning capabilities; stdio must not cross network or multi-tenant boundaries. | 3 |
 | **10.6.2** | **Verify that** MCP servers expose only allow-listed functions and resources and prohibit dynamic dispatch, reflective invocation, or execution of function names influenced by user or model-provided input. | 3 |
 | **10.6.3** | **Verify that** tenant boundaries, environment boundaries (e.g., dev/test/prod), and data domain boundaries are enforced at the MCP layer to prevent cross-tenant or cross-environment server or resource discovery. | 3 |

--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -31,6 +31,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | **10.2.10** | **Verify that** MCP servers acting as OAuth proxies to third-party APIs enforce per-client consent before forwarding authorization requests, preventing cached approvals from being reused across dynamically registered clients. | 2 |
 | **10.2.11** | **Verify that** MCP clients request only the minimum scopes needed for the current operation, elevate progressively via step-up authorization, and that servers reject wildcard or overly broad scopes. | 2 |
 | **10.2.12** | **Verify that** MCP servers enforce deterministic session teardown, destroying cached tokens, in-memory state, temporary storage, and file handles when a session terminates, disconnects, or times out. | 2 |
+| **10.2.13** | **Verify that** autonomous agents authenticate using cryptographically bound identity credentials (e.g., key-based proof-of-possession) rather than bearer-only tokens, ensuring that agent identity cannot be transferred, replayed, or impersonated by forwarding a shared secret. | 2 |
 
 ---
 
@@ -58,6 +59,9 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | **10.4.6** | **Verify that** MCP server error and exception responses do not expose stack traces, internal file paths, tokens, or tool implementation details to the client or model context. | 1 |
 | **10.4.7** | **Verify that** MCP implementations reject JSON-RPC messages containing duplicate keys at any nesting level, preventing parser disagreement where different components resolve the same message to different values. | 2 |
 | **10.4.8** | **Verify that** intermediaries evaluating message content either forward the canonicalized representation they evaluated or reject messages where multiple byte representations could produce different parsed structures. | 3 |
+| **10.4.9** | **Verify that** MCP implementations support per-message cryptographic signing using asymmetric algorithms (e.g., ECDSA) so that each tool call and response carries a verifiable signature binding the message content to the sender's identity, preventing undetected message modification between MCP endpoints. | 2 |
+| **10.4.10** | **Verify that** MCP implementations enforce application-layer replay protection by requiring a unique nonce and a timestamp within a bounded time window for each signed message, and that the receiver rejects messages with duplicate nonces or timestamps outside the permitted window. | 2 |
+| **10.4.11** | **Verify that** MCP servers sign tool responses so that the calling agent can verify that the response originated from the expected server and was not modified in transit, preventing tool response spoofing or tampering by intermediaries. | 2 |
 
 ---
 
@@ -78,10 +82,12 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | **10.6.1** | **Verify that** stdio-based MCP transports are limited to co-located, single-process development scenarios and isolated from shell execution, terminal injection, and process-spawning capabilities; stdio must not cross network or multi-tenant boundaries. | 3 |
 | **10.6.2** | **Verify that** MCP servers expose only allow-listed functions and resources and prohibit dynamic dispatch, reflective invocation, or execution of function names influenced by user or model-provided input. | 3 |
 | **10.6.3** | **Verify that** tenant boundaries, environment boundaries (e.g., dev/test/prod), and data domain boundaries are enforced at the MCP layer to prevent cross-tenant or cross-environment server or resource discovery. | 3 |
+| **10.6.4** | **Verify that** MCP security controls enforce fail-closed semantics: if a signature verification, authentication check, or policy evaluation fails or cannot be completed, the default action is to deny the request rather than permit it. | 2 |
 
 ---
 
 ## References
 
 * [Model Context Protocol (MCP) Specification](https://modelcontextprotocol.io/)
+* [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html)
 * [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final)


### PR DESCRIPTION
Rebased version of #607 (originally #599) with the markdownlint MD060 fix applied.

## Changes

Adds the 5 requirements accepted in #598:

- **10.2.13** — Autonomous agent identity (cryptographically bound, not bearer-only)
- **10.4.9** — Per-message cryptographic signing (ECDSA)
- **10.4.10** — Application-layer replay protection (nonce + timestamp)
- **10.4.11** — Tool response integrity (server-signed responses)
- **10.6.4** — Fail-closed semantics for security controls

Also adds the [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html) to C10 references.

Fixes pre-existing MD060 lint errors in all 6 table header separator rows (missing space before closing pipe in compact style).

Supersedes #607. Credit to @razashariff for the original work.