### PR TITLE
feat(C1): add distributed training data collection endpoint security control (1.2.8)

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -34,7 +34,6 @@ Restrict access to training data, encrypt it at rest and in transit, and validat
 | **1.2.5** | **Verify that** automated integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
 | **1.2.6** | **Verify that** obsolete training data is securely purged or anonymized. | 1 |
 | **1.2.7** | **Verify that** all training dataset versions are uniquely identified, stored immutably, and auditable to support rollback and forensic analysis. | 3 |
-| **1.2.8** | **Verify that** distributed training data collection endpoints authenticate to the central aggregation system using mutual authentication, and that data received from those endpoints is integrity-verified (e.g., via cryptographic checksums or digital signatures generated at source) before being accepted into training pipelines. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -293,7 +293,6 @@ Verify origin and authenticity, scan dependencies, and enforce integrity of mode
 | Approved source and internal registry enforcement | 6.4.1 |
 | Malicious layer and trojan trigger scanning | 6.1.2 |
 | External dataset poisoning assessment (fingerprinting, outlier detection) | 6.5.1 |
-| Distributed data collection endpoint mutual authentication and source integrity verification | 1.2.8 |
 | Copyright and PII detection in external datasets | 6.5.2 |
 | Dataset origin and lineage documentation | 6.5.3 |
 | Automated AI BOM generation and signing in CI | 6.7.2 |


### PR DESCRIPTION
## Summary

Adds **1.2.8** to C1.2 (Training Data Security & Integrity) to close a gap where no control addresses the security of distributed or federated training data collection endpoints.

**New control:**

> **Verify that** distributed training data collection endpoints authenticate to the central aggregation system using mutual authentication, and that data received from those endpoints is integrity-verified (e.g., via cryptographic checksums or digital signatures generated at source) before being accepted into training pipelines.

**Level:** 2

## Why this is needed

Federated and distributed training setups route data from many collection nodes (edge devices, partner systems, regional data pipelines) to a central aggregation point. Existing C1.2 controls protect data at rest and in transit once it reaches central storage, but none address the authentication of collection endpoints or the integrity of data before ingestion. An attacker who can inject data from an unauthenticated endpoint, or replay/modify data in transit before the integrity check at the aggregation point, bypasses all downstream training data validation.

This is AI-specific: distributed training data collection is a common pattern in AI/ML operations with no direct equivalent in general web application data flows.

## Changes

- `1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md`: add 1.2.8, fix MD060 separator rows
- `1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md`: add entry to AD.12