### PR TITLE
C01 reduction pass

### DIFF
--- a/1.0/en/0x03-Using-AISVS.md
+++ b/1.0/en/0x03-Using-AISVS.md
@@ -4,11 +4,15 @@ The Artificial Intelligence Security Verification Standard (AISVS) defines secur
 
 The AISVS is intended for anyone developing or evaluating the security of AI applications, including developers, architects, security engineers, and auditors. This chapter introduces the structure and use of the AISVS, including its verification levels and intended use cases.
 
+The standard contains scope notes that may contain references to other chapters, references to ASVS requirements or other information about concerns specifically included or excluded from scope of the control objective or section.
+
 ## Artificial Intelligence Security Verification Levels
 
 The AISVS defines three ascending levels of security verification. Each level adds depth and complexity, enabling organizations to tailor their security posture to the risk level of their AI systems.
 
 Organizations may begin at Level 1 and progressively adopt higher levels as security maturity and threat exposure increase.
+
+AISVS levels aim to be aligned with ASVS levels, and relevant guidance on the respective level should be followed.
 
 ### Definition of the Levels
 
@@ -25,5 +29,3 @@ Level 2 addresses more advanced or less common attacks, as well as layered defen
 #### Level 3 requirements
 
 Level 3 includes controls that are typically harder to implement or situational in applicability. These often represent defense-in-depth mechanisms or mitigations against niche, targeted, or high-complexity attacks.
-
-

--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -4,7 +4,9 @@
 
 Training data must be sourced, handled, and maintained in a way that preserves origin traceability, integrity, and quality. The core security concern is ensuring data has not been tampered with, poisoned, or corrupted. Security-relevant bias (e.g., skewed abuse-detection training data that allows attackers to bypass controls) is treated as a possible consequence of compromised or unvalidated data, not as a standalone control category.
 
-> **Scope note — bias.** AISVS addresses bias only where it introduces security risk (e.g., bypass of abuse detection, authentication heuristics, or automated trust decisions). Broader fairness governance requirements are out of scope; see ISO/IEC 42001 or the NIST AI RMF for general fairness and ethics guidance.
+> **Scope note -- bias.** AISVS addresses bias only where it introduces security risk (e.g., bypass of abuse detection, authentication heuristics, or automated trust decisions). Broader fairness governance requirements are out of scope; see e.g. ISO/IEC 42001 or the NIST AI RMF for general fairness and ethics guidance.
+
+> **Scope note -- general data security.** Generic data security control details for access control, logging, encryption at rest and in transit, and data retention/purging are covered by ASVS v5 (V8, V11, V12, V14, V16) and apply to training data storage and labeling systems. This section sets on higher level requirements with levels that are specific to AI.
 
 ---
 
@@ -39,7 +41,7 @@ Restrict access to training data, encrypt it at rest and in transit, and validat
 
 ## C1.3 Data Labeling and Annotation Security
 
-Ensure labeling and annotation processes are access-controlled, auditable, and protect sensitive information.
+Ensure labeling and annotation processes are access-controlled and auditable.
 
 | # | Description | Level |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
@@ -47,8 +49,7 @@ Ensure labeling and annotation processes are access-controlled, auditable, and p
 | **1.3.2** | **Verify that** all labeling activities are recorded in audit logs, including the annotator identity, timestamp, and action performed. | 1 |
 | **1.3.3** | **Verify that** annotator identity metadata is exported and retained alongside the dataset so that every annotation or preference pair can be attributed to a specific, verified human annotator throughout the training pipeline. | 1 |
 | **1.3.4** | **Verify that** cryptographic hashes or digital signatures are applied to labeling artifacts, annotation data, and fine-tuning feedback records (including RLHF preference pairs) to ensure their integrity and authenticity. | 2 |
-| **1.3.5** | **Verify that** labeling audit logs are tamper-evident. | 2 |
-| **1.3.6** | **Verify that** sensitive information in labels is redacted, anonymized, or encrypted using appropriate granularity at rest and in transit. | 2 |
+| **1.3.5** | **Verify that** sensitive information in labels is redacted, anonymized, or encrypted using appropriate granularity at rest and in transit. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -71,8 +71,8 @@ Protect stored data, models, secrets, logs, and backups through encryption.
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Training data encryption at rest | 1.2.3 |
-| Labeled data encryption | 1.3.6 |
+| Training data encryption at rest | ASVS v5 V11/V12 |
+| Labeled data encryption | ASVS v5 V11/V12 |
 | Secrets encryption at rest in secrets management system | 4.4.1 |
 | Log encryption at rest | 13.1.3 |
 | TEE memory encryption and integrity protection | 4.5.4 |
@@ -132,7 +132,7 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Cryptographic hashes for training data integrity | 1.2.4, 1.3.4 |
+| Cryptographic hashes for training data integrity | 1.2.1, 1.3.2 |
 | Cryptographic model signing | 3.1.2 |
 | Model signature and checksum verification at deployment and load | 3.1.3 |
 | Signed build artifacts with build-origin metadata | 4.2.2 |
@@ -359,7 +359,7 @@ Protect personal data and enforce data subject rights throughout the AI lifecycl
 | Control / Technique | Requirement IDs |
 | --- | --- |
 | Training data minimization (exclude unnecessary features, PII, leaked test data) | 1.1.2 |
-| Labeled data anonymization and granular redaction | 1.3.6 |
+| Labeled data anonymization and granular redaction | ASVS v5 V14/V16.2.5 |
 | Direct and quasi-identifier removal | 12.1.1 |
 | k-anonymity and l-diversity measurement with automated audits | 12.1.2 |
 | Synthetic data with formal re-identification risk bounds | 12.1.4 |
