### PR TITLE
Strengthen C5.6.4: Runtime isolation for agent PDP

### DIFF
--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -87,7 +87,9 @@ Control permissions for AI agents and autonomous systems through scoped capabili
 | **5.6.1** | **Verify that** autonomous agents receive scoped capability tokens that explicitly enumerate permitted actions, accessible resources, time boundaries, and operational constraints. | 1 |
 | **5.6.2** | **Verify that** high-risk capabilities (file system access, code execution, external API calls, financial transactions) are disabled by default and require explicit authorization. | 1 |
 | **5.6.3** | **Verify that** capability tokens are bound to user sessions, include cryptographic integrity protection, and cannot be persisted or reused across sessions. | 2 |
-| **5.6.4** | **Verify that** agent-initiated actions undergo authorization through a policy decision point that evaluates contextual attributes (e.g., user identity, resource sensitivity, action type, environmental context). | 3 |
+| **5.6.4** | **Verify that** agent-initiated actions undergo authorization through a policy decision point that is isolated from the agent's execution environment such that a compromised or manipulated agent runtime cannot influence or bypass the evaluation, and that evaluates contextual attributes (e.g., user identity, resource sensitivity, action type, environmental context) based on a structured action description rather than the agent's raw reasoning context. | 3 |
+
+> **Scope note -- C5.6.4 runtime isolation.** The policy decision point must receive a sanitized, structured representation of the proposed action (action type, target resource, parameters) rather than the agent's full context window, which may contain injected content that could influence the evaluation. This isolation requirement complements C14.1 (human oversight gates) and C9.6.4 (model cannot make access control decisions). For high-risk actions, C14.2 defines the escalation path from automated governance evaluation to human approval.
 
 ---
 

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -82,6 +82,8 @@ Ensure logical and cryptographic isolation between tenants in shared AI infrastr
 
 Control permissions for AI agents and autonomous systems through scoped capability tokens and continuous authorization.
 
+> **Scope note:** Runtime isolation of the policy decision point from the agent execution environment complements C9.6.4 (model cannot make access control decisions) and C14.2 (human oversight escalation for high-risk actions).
+
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.6.1** | **Verify that** autonomous agents receive scoped capability tokens that explicitly enumerate permitted actions, accessible resources, time boundaries, and operational constraints. | 1 |

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -82,14 +82,14 @@ Ensure logical and cryptographic isolation between tenants in shared AI infrastr
 
 Control permissions for AI agents and autonomous systems through scoped capability tokens and continuous authorization.
 
+> **Scope note:** The policy decision point must receive a sanitized, structured representation of the proposed action (action type, target resource, parameters) rather than the agent's full context window, which may contain injected content that could influence the evaluation. This isolation requirement complements C14.1 (human oversight gates) and C9.6.4 (model cannot make access control decisions). For high-risk actions, C14.2 defines the escalation path from automated governance evaluation to human approval.
+
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.6.1** | **Verify that** autonomous agents receive scoped capability tokens that explicitly enumerate permitted actions, accessible resources, time boundaries, and operational constraints. | 1 |
 | **5.6.2** | **Verify that** high-risk capabilities (file system access, code execution, external API calls, financial transactions) are disabled by default and require explicit authorization. | 1 |
 | **5.6.3** | **Verify that** capability tokens are bound to user sessions, include cryptographic integrity protection, and cannot be persisted or reused across sessions. | 2 |
 | **5.6.4** | **Verify that** agent-initiated actions undergo authorization through a policy decision point that is isolated from the agent's execution environment such that a compromised or manipulated agent runtime cannot influence or bypass the evaluation, and that evaluates contextual attributes (e.g., user identity, resource sensitivity, action type, environmental context) based on a structured action description rather than the agent's raw reasoning context. | 3 |
-
-> **Scope note -- C5.6.4 runtime isolation.** The policy decision point must receive a sanitized, structured representation of the proposed action (action type, target resource, parameters) rather than the agent's full context window, which may contain injected content that could influence the evaluation. This isolation requirement complements C14.1 (human oversight gates) and C9.6.4 (model cannot make access control decisions). For high-risk actions, C14.2 defines the escalation path from automated governance evaluation to human approval.
 
 ---
 

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -82,14 +82,14 @@ Ensure logical and cryptographic isolation between tenants in shared AI infrastr
 
 Control permissions for AI agents and autonomous systems through scoped capability tokens and continuous authorization.
 
-> **Scope note:** The policy decision point must receive a sanitized, structured representation of the proposed action (action type, target resource, parameters) rather than the agent's full context window, which may contain injected content that could influence the evaluation. This isolation requirement complements C14.1 (human oversight gates) and C9.6.4 (model cannot make access control decisions). For high-risk actions, C14.2 defines the escalation path from automated governance evaluation to human approval.
-
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.6.1** | **Verify that** autonomous agents receive scoped capability tokens that explicitly enumerate permitted actions, accessible resources, time boundaries, and operational constraints. | 1 |
 | **5.6.2** | **Verify that** high-risk capabilities (file system access, code execution, external API calls, financial transactions) are disabled by default and require explicit authorization. | 1 |
 | **5.6.3** | **Verify that** capability tokens are bound to user sessions, include cryptographic integrity protection, and cannot be persisted or reused across sessions. | 2 |
-| **5.6.4** | **Verify that** agent-initiated actions undergo authorization through a policy decision point that is isolated from the agent's execution environment such that a compromised or manipulated agent runtime cannot influence or bypass the evaluation, and that evaluates contextual attributes (e.g., user identity, resource sensitivity, action type, environmental context) based on a structured action description rather than the agent's raw reasoning context. | 3 |
+| **5.6.4** | **Verify that** agent-initiated actions undergo authorization through a policy decision point that evaluates contextual attributes (e.g., user identity, resource sensitivity, action type, environmental context). | 3 |
+| **5.6.5** | **Verify that** the policy decision point for agent authorization is isolated from the agent's execution environment such that a compromised agent runtime cannot influence or bypass evaluation. | 3 |
+| **5.6.6** | **Verify that** the policy decision point receives structured action descriptions (e.g., action type, target resource, parameters) rather than the agent's raw reasoning context. | 3 |
 
 ---
 


### PR DESCRIPTION
## Summary
- **Updates C5.6.4** to explicitly require that the policy decision point is isolated from the agent's execution environment, so a compromised agent cannot influence or bypass evaluation
- Adds requirement that the PDP receives structured action descriptions rather than the agent's raw reasoning context
- Adds **scope note** cross-referencing C14.1, C14.2, and C9.6.4 for the escalation path

## Rationale
Existing controls (C5.2.6, C5.6.4, C9.6.4) already require an external PDP for agent authorization, but none explicitly state that the PDP must be isolated at runtime such that a compromised agent cannot reach or influence it. The data-plane isolation concern (PDP should not ingest the raw agent context that may contain injected content) was raised in the discussion and is addressed in the scope note.

Per reviewer consensus in #662 (Rico + Otto), strengthening C5.6.4 with a scope note is preferred over a new standalone control.

## Test plan
- [ ] Verify updated C5.6.4 wording is clear and auditable
- [ ] Confirm cross-references to C14.1, C14.2, C9.6.4 are accurate
- [ ] Verify Level 3 assignment remains appropriate

Closes #662