### PR TITLE
fix(C4-C6): split compound requirements into independently testable controls

### DIFF
--- a/1.0/en/0x10-C04-Infrastructure.md
+++ b/1.0/en/0x10-C04-Infrastructure.md
@@ -26,10 +26,11 @@ Ensure cryptographic integrity and supply chain security through reproducible bu
 
 | # | Description | Level |
 |:--------:|--------------------------------------------------------------------------------------------|:---:|
-| **4.2.1** | **Verify that** builds are completely automated and produce a software bill of materials (SBOM). | 1 |
+| **4.2.1** | **Verify that** builds are completely automated with no manual steps that could introduce untracked changes. | 1 |
 | **4.2.2** | **Verify that** build artifacts are cryptographically signed with build-origin metadata (source repository, build pipeline, commit hash) that can be independently verified. | 2 |
 | **4.2.3** | **Verify that** build artifact signatures and build-origin metadata are validated at deployment admission, and unverified artifacts are rejected. | 2 |
 | **4.2.4** | **Verify that** builds are reproducible, producing identical output from identical source inputs, enabling independent verification of build integrity. | 3 |
+| **4.2.5** | **Verify that** automated builds produce a software bill of materials (SBOM) listing all components, versions, and their origins. | 1 |
 
 ---
 
@@ -40,10 +41,11 @@ Implement zero-trust networking with default-deny policies and encrypted communi
 | # | Description | Level |
 |:--------:|--------------------------------------------------------------------------------------------|:---:|
 | **4.3.1** | **Verify that** network policies enforce default-deny ingress and egress, with only required services explicitly allowed. | 1 |
-| **4.3.2** | **Verify that** AI workloads across environments (development, testing, production) run in isolated network segments with no direct internet access and no shared identity roles, security groups, or cross-environment connectivity. | 1 |
+| **4.3.2** | **Verify that** AI workloads across environments (development, testing, production) run in isolated network segments with no direct internet access and no cross-environment network connectivity. | 1 |
 | **4.3.3** | **Verify that** administrative and remote access protocols and access to cloud metadata services are restricted and require strong authentication. | 1 |
 | **4.3.4** | **Verify that** inter-service communication uses mutual TLS with certificate validation and regular automated rotation. | 2 |
 | **4.3.5** | **Verify that** egress traffic is restricted to approved destinations and all requests are logged. | 3 |
+| **4.3.6** | **Verify that** environments (development, testing, production) use separate identity roles and security groups with no shared principals or credentials across environment boundaries. | 1 |
 
 ---
 
@@ -72,8 +74,10 @@ Isolate untrusted AI models in secure sandboxes and protect sensitive AI workloa
 | **4.5.3** | **Verify that** workload attestation is performed before model loading, ensuring cryptographic proof that the execution environment has not been tampered with. | 2 |
 | **4.5.4** | **Verify that** confidential workloads execute within a trusted execution environment (TEE) that provides hardware-enforced isolation, memory encryption, and integrity protection. | 3 |
 | **4.5.5** | **Verify that** confidential inference services prevent model extraction through encrypted computation with sealed model weights and protected execution. | 3 |
-| **4.5.6** | **Verify that** orchestration of trusted execution environments includes lifecycle management, remote attestation, and encrypted communication channels. | 3 |
+| **4.5.6** | **Verify that** TEE orchestration manages the full lifecycle of trusted execution environments, including provisioning, suspension, and termination. | 3 |
 | **4.5.7** | **Verify that** secure multi-party computation (SMPC) enables collaborative AI training without exposing individual datasets or model parameters. | 3 |
+| **4.5.8** | **Verify that** TEE orchestration performs remote attestation before each workload placement to confirm the execution environment has not been tampered with. | 3 |
+| **4.5.9** | **Verify that** communication channels between TEE orchestration components and execution environments are encrypted and mutually authenticated. | 3 |
 
 ---
 
@@ -85,7 +89,8 @@ Prevent resource exhaustion attacks and ensure fair resource allocation through 
 |:--------:|--------------------------------------------------------------------------------------------|:---:|
 | **4.6.1** | **Verify that** workload resource consumption is limited through quotas and limits (e.g., CPU, memory, GPU) to mitigate denial-of-service attacks. | 1 |
 | **4.6.2** | **Verify that** resource exhaustion triggers automated protections (e.g., rate limiting or workload isolation) once defined CPU, memory, or request thresholds are exceeded. | 2 |
-| **4.6.3** | **Verify that** backup systems run in isolated networks with separate credentials, and the storage system is either run in an air-gapped network or implements WORM (write-once-read-many) protection against unauthorized modification. | 2 |
+| **4.6.3** | **Verify that** backup systems run in isolated networks with separate credentials that are not shared with production workloads. | 2 |
+| **4.6.4** | **Verify that** backup storage is either air-gapped or implements WORM (write-once-read-many) protection to prevent unauthorized modification or deletion. | 2 |
 
 ---
 
@@ -117,7 +122,8 @@ Secure distributed AI deployments including edge computing, federated learning, 
 | **4.8.3** | **Verify that** edge devices implement secure boot with verified signatures and rollback protection to prevent firmware downgrade attacks. | 2 |
 | **4.8.4** | **Verify that** mobile or edge inference applications implement platform-level anti-tampering protections (e.g., code signing, verified boot, runtime integrity checks) that detect and block modified binaries, repackaged applications, or attached instrumentation frameworks. | 2 |
 | **4.8.5** | **Verify that** distributed AI coordination uses Byzantine fault-tolerant consensus mechanisms with participant validation and malicious node detection. | 3 |
