### PR TITLE
C02 Reduction Pass

### DIFF
--- a/1.0/en/0x10-C02-User-Input-Validation.md
+++ b/1.0/en/0x10-C02-User-Input-Validation.md
@@ -4,6 +4,8 @@
 
 Robust validation of user input is a first-line defense against some of the most damaging attacks on AI systems. Prompt injection attacks can override system instructions, leak sensitive data, or steer the model toward behavior that is not allowed. Unless dedicated filters and other validation is in place, research shows that jailbreaks that exploit context windows will continue to be effective.
 
+> **Scope note:** This chapter covers AI-specific input validation concerns that go beyond general application input validation. Standard input validation (schema enforcement, type checking, character allow-listing, rate limiting, file upload validation, server-side enforcement, logging of validation failures) is addressed by OWASP ASVS v5 chapters V1, V2, V4, V5, and V16, and should be implemented as a baseline. This chapter focuses on threats unique to AI systems: prompt injection, adversarial inputs targeting model behavior, AI-specific content screening, and multi-modal attack vectors.
+
 ---
 
 ## C2.1 Prompt Injection Defense
@@ -14,113 +16,57 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.1.1** | **Verify that** all external or derived inputs that may steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier before being included in prompts or used to trigger actions. | 1 |
 | **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. This enforcement must be preserved across multi-step interactions and tool-augmented workflows. In such cases, prompt composition or intermediate outputs must not allow user-controlled content to influence or override system or developer instructions. | 1 |
-| **2.1.3** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
-| **2.1.4** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
+| **2.1.3** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, and that inputs exceeding token limits are rejected rather than silently truncated, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
+| **2.1.4** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
 | **2.1.5** | **Verify that** the system enforces per-request limits on the number of user-supplied demonstrations included in a single context window. | 2 |
 | **2.1.6** | **Verify that** the system detects patterns indicative of systematic in-context behavioral override attempts consistent with many-shot jailbreaking. | 2 |
 | **2.1.7** | **Verify that** detected in-context behavioral override attempts are classified and handled as prompt injection events. | 2 |
+| **2.1.8** | **Verify that** prompt injection screening respects user-specific policies (age and regional legal constraints) via attribute-based rules resolved at request time, including the role or permission level of the calling agent. | 2 |
+| **2.1.9** | **Verify that** the system implements a character set limitation for user inputs to model prompts, allowing only characters that are explicitly required for business purposes using an allow-list approach. | 1 |
 
 ---
 
-## C2.2 Adversarial-Example Resistance
+## C2.2 Pre-Tokenization Input Normalization
 
-AI models are vulnerable to subtle input perturbations that humans often miss but models tend to misclassify.
+AI models process text through tokenizers and embeddings that can be exploited via encoding tricks invisible to conventional input validation. Normalization before tokenization closes attack vectors such as homoglyph substitution, invisible character injection, and bidirectional text manipulation that bypass standard allow-list filters but alter model behavior.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.2.1** | **Verify that** basic input normalization steps (Unicode NFC, homoglyph mapping, whitespace trimming, removal of control and invisible Unicode characters) are run before tokenization or embedding and before parsing into tool or MCP arguments. | 1 |
+| **2.2.1** | **Verify that** input normalization (Unicode NFC canonicalization, homoglyph mapping, removal of control and invisible Unicode characters, and bidirectional text neutralization) is applied before tokenization or embedding, and that inputs which still contain suspicious encoding artifacts after normalization are rejected or flagged for review. | 1 |
 | **2.2.2** | **Verify that** suspected adversarial inputs are quarantined and logged. | 1 |
-| **2.2.3** | **Verify that** inputs that deviate from expected input patterns, as determined by statistical or semantic anomaly detection, are gated prior to inclusion in prompts or execution of actions. | 2 |
-| **2.2.4** | **Verify that** the inference pipeline supports adversarial-training-hardened model variants or defense layers (e.g., randomization, defensive distillation, alignment checks) for high-risk endpoints. | 2 |
-| **2.2.5** | **Verify that** encoding and representation smuggling in both inputs and outputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) are detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
+| **2.2.3** | **Verify that** encoding and representation smuggling in both inputs and outputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) are detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
 
 ---
 
