### PR TITLE
feat(C2): add many-shot jailbreaking defense control (2.1.5)

### DIFF
--- a/.github/workflows/config/local-custom.txt
+++ b/.github/workflows/config/local-custom.txt
@@ -106,3 +106,5 @@ Cylance
 NDSS
 RONI
 PATE
+jailbreaking
+jailbreak

--- a/1.0/en/0x10-C02-User-Input-Validation.md
+++ b/1.0/en/0x10-C02-User-Input-Validation.md
@@ -16,6 +16,7 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. This enforcement must be preserved across multi-step interactions and tool-augmented workflows. In such cases, prompt composition or intermediate outputs must not allow user-controlled content to influence or override system or developer instructions. | 1 |
 | **2.1.3** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
 | **2.1.4** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
+| **2.1.5** | **Verify that** the system implements defenses against many-shot jailbreaking, where a high volume of user-supplied demonstrations within a single context window is used to override model safety training through in-context learning, by enforcing per-request demonstration count limits and flagging systematic in-context behavioral override patterns as prompt injection events. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C02-User-Input-Validation.md
+++ b/1.0/en/0x10-C02-User-Input-Validation.md
@@ -16,7 +16,9 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. This enforcement must be preserved across multi-step interactions and tool-augmented workflows. In such cases, prompt composition or intermediate outputs must not allow user-controlled content to influence or override system or developer instructions. | 1 |
 | **2.1.3** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
 | **2.1.4** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
-| **2.1.5** | **Verify that** the system implements defenses against many-shot jailbreaking, where a high volume of user-supplied demonstrations within a single context window is used to override model safety training through in-context learning, by enforcing per-request demonstration count limits and flagging systematic in-context behavioral override patterns as prompt injection events. | 2 |
+| **2.1.5** | **Verify that** the system enforces per-request limits on the number of user-supplied demonstrations included in a single context window. | 2 |
+| **2.1.6** | **Verify that** the system detects patterns indicative of systematic in-context behavioral override attempts consistent with many-shot jailbreaking. | 2 |
+| **2.1.7** | **Verify that** detected in-context behavioral override attempts are classified and handled as prompt injection events. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -151,6 +151,7 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | --- | --- |
 | Prompt injection detection ruleset / service | 2.1.1 |
 | Instruction hierarchy enforcement (system > developer > user) | 2.1.2 |
+| Many-shot jailbreaking detection (demonstration count limits, in-context override pattern detection) | 2.1.5 |
 | Third-party content sanitization | 2.1.3 |
 | Unicode NFC normalization and homoglyph mapping | 2.2.1 |
 | Control / invisible character removal | 2.2.1, 2.2.5 |

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -151,7 +151,9 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | --- | --- |
 | Prompt injection detection ruleset / service | 2.1.1 |
 | Instruction hierarchy enforcement (system > developer > user) | 2.1.2 |
-| Many-shot jailbreaking detection (demonstration count limits, in-context override pattern detection) | 2.1.5 |
+| Per-request demonstration count limits in context window | 2.1.5 |
+| Many-shot jailbreaking pattern detection (systematic in-context behavioral override) | 2.1.6 |
+| In-context behavioral override attempts classified as prompt injection events | 2.1.7 |
 | Third-party content sanitization | 2.1.3 |
 | Unicode NFC normalization and homoglyph mapping | 2.2.1 |
 | Control / invisible character removal | 2.2.1, 2.2.5 |


### PR DESCRIPTION
## Summary

Adds **2.1.5** to C2.1 (Prompt Injection Defense) to address many-shot jailbreaking, a distinct and well-documented attack class not covered by existing prompt injection controls.

**New control:**

> **Verify that** the system implements defenses against many-shot jailbreaking, where a high volume of user-supplied demonstrations within a single context window is used to override model safety training through in-context learning, by enforcing per-request demonstration count limits and flagging systematic in-context behavioral override patterns as prompt injection events.

**Level:** 2

## Why this is needed

Many-shot jailbreaking was documented in Anthropic's April 2024 research paper showing that including dozens to hundreds of fictional "demonstrations" of unsafe behavior in a single context window exploits the model's in-context learning to override safety training. This is distinct from classic prompt injection (which typically involves a few sentences attempting to override instructions) and requires a different defense: counting the number of demonstrations and flagging structured patterns of behavioral override across a long context.

Existing C2.1 controls cover instruction hierarchy enforcement (2.1.2) and third-party content sanitization (2.1.3), but neither addresses the many-shot vector where the attack is purely volumetric and statistical rather than a single injected directive.

## Changes

- `1.0/en/0x10-C02-User-Input-Validation.md`: add 2.1.5
- `1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md`: add entry to AD.7