-| **4.8.6** | **Verify that** edge-to-cloud communication supports bandwidth throttling, data compression, and secure offline operation with encrypted local storage. | 3 |
+| **4.8.6** | **Verify that** edge-to-cloud communication implements bandwidth throttling and data compression to maintain availability under constrained or degraded network conditions. | 3 |
+| **4.8.10** | **Verify that** edge devices support secure offline operation, with data stored locally encrypted at rest using hardware-backed key management. | 3 |
 | **4.8.7** | **Verify that** on-device inference runtimes enforce process, memory, and file access isolation to prevent model dumping, debugging, or extraction of intermediate embeddings and activations. | 3 |
 | **4.8.8** | **Verify that** model weights and sensitive parameters stored locally are encrypted using hardware-backed key stores or secure enclaves (e.g., Android Keystore, iOS Secure Enclave, TPM/TEE), with keys inaccessible to user space. | 3 |
 | **4.8.9** | **Verify that** models packaged within mobile, IoT, or embedded applications are encrypted or obfuscated at rest, and decrypted only inside a trusted runtime or secure enclave, preventing direct extraction from the app package or filesystem. | 3 |

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -43,8 +43,10 @@ Enforce authorization at the data access layer to prevent unauthorized data retr
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
 | **5.3.1** | **Verify that** all data store queries (e.g., vector databases, SQL databases, search indices) include mandatory security filters (tenant ID, sensitivity labels, user scope) enforced at the data access layer. | 1 |
 | **5.3.2** | **Verify that** failed authorization evaluations immediately abort queries and return explicit authorization error codes. | 1 |
-| **5.3.3** | **Verify that** row-level security policies and field-level masking are enabled with policy inheritance for all data stores containing sensitive data used by AI systems. | 2 |
+| **5.3.3** | **Verify that** row-level security policies are enabled for all data stores containing sensitive data used by AI systems. | 2 |
 | **5.3.4** | **Verify that** query retry mechanisms re-evaluate authorization policies to account for dynamic permission changes within active sessions. | 3 |
+| **5.3.5** | **Verify that** field-level masking is applied to sensitive fields in all data stores used by AI systems, restricting access to only authorized principals. | 2 |
+| **5.3.6** | **Verify that** row-level security and field-level masking policies are inherited by derived or replicated data stores and are not bypassed by replication or ETL processes. | 2 |
 
 ---
 
@@ -68,7 +70,8 @@ Ensure logical and cryptographic isolation between tenants in shared AI infrastr
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
 | **5.5.1** | **Verify that** network policies implement default-deny rules for cross-tenant communication. | 2 |
 | **5.5.2** | **Verify that** every API request includes an authenticated tenant identifier that is cryptographically validated against session context and user entitlements. | 1 |
-| **5.5.3** | **Verify that** memory spaces, embedding stores, cache entries (e.g., result caches, embedding caches), and temporary files are namespace-segregated per tenant with secure purging on tenant deletion or session termination. | 2 |
+| **5.5.3** | **Verify that** memory spaces, embedding stores, cache entries (e.g., result caches, embedding caches), and temporary files are namespace-segregated per tenant so that one tenant cannot access another tenant's data. | 2 |
+| **5.5.6** | **Verify that** per-tenant memory spaces, embedding stores, cache entries, and temporary files are securely purged on tenant deletion or session termination. | 2 |
 | **5.5.4** | **Verify that** encryption keys are unique per tenant with customer-managed key (CMK) support and cryptographic isolation between tenant data stores. | 3 |
 | **5.5.5** | **Verify that** inference-time KV-cache entries are partitioned by authenticated session or tenant identity and that automatic prefix caching does not share cached prefixes across distinct security principals, to prevent timing-based prompt reconstruction attacks. | 2 |
 

--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -84,8 +84,9 @@ Detect supply-chain threats early through vulnerability feeds, audit-log analyti
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---:|
 | **6.6.1** | **Verify that** incident response playbooks include rollback procedures for compromised models or libraries. | 2 |
-| **6.6.2** | **Verify that** CI/CD audit logs are streamed to centralized security monitoring with detections for anomalous package pulls or tampered build steps. | 2 |
+| **6.6.2** | **Verify that** CI/CD audit logs are streamed to centralized security monitoring in real time. | 2 |
 | **6.6.3** | **Verify that** threat-intelligence enrichment tags AI-specific indicators (e.g., model-poisoning indicators of compromise) in alert triage. | 3 |
+| **6.6.4** | **Verify that** security monitoring includes detection rules for anomalous package pulls and tampered or unexpected build steps in the CI/CD pipeline. | 2 |
 
 ---
 


### PR DESCRIPTION
Mirrors the approach from issue #588. Each requirement now represents one independently verifiable control, a concern that can pass or fail on its own without implying the result of a sibling concern.

Splits applied (7 compounds, producing 9 new controls):

C4:
- 4.2.1: automated builds + SBOM production -> 4.2.1 + 4.2.5
- 4.3.2: network isolation + no shared IAM roles/security groups -> 4.3.2 + 4.3.6
- 4.5.6: TEE lifecycle + remote attestation + encrypted channels -> 4.5.6 + 4.5.8 + 4.5.9
- 4.6.3: backup network isolation + WORM/air-gap storage -> 4.6.3 + 4.6.4
- 4.8.6: bandwidth/compression + secure offline/encrypted storage -> 4.8.6 + 4.8.10

C5:
- 5.3.3: row-level security + field-level masking + policy inheritance -> 5.3.3 + 5.3.5 + 5.3.6
- 5.5.3: namespace segregation + secure purging on deletion -> 5.5.3 + 5.5.6

C6:
- 6.6.2: log streaming to SIEM + detection rules -> 6.6.2 + 6.6.4

Ref: #588