@@ -409,7 +409,7 @@ Test for and defend against evasion, extraction, inversion, poisoning, and align
 | Self-modification restriction with scope bounds and rate limits | 11.9.1, 11.9.4 |
 | Self-modification reversibility and integrity verification enabling rollback to known-good state | 11.9.6 |
 | Data augmentation with perturbed inputs for training robustness | 1.4.4 |
-| RONI (Reject On Negative Influence) filtering — influence-score each training sample and reject those that degrade held-out performance beyond a threshold (implementation example for 1.4.2) | 1.4.2 |
+| RONI (Reject On Negative Influence) filtering -- influence-score each training sample and reject those that degrade held-out performance beyond a threshold (implementation example for 1.4.2) | 1.4.2 |
 | Gradient fingerprinting / per-sample gradient analysis — detect abnormal gradient norms or directions indicating poisoned samples during training (implementation example for 1.4.2) | 1.4.2 |
 | Activation clustering — cluster intermediate activations to detect backdoor-associated subpopulations (implementation example for 1.4.2) | 1.4.2 |
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -71,8 +71,8 @@ Protect stored data, models, secrets, logs, and backups through encryption.
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Training data encryption at rest | ASVS v5 V11/V12 |
-| Labeled data encryption | ASVS v5 V11/V12 |
+| Training data encryption at rest | 1.2.3 |
+| Labeled data encryption | 1.3.5 |
 | Secrets encryption at rest in secrets management system | 4.4.1 |
 | Log encryption at rest | 13.1.3 |
 | TEE memory encryption and integrity protection | 4.5.4 |
@@ -132,7 +132,7 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Cryptographic hashes for training data integrity | 1.2.1, 1.3.2 |
+| Cryptographic hashes for training data integrity | 1.2.4, 1.3.4 |
 | Cryptographic model signing | 3.1.2 |
 | Model signature and checksum verification at deployment and load | 3.1.3 |
 | Signed build artifacts with build-origin metadata | 4.2.2 |
@@ -359,7 +359,7 @@ Protect personal data and enforce data subject rights throughout the AI lifecycl
 | Control / Technique | Requirement IDs |
 | --- | --- |
 | Training data minimization (exclude unnecessary features, PII, leaked test data) | 1.1.2 |
-| Labeled data anonymization and granular redaction | ASVS v5 V14/V16.2.5 |
+| Labeled data anonymization and granular redaction | 1.3.5 |
 | Direct and quasi-identifier removal | 12.1.1 |
 | k-anonymity and l-diversity measurement with automated audits | 12.1.2 |
 | Synthetic data with formal re-identification risk bounds | 12.1.4 |


### PR DESCRIPTION
I reviewed the requirement and ended up considering the exact requirements on this level are quite AI-specific and did not propose a lot of changes. However, added reference to ASVS for more details of implementation of general security controls.

## Changes

### Removed requirement (1)

| Old ID | Description | Covered by |
|--------|-------------|------------|
| 1.3.5 | Tamper-evident labeling audit logs | ASVS V16.4.2 (logs cannot be modified) + AISVS C13.1.6 (log integrity via cryptographic signatures or write-only storage) |

Old 1.3.6 (sensitive info in labels) renumbered to 1.3.5.

### Scope note added

Added chapter-level scope note clarifying that generic data security controls (access control, logging, encryption at rest/in transit, data retention/purging) are covered by ASVS v5 (V8, V11, V12, V14, V16) and apply to training data as they do to any sensitive data store.

### Other

- C1.3 section description simplified: removed "and protect sensitive information"
- Style: replaced em dashes with `--` per project convention
- **Appendix D**: Updated cross-references for renumbered requirements. Rows referencing removed C01 requirements now point to the corresponding ASVS v5 controls.

## Items for discussion

The following requirements were reviewed for AI-specificity and kept, but could be discussed further:

- **1.1.2** (exclude unnecessary features/PII): Kept as AI-specific due to the model memorization and feature leakage angle, but could be seen as generic data minimization. The AI-specific nuance (unused metadata and leaked test data ending up in training sets) is what justifies inclusion.
- **1.1.3** (logged approval workflow for dataset changes): Borderline generic (change management is universal), but dataset changes can silently poison models in ways that code changes cannot. This justifies an AI-specific callout.
- **1.2.1 through 1.2.3** (access controls, audit logging, encryption): These are generic data security controls well-covered by ASVS v5. They were kept because the chapter-level scope note now frames them as higher-level AI-context requirements rather than detailed control specifications. Opinions welcome on whether this framing is sufficient or whether they should still be removed.
- **1.3.1** (labeling platform access controls): Generic access control, covered by ASVS V8.2.1. Kept for the same reason as above.
- **1.3.2** (labeling audit logs): Generic audit logging, covered by ASVS V16.2.1. Kept for the same reason as above.
- **1.3.5** (sensitive info in labels redacted/encrypted): Could be seen as generic data protection (ASVS V14/V16.2.5), but the specific concern about sensitive information leaking *into model training via labels* has an AI-specific angle. Opinions welcome.
- **C1.3 tamper-evident logs (removed 1.3.5)**: This was removed because it duplicates ASVS V16.4.2 + AISVS C13.1.6. However, if there is a view that labeling audit logs deserve an explicit tamper-evidence callout in the training data chapter, it could be restored. Opinions welcome.