-## C2.3 Prompt Character Set
+## C2.3 Content & Policy Screening
 
-Restricting the character set of user inputs to only allow characters that are necessary for business requirements can help prevent various types of attacks.
+Syntactically valid prompts may request disallowed content such as policy-violating instructions, harmful content, or restricted material. Input-side content screening prevents such prompts from reaching the model. For output-side content filtering, see C7.3.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.3.1** | **Verify that** the system implements a character set limitation for user inputs, allowing only characters that are explicitly required for business purposes using an allow-list approach. | 1 |
-| **2.3.2** | **Verify that** inputs containing characters outside of the allowed set are rejected and logged with trace metadata (source, tool or MCP server, agent ID, session). | 1 |
+| **2.3.1** | **Verify that** a content classifier scores every inbound prompt for violence, self-harm, hate, sexual content and illegal requests, with configurable thresholds, before the prompt is included in model context. | 1 |
+| **2.3.2** | **Verify that** inputs which violate policies are rejected so they do not propagate to downstream model or tool/MCP calls. | 1 |
+| **2.3.3** | **Verify that** screening logs include classifier confidence scores and policy category tags with applied stage (pre-prompt or post-response) and trace metadata (source, tool or MCP server, agent ID, session) for SOC correlation and future red-team replay. | 3 |
 
 ---
 
-## C2.4 Schema, Type & Length Validation
+## C2.4 Multi-Modal Input Validation
 
-AI attacks featuring malformed or oversized inputs can cause parsing errors, prompt spillage across fields, and resource exhaustion. Strict schema enforcement is also a prerequisite when performing deterministic tool calls.
+AI systems that accept non-textual inputs (images, audio, video, files) face unique attack vectors where malicious content can be embedded across modalities and extracted into text that feeds the model's context.
+
+> **Scope note:** Standard file upload validation (type, size, format, malware scanning, path traversal prevention) is covered by OWASP ASVS v5 chapter V5 and should be implemented as a baseline. This section addresses AI-specific risks: extraction of text from non-text inputs feeding into prompts, adversarial perturbations targeting model perception, and coordinated cross-modal attacks.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.4.1** | **Verify that** every API, tool, or MCP endpoint defines an explicit input schema (e.g., JSON Schema, Protocol Buffers, or multimodal equivalent). | 1 |
-| **2.4.2** | **Verify that** input validation rejects extra or unknown fields and implicit type coercion (strict schema enforcement). | 1 |
-| **2.4.3** | **Verify that** all input validation occurs server-side before prompt assembly or tool execution. | 1 |
-| **2.4.4** | **Verify that** inputs exceeding maximum token or byte limits are rejected with a safe error and never silently truncated. | 1 |
-| **2.4.5** | **Verify that** type checks (e.g., numeric ranges, enumerated values, and MIME types for images or audio) are enforced for all server-side inputs, including tool or MCP arguments. | 1 |
-| **2.4.6** | **Verify that** semantic validators run in constant time and avoid external network calls to prevent algorithmic DoS. | 2 |
-| **2.4.7** | **Verify that** validation failures are logged with redacted payload snippets and unambiguous error codes and include trace metadata (source, tool or MCP server, agent ID, session) to aid security triage. | 3 |
+| **2.4.1** | **Verify that** text extracted from non-text inputs (e.g., image-to-text, speech-to-text) and hidden or embedded content (metadata, layers, alt text, comments) is treated as untrusted and screened per 2.1.1. | 1 |
+| **2.4.2** | **Verify that** image/audio inputs are checked for adversarial perturbations, steganographic payloads, or known attack patterns, and detections trigger gating (block or degrade capabilities) before model use. | 2 |
+| **2.4.3** | **Verify that** cross-modal attack detection identifies coordinated attacks spanning multiple input types (e.g., steganographic payloads in images combined with prompt injection in text) with correlation rules and alert generation, and that confirmed detections are blocked or require HITL (human-in-the-loop) approval. | 3 |
 
 ---
