### PR TITLE
Reduction pass C03

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -58,11 +58,9 @@ Model development and training processes must follow secure practices to prevent
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **3.4.1** | **Verify that** model development, testing, and production environments are logically or physically separated with distinct access controls. | 1 |
-| **3.4.2** | **Verify that** separated environments do not share infrastructure, data stores, agent orchestration runtimes, or tool/MCP servers across environment boundaries. | 1 |
-| **3.4.3** | **Verify that** model development artifacts (such as hyperparameters, training scripts, configuration files, prompt templates, agent policies/routing graphs, tool or MCP contracts/schemas, and action catalogs or capability allow-lists) are stored in version control and require peer review approval before use in training. | 1 |
-| **3.4.4** | **Verify that** model training and fine-tuning occur in isolated environments with controlled network access using egress allow-lists and no access to production tools or MCP resources. | 2 |
-| **3.4.5** | **Verify that** training data sources are validated through integrity checks and authenticated via trusted sources with documented chain of custody before use in model development, including RAG indexes, tool logs, and agent-generated data used for fine-tuning. | 2 |
+| **3.4.1** | **Verify that** AI-specific runtime components (agent orchestration services, tool/MCP servers, model registries, and prompt/policy stores) are not shared across environment boundaries (e.g., development, staging, production). | 1 |
+| **3.4.2** | **Verify that** AI-specific configuration artifacts (prompt templates, agent policies and routing graphs, tool or MCP contracts and schemas, and action catalogs or capability allow-lists) are subject to the same version control and peer review requirements as application code. | 1 |
+| **3.4.3** | **Verify that** model training and fine-tuning environments do not have access to production model endpoints, agent orchestration services, tool/MCP servers, or live RAG data sources. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -59,8 +59,8 @@ Model development and training processes must follow secure practices to prevent
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **3.4.1** | **Verify that** AI-specific runtime components (agent orchestration services, tool/MCP servers, model registries, and prompt/policy stores) are not shared across environment boundaries (e.g., development, staging, production). | 1 |
-| **3.4.2** | **Verify that** AI-specific configuration artifacts (prompt templates, agent policies and routing graphs, tool or MCP contracts and schemas, and action catalogs or capability allow-lists) are subject to the same version control and peer review requirements as application code. | 1 |
-| **3.4.3** | **Verify that** model training and fine-tuning environments do not have access to production model endpoints, agent orchestration services, tool/MCP servers, or live RAG data sources. | 2 |
+| **3.4.2** | **Verify that** AI-specific configuration artifacts (prompt templates, agent policies and routing graphs, tool or MCP contracts and schemas, and action catalogs or capability allow-lists) are stored in version control with change history and require approved review before deployment. | 1 |
+| **3.4.3** | **Verify that** model training and fine-tuning environments are isolated from production model endpoints, agent orchestration services, tool/MCP servers, and live RAG data sources. | 2 |
 
 ---
 


### PR DESCRIPTION
Polishes C03 (Model Lifecycle Management) by removing or reworking requirements that are not AI-specific or duplicate controls already present in ASVS v5 or other AISVS chapters (C1, C4).

## Changes

### Removed: 3.4.1 (environment separation)

Generic DevOps/security practice ("dev, testing, and production environments are logically or physically separated with distinct access controls"). Not AI-specific - applies equally to any software system. Already covered by:
- AISVS C4.3.2: "AI workloads across environments run in isolated network segments with no direct internet access and no cross-environment network connectivity."
- AISVS C4.3.6: "environments use separate identity roles and security groups with no shared principals or credentials across environment boundaries."

### Removed: 3.4.5 (training data source validation)

Heavily overlaps with C1 (Training Data Integrity & Traceability):
- C1.1.1 covers inventory of training data sources with origin and processing history.
- C1.2.4 covers cryptographic hashes/signatures for data integrity.
- C1.2.5 covers automated integrity monitoring against unauthorized modifications.
- C1.5.1 covers lineage of each dataset including transformations.

The tail clause about "RAG indexes, tool logs, and agent-generated data used for fine-tuning" is already scoped into C1 by its general applicability to all training data.

### Reworked: 3.4.2 (environment isolation)

The original mixed generic infrastructure isolation (already in C4.3.2) with AI-specific concerns. Reworked to focus only on the AI-specific layer: agent orchestration runtimes, tool/MCP servers, and model registries must not be shared across environment boundaries. Removed the generic "infrastructure, data stores" part that C4 already covers.

### Reworked: 3.4.3 (version control and peer review)

The original was a compound requirement mixing a generic software practice (use version control + peer review) with AI-specific artifact types. "Stored in version control and require peer review" is standard SDLC, not AI-specific. Reworked to focus on the AI-specific value: ensuring that AI-specific configuration artifacts (prompt templates, agent policies, tool/MCP schemas, capability allow-lists) are subject to the same version control and review rigor as application code. This framing acknowledges these artifact types are often treated informally and highlights the AI-specific gap.

### Reworked: 3.4.4 (training environment isolation)

The original overlapped with C4.3.1 (default-deny network policies) and C4.3.2 (isolated network segments). Reworked to focus on the AI-specific isolation concern: training and fine-tuning environments must not have access to production model endpoints, agent orchestration services, tool/MCP servers, or live RAG data sources. The generic network isolation is left to C4.

## Requirements retained without changes

All requirements in C3.1, C3.2, C3.3, C3.5, and C3.6 are retained. They are AI-specific (model artifacts, MBOM/AIBOM, model safety evaluations, agent workflow testing, model rollback, hosted model controls, RLHF reward model integrity) and not covered by ASVS v5 or other AISVS chapters.
