### PR TITLE
Add C9.7.7: Fail-closed on governance PDP unavailability

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -111,6 +111,7 @@ Prevent "technically authorized but unintended" actions by binding execution to 
 | **9.7.4** | **Verify that** any mismatch between intended outcome and actual results triggers containment and, where supported, compensating actions. | 2 |
 | **9.7.5** | **Verify that** prompt templates and agent policy configurations retrieved from a remote source are integrity-verified at load time against their approved versions (e.g., via hashes or signatures). | 3 |
 | **9.7.6** | **Verify that** all write operations to persistent external state are authorized by either explicit human approval or an independent policy-based authorization mechanism that evaluates the operation against the original user intent, and not solely on agent-generated output. | 2 |
+| **9.7.7** | **Verify that** when the policy decision point (PDP) used for governance evaluation is unavailable (e.g., timeout, network partition, service failure), agent execution fails closed by blocking the proposed action, and the unavailability event is logged with sufficient detail for incident investigation. | 2 |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds **C9.7.7** (Level 2): requires agent execution to fail closed when the policy decision point (PDP) is unavailable (timeout, network partition, service failure), blocking the proposed action and logging the event

## Rationale
C5.3.2 covers failed authorization evaluations (PDP returning denial) and C9.7.1 covers violations returned by the gate, but neither explicitly addresses the case where no response arrives from the PDP. This control closes that gap by requiring fail-closed behavior on PDP unavailability.

Testable: simulate PDP unavailability, confirm execution is blocked, confirm the event is logged.

See discussion in #676 for full analysis.

## Test plan
- [ ] Verify C9.7.7 numbering does not conflict (9.7.5 and 9.7.6 are taken)
- [ ] Confirm Level 2 assignment is appropriate
- [ ] Verify control is testable as described

Closes #676