-
-## C2.5 Content & Policy Screening
-
-Developers should be able to detect syntactically valid prompts that request disallowed content (such as policy-violating instructions, harmful content, or restricted material) then prevent them from propagating.
-
-| # | Description | Level |
-| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.5.1** | **Verify that** a content classifier scores every input and output for violence, self-harm, hate, sexual content and illegal requests, with configurable thresholds. | 1 |
-| **2.5.2** | **Verify that** inputs which violate policies will be rejected so they will not propagate to downstream model or tool/MCP calls. | 1 |
-| **2.5.3** | **Verify that** screening respects user-specific policies (age and regional legal constraints) via attribute-based rules resolved at request time, including the role or permission level of the calling agent. | 2 |
-| **2.5.4** | **Verify that** screening logs include classifier confidence scores and policy category tags with applied stage (pre-prompt or post-response) and trace metadata (source, tool or MCP server, agent ID, session) for SOC correlation and future red-team replay. | 3 |
-
----
-
-## C2.6 Input Rate Limiting & Abuse Prevention
-
-Developers should prevent abuse, resource exhaustion, and automated attacks against AI systems by limiting input rates and detecting anomalous usage patterns.
-
-> **Scope note:** Controls in this section address edge/API-level throttling applied to inbound requests before they enter AI processing — generic abuse prevention, DoS resistance, and brute-force mitigation. They are distinct from orchestration runtime budgets (C9.1), which govern internal execution of agentic tasks, and from attack-specific throttling designed to frustrate model-inversion or model-extraction attempts (C11.4, C11.5). Evidence that satisfies a C9.1 or C11 control does not satisfy C2.6, and vice versa.
-
-| # | Description | Level |
-| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.6.1** | **Verify that** per-user, per-IP, per-API-key, and per-agent and per-session/task rate limits are enforced for all input and tool/MCP endpoints. | 1 |
-| **2.6.2** | **Verify that** burst and sustained rate limits are tuned to prevent DoS and brute force attacks. | 2 |
-| **2.6.3** | **Verify that** anomalous usage patterns (e.g., rapid-fire requests, input flooding, repetitive failing tool/MCP calls or recursive agent loops) trigger automated blocks or escalations. | 2 |
-| **2.6.4** | **Verify that** abuse prevention logs are retained and reviewed for emerging attack patterns, with trace metadata (source, tool or MCP server, agent ID, session). | 3 |
-
----
-
-## C2.7 Multi-Modal Input Validation
-
-AI systems should include robust validation for non-textual inputs (images, audio, files) to prevent injection, evasion, or resource abuse.
-
-| # | Description | Level |
-| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.7.1** | **Verify that** all non-text inputs (images, audio, files) are validated for type, size, and format before processing. | 1 |
-| **2.7.2** | **Verify that** text extracted from non-text inputs (e.g., image-to-text, speech-to-text) and hidden or embedded content (metadata, layers, alt text, comments) is treated as untrusted and screened per 2.1.1. | 1 |
-| **2.7.3** | **Verify that** files are scanned for malware and steganographic payloads before ingestion, and that any active content (like scripts or macros) is removed or the file is quarantined. | 2 |
-| **2.7.4** | **Verify that** image/audio inputs are checked for adversarial perturbations or known attack patterns, and detections trigger gating (block or degrade capabilities) before model use. | 2 |
-| **2.7.5** | **Verify that** multi-modal input validation failures trigger detailed logging including all input modalities, validation results, threat scores, and trace metadata (source, tool or MCP server, agent ID, session as applicable), and generate alerts for investigation. | 3 |
-| **2.7.6** | **Verify that** cross-modal attack detection identifies coordinated attacks spanning multiple input types (e.g., steganographic payloads in images combined with prompt injection in text) with correlation rules and alert generation, and that confirmed detections are blocked or require HITL (human-in-the-loop) approval. | 3 |
-
----
-
-## C2.8 Real-Time Adaptive Threat Detection
-
-Developers should employ advanced threat detection systems for AI that adapt to new attack patterns and provide real-time protection.
-
-| # | Description | Level |
-| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.8.1** | **Verify that** pattern matching (e.g., compiled regular expressions) runs on all inputs and outputs (including tool/MCP surfaces). | 1 |
-| **2.8.2** | **Verify that** threat detection models adjust sensitivity based on recent attack activity and are updated with new patterns. | 2 |
-| **2.8.3** | **Verify that** threat detections trigger risk-adaptive responses (e.g., disable tools, shrink context, or require HITL approval). | 2 |
-| **2.8.4** | **Verify that** detection accuracy is improved via contextual analysis of user history, source, and session behavior, including trace metadata (source, tool or MCP server, agent ID, session). | 3 |
-| **2.8.5** | **Verify that** detection performance metrics (detection rate, false positive rate, processing latency) are continuously monitored and optimized, including time-to-block and stage (pre-prompt/post-response). | 3 |
 
 ## References
 
 * [OWASP LLM01:2025 Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)
 * [LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html)
