### PR TITLE
Remove 25 ASVS v5 duplicate controls from C04, C05, C06, C13

### DIFF
--- a/1.0/en/0x10-C04-Infrastructure.md
+++ b/1.0/en/0x10-C04-Infrastructure.md
@@ -4,6 +4,8 @@
 
 AI infrastructure must be hardened against privilege escalation, supply chain tampering, and lateral movement through secure configuration, runtime isolation, trusted deployment pipelines, and comprehensive monitoring. Only validated and authorized infrastructure components reach production through controlled processes that ensure security, integrity, and auditability.
 
+> **Scope note:** General infrastructure hardening controls — including OS-level least-privilege, seccomp/AppArmor/SELinux sandboxing, read-only filesystems, default-deny network policies, mTLS, secrets management, secret rotation, and backup isolation — are governed by [OWASP ASVS v5](https://owasp.org/www-project-application-security-verification-standard/) (V6, V8, V11, V12, V13, V14). This chapter extends those requirements where AI-specific implementation concerns apply. Implementers should satisfy both ASVS and AISVS infrastructure controls.
+
 ---
 
 ## C4.1 Runtime Environment Isolation
@@ -12,9 +14,6 @@ Prevent container escapes and privilege escalation through OS-level isolation pr
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------ | :---: |
-| **4.1.1** | **Verify that** all AI workloads run with minimal permissions needed on the operating system, by e.g. dropping unnecessary Linux capabilities in case of a container. | 1 |
-| **4.1.2** | **Verify that** workloads are protected by technologies limiting exploitation such as sandboxing, seccomp profiles, AppArmor, SELinux or similar, and that the configuration is appropriate. | 1 |
-| **4.1.3** | **Verify that** workloads run with a read-only root filesystem, and that any writable mounts are explicitly defined and hardened with restrictive options that prevent execution and privilege escalation (e.g., noexec, nosuid, nodev). | 2 |
 | **4.1.4** | **Verify that** runtime monitoring detects privilege-escalation and container-escape behaviors and automatically terminates offending processes. | 3 |
 | **4.1.5** | **Verify that** high-risk AI workloads run in hardware-isolated environments (e.g., TEEs, trusted hypervisors, or bare-metal nodes) only after successful remote attestation. | 3 |
 
@@ -40,13 +39,8 @@ Implement zero-trust networking with default-deny policies and encrypted communi
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------ | :---: |
-| **4.3.1** | **Verify that** network policies enforce default-deny ingress and egress, with only required services explicitly allowed. | 1 |
 | **4.3.2** | **Verify that** AI workloads across environments (development, testing, production) run in isolated network segments with no direct internet access and no cross-environment network connectivity. | 1 |
-| **4.3.3** | **Verify that** administrative and remote access protocols and access to cloud metadata services are restricted and require strong authentication. | 1 |
-| **4.3.4** | **Verify that** inter-service communication uses mutual TLS with certificate validation and regular automated rotation. | 2 |
 | **4.3.5** | **Verify that** egress traffic is restricted to approved destinations and all requests are logged. | 3 |
-| **4.3.6** | **Verify that** environments (development, testing, production) use separate identity roles and security groups with no shared principals or credentials across environment boundaries. | 1 |
-
 ---
 
 ## C4.4 Secrets & Cryptographic Key Management
@@ -55,12 +49,7 @@ Protect secrets and cryptographic keys with secure storage, automated rotation, 
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------ | :---: |
-| **4.4.1** | **Verify that** secrets are stored in a dedicated secrets management system with encryption at rest and isolated from application workloads. | 1 |
-| **4.4.2** | **Verify that** access to production secrets requires strong authentication. | 1 |
-| **4.4.3** | **Verify that** secrets are deployed to applications at runtime through a dedicated secrets management system. Secrets must never be embedded in source code, configuration files, build artifacts, container images, or environment variables. | 1 |
 | **4.4.4** | **Verify that** cryptographic keys are generated and stored in hardware-backed modules (e.g., HSMs, cloud KMS). | 2 |
-| **4.4.5** | **Verify that** secrets rotation is automated. | 2 |
-
 ---
 
 ## C4.5 AI Workload Sandboxing & Validation
@@ -90,9 +79,6 @@ Prevent resource exhaustion attacks and ensure fair resource allocation through 
 | :--------: | ------------------------------------------------------------------------------------------ | :---: |
 | **4.6.1** | **Verify that** workload resource consumption is limited through quotas and limits (e.g., CPU, memory, GPU) to mitigate denial-of-service attacks. | 1 |
 | **4.6.2** | **Verify that** resource exhaustion triggers automated protections (e.g., rate limiting or workload isolation) once defined CPU, memory, or request thresholds are exceeded. | 2 |
-| **4.6.3** | **Verify that** backup systems run in isolated networks with separate credentials that are not shared with production workloads. | 2 |
-| **4.6.4** | **Verify that** backup storage is either air-gapped or implements WORM (write-once-read-many) protection to prevent unauthorized modification or deletion. | 2 |
-
 ---
 
 ## C4.7 AI Hardware Security

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -4,6 +4,8 @@
 
 Effective access control for AI systems requires robust identity management, context-aware authorization, and runtime enforcement following zero-trust principles. These controls ensure that humans, services, and autonomous agents only interact with models, data, and computational resources within explicitly granted scopes, with continuous verification and audit capabilities.
 
+> **Scope note:** General identity management controls — including centralized IdP federation (OIDC/SAML), access control audit logging, tamper-evident log storage, and real-time alerting on unauthorized access — are governed by [OWASP ASVS v5](https://owasp.org/www-project-application-security-verification-standard/) (V6, V16). This chapter focuses on AI-specific access control concerns including query-time enforcement, output DLP, multi-tenant isolation, and autonomous agent authorization.
+
 ---
 
 ## C5.1 Identity Management & Authentication
@@ -12,7 +14,6 @@ Establish verified identities for all entities interacting with AI systems, with
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
-| **5.1.1** | **Verify that** all human users and service principals authenticate through a centralized identity provider using industry-standard federation protocols (e.g., OIDC, SAML). | 1 |
 | **5.1.2** | **Verify that** high-risk operations (model deployment, weight export, training data access, production configuration changes) require multi-factor authentication or step-up authentication with session re-validation. | 2 |
 | **5.1.3** | **Verify that** AI agents in federated or multi-system deployments authenticate via short-lived, cryptographically signed authentication tokens (e.g., signed JWT assertions) with a maximum lifetime appropriate to the risk level and including cryptographic proof of origin. | 3 |
 
@@ -25,10 +26,7 @@ Implement access controls for all AI resources with explicit permission models a
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.2.1** | **Verify that** every AI resource (datasets, models, endpoints, vector collections, embedding indices, compute instances) enforces access controls (e.g., RBAC, ABAC) with explicit allow-lists and default-deny policies. | 1 |
-| **5.2.2** | **Verify that** all access control modifications are logged with timestamps, actor identities, resource identifiers, and permission changes. | 1 |
-| **5.2.3** | **Verify that** access control audit logs are stored immutably and are tamper-evident. | 2 |
 | **5.2.4** | **Verify that** data classification labels (PII, PHI, proprietary, etc.) automatically propagate to derived resources (embeddings, prompt caches, model outputs). | 2 |
-| **5.2.5** | **Verify that** unauthorized access attempts and privilege escalation events trigger real-time alerts with contextual metadata. | 2 |
 | **5.2.6** | **Verify that** authorization decisions are externalized to a dedicated policy decision point (e.g., OPA, Cedar, or equivalent). | 3 |
 | **5.2.7** | **Verify that** policies evaluate dynamic attributes at runtime including user role or group, resource classification, request context, tenant isolation, and temporal constraints. | 3 |
 | **5.2.8** | **Verify that** policy cache TTL values are defined based on resource sensitivity, with shorter TTLs for high-sensitivity resources, and that cache invalidation capabilities are available. | 3 |

--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -4,6 +4,8 @@
 
 AI supply-chain attacks exploit third-party models, frameworks, or datasets to embed backdoors, bias, or exploitable code. These controls provide end-to-end traceability, vulnerability management, and monitoring to protect the entire model lifecycle.
 
+> **Scope note:** General software supply chain controls — including CVE-based promotion gates, lockfile version pinning, immutable container digests, and CI/CD audit log streaming — are governed by [OWASP ASVS v5](https://owasp.org/www-project-application-security-verification-standard/) (V15, V16). This chapter focuses on AI-specific supply chain concerns including model origin integrity, AI framework scanning, third-party dataset risk, and AI BOM generation.
+
 ---
 
 ## C6.1 Pretrained Model Vetting & Origin Integrity
@@ -28,7 +30,6 @@ Continuously scan AI frameworks and libraries for vulnerabilities and malicious 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **6.2.1** | **Verify that** CI pipelines run dependency scanners on AI frameworks and critical libraries. | 1 |
-| **6.2.2** | **Verify that** critical and high-severity vulnerabilities block promotion to production images. | 2 |
 | **6.2.3** | **Verify that** static code analysis runs on forked or vendored AI libraries. | 2 |
 | **6.2.4** | **Verify that** framework upgrade proposals include a security impact assessment referencing public vulnerability feeds. | 2 |
 | **6.2.5** | **Verify that** runtime sensors alert on unexpected dynamic library loads that deviate from the signed SBOM. | 3 |
@@ -41,8 +42,6 @@ Pin every dependency to immutable digests and verify builds to guarantee tamper-
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.3.1** | **Verify that** all package managers enforce version pinning via lockfiles. | 1 |
-| **6.3.2** | **Verify that** immutable digests are used instead of mutable tags in container references. | 1 |
 | **6.3.3** | **Verify that** expired or unmaintained dependencies trigger automated notifications to update or replace pinned versions. | 2 |
 | **6.3.4** | **Verify that** build attestations are retained for a period defined by organizational policy for audit traceability. | 3 |
 | **6.3.5** | **Verify that** reproducible-build checks compare hashes across CI runs to ensure identical outputs. | 3 |
@@ -85,7 +84,6 @@ Detect supply-chain threats early through vulnerability feeds, audit-log analyti
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **6.6.1** | **Verify that** incident response playbooks include rollback procedures for compromised models or libraries. | 2 |
-| **6.6.2** | **Verify that** CI/CD audit logs are streamed to centralized security monitoring in real time. | 2 |
 | **6.6.3** | **Verify that** threat-intelligence enrichment tags AI-specific indicators (e.g., model-poisoning indicators of compromise) in alert triage. | 3 |
 | **6.6.4** | **Verify that** security monitoring includes detection rules for anomalous package pulls and tampered or unexpected build steps in the CI/CD pipeline. | 2 |
 

--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -4,13 +4,13 @@
 
 This section provides requirements for delivering real-time and forensic visibility into what the model and other AI components see, do, and return, so threats can be detected, triaged, and learned from.
 
+> **Scope note:** General logging infrastructure controls — including secure log storage with retention policies, log encryption at rest and in transit, SIEM integration using standard formats, and success/failure rate tracking — are governed by [OWASP ASVS v5](https://owasp.org/www-project-application-security-verification-standard/) (V11, V12, V16). This chapter focuses on AI-specific monitoring concerns including AI interaction metadata logging, abuse detection, drift monitoring, hallucination detection, and agent behavior analysis.
+
 ## C13.1 Request & Response Logging
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **13.1.1** | **Verify that** AI interactions are logged with security-relevant metadata (e.g. timestamp, user ID, session ID, model version, token count, input hash, system prompt version, confidence score, safety filter outcome, and safety filter decisions) without logging prompt or response content by default. | 1 |
-| **13.1.2** | **Verify that** logs are stored in secure, access-controlled repositories with appropriate retention policies and backup procedures. | 1 |
-| **13.1.3** | **Verify that** log storage systems implement encryption at rest and in transit to protect sensitive information contained in logs. | 1 |
 | **13.1.4** | **Verify that** sensitive data in prompts and outputs is automatically redacted or masked before logging, with configurable redaction rules for PII, credentials, and proprietary information. | 1 |
 | **13.1.5** | **Verify that** policy decisions and safety filtering actions are logged with sufficient detail to enable audit and debugging of content moderation systems. | 2 |
 | **13.1.6** | **Verify that** log integrity is protected through e.g. cryptographic signatures or write-only storage. | 2 |
@@ -24,7 +24,6 @@ This section provides requirements for delivering real-time and forensic visibil
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **13.2.1** | **Verify that** the system detects and alerts on known jailbreak patterns, prompt injection attempts, and adversarial inputs using signature-based detection. | 1 |
-| **13.2.2** | **Verify that** the system integrates with existing Security Information and Event Management (SIEM) platforms using standard log formats and protocols. | 1 |
 | **13.2.3** | **Verify that** enriched security events include AI-specific context such as model identifiers, confidence scores, and safety filter decisions. | 2 |
 | **13.2.4** | **Verify that** behavioral anomaly detection identifies unusual conversation patterns, excessive retry attempts, or systematic probing behaviors. | 2 |
 | **13.2.5** | **Verify that** real-time alerting mechanisms notify security teams when potential policy violations or attack attempts are detected. | 2 |
@@ -61,7 +60,6 @@ Monitor and detect drift and degradation across model outputs, input distributio
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **13.4.1** | **Verify that** operational metrics including request latency, token consumption, memory usage, and throughput are continuously collected and monitored. | 1 |
-| **13.4.2** | **Verify that** success and failure rates are tracked with categorization of error types and their root causes. | 1 |
 | **13.4.3** | **Verify that** resource utilization monitoring includes GPU/CPU usage, memory consumption, and storage requirements with alerting on threshold breaches. | 2 |
 | **13.4.4** | **Verify that** token usage is tracked at granular attribution levels including per user, per session, per feature endpoint, and per team or workspace. | 2 |
 | **13.4.5** | **Verify that** output-to-input token ratio anomalies are detected and alerted. | 2 |


### PR DESCRIPTION
## Summary

Removes 25 controls from C04, C05, C06, and C13 that duplicate OWASP ASVS v5 without adding AI-specific implementation concerns, as identified in the analysis by @RicoKomenda in #659.

Each affected chapter now includes a **normative scope note** referencing the applicable ASVS v5 sections and clarifying that implementers should satisfy both standards.

## Controls Removed (25 total)

### C04 Infrastructure — 13 controls removed

| Removed | Description | ASVS v5 Equivalent |
|---------|-------------|---------------------|
| 4.1.1 | Least-privilege OS accounts | V13.2.1-13.2.2 |
| 4.1.2 | seccomp/AppArmor/SELinux sandboxing | V13.4.2 |
| 4.1.3 | Read-only root filesystem, noexec/nosuid | V13.4.2 |
| 4.3.1 | Default-deny network ingress/egress | V13.2.4 |
| 4.3.3 | Restrict admin/remote access, cloud metadata | V8.4.2, V13.2.3 |
| 4.3.4 | mTLS with cert validation and rotation | V12.3.1, V12.3.4-5 |
| 4.3.6 | Separate identity roles per environment | V13.2.1 |
| 4.4.1 | Secrets in dedicated vault | V13.3.1 |
| 4.4.2 | Strong auth for production secrets | V13.3.1, V6.3.3 |
| 4.4.3 | No secrets in source/configs/images/env vars | V13.2.1, V13.3.1 |
| 4.4.5 | Automated secret rotation | V11.1.1, V13.3.1 |
| 4.6.3 | Backup systems in isolated networks | V14.2.4 |
| 4.6.4 | Air-gapped or WORM backup storage | V14.2.4 |

### C05 Access Control — 4 controls removed

| Removed | Description | ASVS v5 Equivalent |
|---------|-------------|---------------------|
| 5.1.1 | Centralized IdP via OIDC/SAML | V6.3.3, V13.2.1 |
| 5.2.2 | Log all access control modifications | V16.3.1 |
| 5.2.3 | Immutable, tamper-evident audit logs | V16.4.1 |
| 5.2.5 | Real-time alerts on unauthorized access | V16.3.3 |

### C06 Supply Chain — 4 controls removed

| Removed | Description | ASVS v5 Equivalent |
|---------|-------------|---------------------|
| 6.2.2 | Critical/high CVEs block production promotion | V15.1.1 |
| 6.3.1 | Lockfile version pinning | V15.1.2 |
| 6.3.2 | Immutable digests instead of mutable tags | V15.2.4 |
| 6.6.2 | CI/CD audit logs to centralized SIEM | V16.4.3 |

### C13 Monitoring — 4 controls removed

| Removed | Description | ASVS v5 Equivalent |
|---------|-------------|---------------------|
| 13.1.2 | Secure log storage with retention/backups | V16.4.3 |
| 13.1.3 | Encrypt logs at rest and in transit | V11.3.2, V12.3.1 |
| 13.2.2 | SIEM integration with standard formats | V16.1.1, V16.4.3 |
| 13.4.2 | Track success/failure rates with categorization | V16.3.3, V16.5.1 |

## What's preserved

- All AI-specific controls remain untouched
- AI-specific sections (C4.5 TEEs/sandboxing, C4.7 hardware security, C4.8 edge/distributed, C5.3-5.6, C6.1/6.5/6.7, C13.3-13.7) are fully intact
- Net reduction: **514 → 489 controls** (~5% reduction)

## Reviewer

@ottosulin (per #659 assignment)

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)