### PR TITLE
Add C9.7.6: prevent agent output from authorizing external state writes

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -110,7 +110,7 @@ Prevent "technically authorized but unintended" actions by binding execution to 
 | **9.7.3** | **Verify that** post-execution checks detect unintended side effects. | 2 |
 | **9.7.4** | **Verify that** any mismatch between intended outcome and actual results triggers containment and, where supported, compensating actions. | 2 |
 | **9.7.5** | **Verify that** prompt templates and agent policy configurations retrieved from a remote source are integrity-verified at load time against their approved versions (e.g., via hashes or signatures). | 3 |
-| **9.7.6** | **Verify that** agent-generated outputs cannot serve as the sole authorization signal or parameter source for write operations to persistent external state (e.g., file systems, databases, code repositories, configuration stores, or external APIs), and that such writes require either explicit human authorization or an independent policy-based authorization check that evaluates the write against the original user intent rather than the model's output. | 2 |
+| **9.7.6** | **Verify that** all write operations to persistent external state are authorized by either explicit human approval or an independent policy-based authorization mechanism that evaluates the operation against the original user intent, and not solely on agent-generated output. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -110,6 +110,7 @@ Prevent "technically authorized but unintended" actions by binding execution to 
 | **9.7.3** | **Verify that** post-execution checks detect unintended side effects. | 2 |
 | **9.7.4** | **Verify that** any mismatch between intended outcome and actual results triggers containment and, where supported, compensating actions. | 2 |
 | **9.7.5** | **Verify that** prompt templates and agent policy configurations retrieved from a remote source are integrity-verified at load time against their approved versions (e.g., via hashes or signatures). | 3 |
+| **9.7.6** | **Verify that** agent-generated outputs cannot serve as the sole authorization signal or parameter source for write operations to persistent external state (e.g., file systems, databases, code repositories, configuration stores, or external APIs), and that such writes require either explicit human authorization or an independent policy-based authorization check that evaluates the write against the original user intent rather than the model's output. | 2 |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds control **9.7.6** (Level 2) to C9.7 Intent Verification and Constraint Gates
- Closes the gap where no existing control explicitly prevented agent-generated outputs from serving as the sole authorization signal for writes to persistent external state (file systems, databases, code repositories, configuration stores, external APIs)

## Problem

Prompt injection can achieve persistence when an injected instruction in a tool output causes the agent to write to external state (a config file, a database record, a code repository) that is later re-read. The injection survives the session because the write committed it.

Existing controls do not cover this:

- **C7.4.2** requires user confirmation for high-impact actions broadly, but does not address the output-as-authorization pattern
- **C9.7.3** detects unintended side effects post-execution, detection only
- **C8.2.4** covers the same loop for vector/memory only
- **C9.6.1** enforces authorization policy but assumes the authorization check is independent of model output -- this control makes that assumption explicit for the write case

## New control

> **9.7.6** | Verify that agent-generated outputs cannot serve as the sole authorization signal or parameter source for write operations to persistent external state (e.g., file systems, databases, code repositories, configuration stores, or external APIs), and that such writes require either explicit human authorization or an independent policy-based authorization check that evaluates the write against the original user intent rather than the model's output. | 2