### PR TITLE
feat(C14): add granular degradation policy requirement (14.1.5)

### DIFF
--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -16,7 +16,7 @@ Provide shutdown or rollback paths when unsafe behavior of the AI system is obse
 | **14.1.2** | **Verify that** override controls are accessible to only to authorized personnel. | 1 |
 | **14.1.3** | **Verify that** rollback procedures can revert to previous model versions or safe-mode operations. | 3 |
 | **14.1.4** | **Verify that** override mechanisms are tested regularly. | 3 |
-| **14.1.5** | **Verify that** a documented degradation policy defines at least two intermediate states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined triggers, scope, and recovery criteria. | 2 |
+| **14.1.5** | **Verify that** the system can be placed into at least two intermediate operational states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined entry triggers and can be exited independently without requiring a full system restart or shutdown. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -16,6 +16,7 @@ Provide shutdown or rollback paths when unsafe behavior of the AI system is obse
 | **14.1.2** | **Verify that** override controls are accessible to only to authorized personnel. | 1 |
 | **14.1.3** | **Verify that** rollback procedures can revert to previous model versions or safe-mode operations. | 3 |
 | **14.1.4** | **Verify that** override mechanisms are tested regularly. | 3 |
+| **14.1.5** | **Verify that** a documented degradation policy defines at least two intermediate states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined triggers, scope, and recovery criteria. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -514,6 +514,7 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 | High-risk model quarantine with human review and sign-off | 6.1.4 |
 | Post-condition outcome checking with containment on mismatch | 9.7.3 |
 | Compensating actions and transactional rollback on failure | 9.2.3 |
+| Pre-defined degradation policy with intermediate states between full operation and shutdown | 14.1.5 |
 
 **Common pitfalls:** not binding approval to exact parameters allowing bait-and-switch; confirmation tokens without quick expiration; missing post-condition checks after approved actions execute.
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -514,7 +514,7 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 | High-risk model quarantine with human review and sign-off | 6.1.4 |
 | Post-condition outcome checking with containment on mismatch | 9.7.3 |
 | Compensating actions and transactional rollback on failure | 9.2.3 |
-| Pre-defined degradation policy with intermediate states between full operation and shutdown | 14.1.5 |
+| Intermediate operational degradation states (tool disable, model swap, read-only, source removal) | 14.1.5 |
 
 **Common pitfalls:** not binding approval to exact parameters allowing bait-and-switch; confirmation tokens without quick expiration; missing post-condition checks after approved actions execute.
 


### PR DESCRIPTION
## Summary

Adds a new control 14.1.5 to C14.1 (Kill-Switch & Override Mechanisms) requiring a documented, pre-defined degradation policy with intermediate states between full operation and complete shutdown.

## Gap addressed

AISVS already has:
- C14.1.1: full kill-switch (binary on/off)
- C14.1.3: rollback to previous version or safe-mode
- C2.8.3: risk-adaptive responses (disable tools, shrink context, HITL)
- C3.3.4: cascading shutdown of all components

What was missing is a requirement for operators to define and document intermediate degradation states *before* an incident, including triggers, scope, and recovery criteria for each state. Without this, teams are left making ad hoc decisions under pressure.

## New control

| # | Description | Level |
|---|---|:---:|
| **14.1.5** | **Verify that** a documented degradation policy defines at least two intermediate states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined triggers, scope, and recovery criteria. | 2 |

## Design principle check

- AI-specific: yes, the degradation states reference AI-layer components (model swap, retrieval source removal, tool disabling, agent mode)
- Security/safety: yes, an undefined degradation path is a safety risk during incidents
- Verifiable: yes, the policy document and its mapping to system behaviour can be audited
- Single concern: yes, one testable assertion (does a pre-defined policy with intermediate states exist?)

Closes #649
Relates to #639