### PR TITLE
Add OpenAPI x-agent-trust to C9 References

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -138,3 +138,4 @@ Reduce cross-domain interference and emergent unsafe collective behavior.
 * [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
 * [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final)
 * [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026)
+* [OpenAPI x-agent-trust Extension (OAI Extensions Registry)](https://spec.openapis.org/registry/extension/x-agent-trust.html)


### PR DESCRIPTION
Hey Rico — `x-agent-trust` just got approved into the OpenAPI Extensions Registry. It's the wire-level binding for C9.4.1 (unique cryptographic agent identity, authenticated as a first-class principal to downstream systems) and C9.4.2 (signed, timestamped agent-initiated actions). Would sit nicely in the C9 references.

https://spec.openapis.org/registry/extension/x-agent-trust.html

Thanks,
Raza