### PR TITLE
docs(README): update for 1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Each stable release of AISVS is published as a numbered folder in this repositor
 
 We welcome contributions from the community. Please [open an issue](https://github.com/OWASP/AISVS/issues) to report bugs or suggest improvements. We may ask you to [submit a pull request](https://github.com/OWASP/AISVS/pulls) based on the discussion.
 
-To report a security issue with the AISVS project itself, please follow the [Security Policy](SECURITY.md).
+To report a security issue with the AISVS project itself, please follow the [Security Policy](Security.md).
 
 ## License
 


### PR DESCRIPTION
Addresses #596.

## Summary

- Move Project Leaders directly under "What is AISVS?" intro paragraph
- Add "Latest Stable Version" section with download table (HTML marked as pending for 1.0 release)
- Overhaul citing/referencing into "How to Reference AISVS Requirements", modeled after ASVS: format `v<version>-C<chapter>.<section>.<requirement>` (e.g. `v1.0-C9.4.3`), with explanation of each component and note on version-pinning
- Add Versioning section explaining the folder-based release model (`1.0/` locked after release, future work in new folders), mirrors ASVS approach
- Add security reporting pointer to `SECURITY.md` in Contributing section
- Remove standalone Project Leaders section at bottom (now under intro)

## Notes

The HTML download link is a placeholder pending the 1.0 release build. The `1.01-dev/` folder in the Versioning diagram is also marked pending. Both should be updated at release time.