-* [MITRE ATLAS : Adversarial Input Detection](https://atlas.mitre.org/mitigations/AML.M00150)
+* [MITRE ATLAS: Adversarial Input Detection](https://atlas.mitre.org/mitigations/AML.M00150)
 * [Mitigate jailbreaks and prompt injections](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks)

--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -10,7 +10,7 @@ Autonomous and multi-agent systems must execute only **authorized, intended, and
 
 Bound runtime expansion (recursion, concurrency, cost) and halt safely on runaway behavior.
 
-> **Scope note:** Controls in this section govern internal orchestration runtime budgets: per-task recursion depth, concurrency, wall-clock time, token spend, and monetary limits. They apply inside the agentic execution layer, not at the API ingress edge (C2.6) and not in response to adversarial probing patterns (C11.4, C11.5). A single token-spend cap at the API gateway does not satisfy C9.1 budget enforcement, which requires enforcement within the orchestration runtime itself.
+> **Scope note:** Controls in this section govern internal orchestration runtime budgets: per-task recursion depth, concurrency, wall-clock time, token spend, and monetary limits. They apply inside the agentic execution layer, not at the API ingress edge (see ASVS v5 V2.4 for generic rate limiting) and not in response to adversarial probing patterns (C11.4, C11.5). A single token-spend cap at the API gateway does not satisfy C9.1 budget enforcement, which requires enforcement within the orchestration runtime itself.
 
 | # | Description | Level |
 | :--: | --- | :---: |

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -50,7 +50,7 @@ Limit the ability to determine whether a specific record was in the training dat
 
 Prevent reconstruction of private training data or sensitive attributes from model outputs.
 
-> **Scope note:** Rate limiting in C11.4 is scoped specifically to inversion attack resistance: throttling repeated adaptive queries from the same principal to raise the cost of reconstructing training data or sensitive attributes. It is not a substitute for generic API rate limiting (C2.6) or orchestration execution budgets (C9.1). Both C2.6 and C11.4 may be satisfied simultaneously, but require distinct evidence — general abuse prevention cannot double-count as inversion resistance.
+> **Scope note:** Rate limiting in C11.4 is scoped specifically to inversion attack resistance: throttling repeated adaptive queries from the same principal to raise the cost of reconstructing training data or sensitive attributes. It is not a substitute for generic API rate limiting (see ASVS v5 V2.4) or orchestration execution budgets (C9.1). Generic abuse prevention cannot double-count as inversion resistance.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
@@ -64,7 +64,7 @@ Prevent reconstruction of private training data or sensitive attributes from mod
 
 Detect and deter unauthorized model cloning through API abuse. Rate limiting, query-pattern analysis, and watermarking are recommended defenses.
 
-> **Scope note:** Rate limits in C11.5 are calibrated specifically to make large-scale query harvesting for model cloning impractical — they are not general-purpose API throttles (C2.6). Satisfying C11.5.1 requires demonstrating that limits are sized to the extraction threat model (e.g., number of queries required to approximate the model), not merely that any rate limit is present.
+> **Scope note:** Rate limits in C11.5 are calibrated specifically to make large-scale query harvesting for model cloning impractical -- they are not general-purpose API throttles (see ASVS v5 V2.4). Satisfying C11.5.1 requires demonstrating that limits are sized to the extraction threat model (e.g., number of queries required to approximate the model), not merely that any rate limit is present.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -166,25 +166,18 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | Per-request demonstration count limits in context window | 2.1.5 |
 | Many-shot jailbreaking pattern detection (systematic in-context behavioral override) | 2.1.6 |
 | In-context behavioral override attempts classified as prompt injection events | 2.1.7 |
-| Third-party content sanitization | 2.1.3 |
-| Unicode NFC normalization and homoglyph mapping | 2.2.1 |
-| Control / invisible character removal | 2.2.1, 2.2.5 |
-| Statistical and embedding-distance anomaly detection on inputs | 2.2.3 |
-| Character set allow-listing | 2.3.1, 2.3.2 |
-| Schema validation (JSON Schema, Protocol Buffers) | 2.4.1, 7.1.1 |
-| Strict schema enforcement (reject unknown fields, type coercion) | 2.4.2 |
-| Server-side input validation before prompt assembly | 2.4.3 |
-| Token and byte limit enforcement | 2.4.4 |
-| Constant-time validation | 2.4.6 |
-| Content classifiers (hate, violence, sexual, illegal) | 2.5.1 |
-| Multi-modal input validation (images, audio, files) | 2.7.1 |
-| Extracted and hidden content from non-text inputs treated as untrusted | 2.7.2 |
-| Malware and steganography scanning | 2.7.3 |
-| Adversarial perturbation detection | 2.7.4 |
-| Cross-modal attack detection | 2.7.6 |
-| Pattern matching (regex) on inputs and outputs | 2.8.1 |
-| Adaptive detection models | 2.8.2 |
-| Risk-adaptive threat responses | 2.8.3 |
+| Context window proportion limits and token limit enforcement (reject, not truncate) | 2.1.3 |
+| Third-party content sanitization | 2.1.4 |
+| Character set allow-listing for model prompt inputs | 2.1.9 |
+| Pre-tokenization input normalization (Unicode NFC, homoglyph mapping, control/invisible character removal, bidirectional text neutralization) | 2.2.1 |
+| Adversarial input quarantine and logging | 2.2.2 |
+| Encoding and representation smuggling detection and mitigation | 2.2.3 |
+| Content classifiers for inbound prompts (hate, violence, sexual, illegal) | 2.3.1 |
+| Policy-violating input rejection before model propagation | 2.3.2 |
+| User-specific and agent-aware policy screening | 2.1.8 |
+| Extracted and hidden content from non-text inputs treated as untrusted | 2.4.1 |
+| Adversarial perturbation detection on image/audio inputs | 2.4.2 |
+| Cross-modal attack detection | 2.4.3 |
 | MCP input type checking, boundary validation, and enumeration enforcement | 10.4.4 |
 | MCP message-framing integrity and payload size limits | 10.4.3 |
 | MCP schema validation for tool and resource integrity | 10.4.2 |
@@ -228,8 +221,8 @@ Enforce consumption bounds to prevent abuse, runaway execution, and denial-of-se
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Per-user, per-IP, per-API-key rate limits | 2.6.1 |
-| Burst and sustained rate limiting | 2.6.2 |
+| Per-user, per-IP, per-API-key rate limits | ASVS v5 V2.4 |
+| Burst and sustained rate limiting | ASVS v5 V2.4 |
 | Per-agent token, cost, and tool-call budgets | 9.1.1 |
 | Recursion depth and max concurrency / fan-out limits | 9.1.1 |
 | Wall-clock time and monetary spend caps | 9.1.1 |
@@ -240,7 +233,7 @@ Enforce consumption bounds to prevent abuse, runaway execution, and denial-of-se
 | Sub-task delegation chain depth limit per execution | 7.4.4 |
 | Query-rate limiting for model extraction and inversion defense | 11.4.2, 11.5.1 |
 | MCP outbound execution limits, timeouts, recursion limits, and circuit breakers | 10.5.2 |
-| Anomalous usage pattern detection and blocking | 2.6.3 |
+| Anomalous usage pattern detection and blocking | 13.2.4, ASVS v5 V2.4 |
 | Resource quotas (CPU, memory, GPU) for infrastructure | 4.6.1 |
 | Threshold-based protection triggers on resource exhaustion | 4.6.2 |
 
@@ -392,7 +385,7 @@ Test for and defend against evasion, extraction, inversion, poisoning, and align
 | Red-team and jailbreak test suites (version-controlled) | 11.1.2 |
 | Automated harmful-content rate evaluation with regression detection | 11.1.3 |
 | RLHF / Constitutional AI alignment training | 11.1.4 |
-| Adversarial training and defensive distillation | 11.2.3, 2.2.4 |
+| Adversarial training and defensive distillation | 11.2.3 |
 | Adversarially robust distillation — distill teacher into student using adversarial training so the student inherits robustness as well as accuracy (implementation example for 11.2.3) | 11.2.3 |
 | Formal robustness verification (certified bounds, interval-bound propagation) | 11.2.5 |
 | Adversarial-example detection with production alerting | 11.2.2 |


### PR DESCRIPTION
Unlike C01, here are quite a few more suggested changes because ASVS does already cover input validation related controls quite extensively. Requirements that apply equally to any web API (schema validation, rate limiting, file type checking, generic logging) are deferred to ASVS v5 via scope notes rather than duplicated here.

PR reduces C02 from 8 sections / 35 requirements to 4 sections / 18 requirements by removing controls already covered by ASVSv5 or duplicated within other AISVS chapters, while retaining all AI-specific controls.

### Sections removed

| Section | Reason |
|---|---|
| C2.3 Prompt Character Set (as standalone section) | Section removed; character set allow-listing for prompt inputs retained as 2.1.9 in Prompt Injection Defense |
| C2.4 Schema, Type & Length | All generic schema/type validation covered by ASVS v5 V2.2. The AI-specific token truncation concern was merged into 2.1.3 |
| C2.6 Input Rate Limiting | Its own scope note called it "generic abuse prevention"; covered by ASVS v5 V2.4. AI-specific rate limiting already lives in C9.1 (orchestration budgets) and C11.4/C11.5 (attack-specific throttling) |
| C2.8 Real-Time Adaptive Threat Detection | Overlaps C13.2 (abuse detection/alerting), C11.7 (security policy adaptation), and C11.6 (inference-time poisoned-data detection) |

### Sections trimmed

| Section | Before | After | What changed |
|---|---|---|---|
| C2.2 Adversarial-Example Resistance | 5 reqs | 3 reqs (renamed to Pre-Tokenization Input Normalization) | Kept normalization (2.2.1), adversarial quarantine (2.2.2), and encoding smuggling detection (2.2.3). Removed anomaly gating (dup of C11.6) and adversarial training (dup of C11.2.3) |
| C2.5 Content & Policy Screening | 4 reqs | 3 reqs (renumbered to C2.3) | Clarified as input-side screening with cross-ref to C7.3 for output-side. User-specific policy screening moved to C2.1.8 |
| C2.7 Multi-Modal Input Validation | 6 reqs | 3 reqs (renumbered to C2.4) | Removed generic file validation (ASVS v5 V5.2), malware scanning (ASVS v5 V5.4.3), logging boilerplate (belongs in C13) |

### Requirements reworked or moved

| Requirement | Change |
|---|---|
| 2.1.3 (new) | Merged old 2.1.4 (context window proportion) with the AI-specific part of old 2.4.4 (token limits rejected not truncated) into a single requirement |
| 2.1.8 (new) | Moved user-specific policy screening (old 2.5.3) into C2.1 since it directly governs how prompt injection screening behaves per-user |
| 2.1.9 (new) | Moved character set allow-listing for prompt inputs (old 2.3.1) into C2.1 as a prompt injection defense measure |
| 2.2.1 | Clarified gating mechanism: inputs with suspicious encoding artifacts after normalization are rejected or flagged for review (previously unclear what happened on detection) |
| 2.4.2 | Added steganographic payload detection alongside adversarial perturbation and known attack pattern checks |

### Other changes

- C9.1, C11.4, C11.5 scope notes: replaced stale `C2.6` references with `ASVS v5 V2.4`
- Appendix D: updated all C2 requirement IDs to new numbering; redirected removed controls to ASVS v5 or correct AISVS chapter
- Added chapter-level scope note explaining the relationship to ASVS v5 baseline
