### PR TITLE
Add C14.1.6: Out-of-band kill-switch enforcement for agents

### DIFF
--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -17,6 +17,7 @@ Provide shutdown or rollback paths when unsafe behavior of the AI system is obse
 | **14.1.3** | **Verify that** rollback procedures can revert to previous model versions or safe-mode operations. | 3 |
 | **14.1.4** | **Verify that** override mechanisms are tested regularly. | 3 |
 | **14.1.5** | **Verify that** the system can be placed into at least two intermediate operational states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined entry triggers and can be exited independently without requiring a full system restart or shutdown. | 2 |
+| **14.1.6** | **Verify that** override and kill-switch commands for autonomous agents are delivered and enforced through a channel that the agent runtime cannot access, intercept, or suppress (e.g., out-of-band infrastructure controls, hypervisor-level signals, network-layer isolation), so that a compromised or manipulated agent cannot prevent its own shutdown. | 2 |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds **C14.1.6** (Level 2): requires override and kill-switch commands for autonomous agents to be delivered and enforced through a channel the agent runtime cannot access, intercept, or suppress

## Rationale
The original proposal (#677) suggested cryptographic authentication for kill-switch commands. Reviewer feedback identified two issues: (1) cryptographic signing only works if the validation layer is outside the agent's control, and (2) many kill-switch implementations operate below the application layer where cryptographic signing is architecturally irrelevant.

This control reframes the requirement to focus on the delivery channel rather than the signing mechanism, addressing the core suppression threat while remaining compatible with both software-based and hardware-level override mechanisms.

See discussion in #677 for full analysis.

## Test plan
- [ ] Verify C14.1.6 numbering does not conflict with existing controls
- [ ] Confirm the control is compatible with both software and hardware override mechanisms
- [ ] Confirm Level 2 assignment is appropriate

Closes #677