### PR TITLE
Add fine-tuning data cross-references in C3.6 and example in C1.4.2

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -5,7 +5,7 @@
 Training data must be sourced, handled, and maintained in a way that preserves origin traceability, integrity, and quality. The core security concern is ensuring data has not been tampered with, poisoned, or corrupted. Security-relevant bias (e.g., skewed abuse-detection training data that allows attackers to bypass controls) is treated as a possible consequence of compromised or unvalidated data, not as a standalone control category.
 
 > **Scope note -- bias.** AISVS addresses bias only where it introduces security risk (e.g., bypass of abuse detection, authentication heuristics, or automated trust decisions). Broader fairness governance requirements are out of scope; see e.g. ISO/IEC 42001 or the NIST AI RMF for general fairness and ethics guidance.
-
+>
 > **Scope note -- general data security.** Generic data security control details for access control, logging, encryption at rest and in transit, and data retention/purging are covered by ASVS v5 (V8, V11, V12, V14, V16) and apply to training data storage and labeling systems. This section sets on higher level requirements with levels that are specific to AI.
 
 ---

--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -60,7 +60,7 @@ Combine automated validation, manual spot-checks, and logged remediation to guar
 | # | Description | Level |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
 | **1.4.1** | **Verify that** automated tests catch format errors and nulls on every ingest or significant data transformation. | 1 |
-| **1.4.2** | **Verify that** training and fine-tuning pipelines implement data integrity validation and poisoning detection techniques (e.g., statistical analysis, outlier detection, embedding analysis) to identify potential data poisoning or unintentional corruption in training data. | 2 |
+| **1.4.2** | **Verify that** training and fine-tuning pipelines implement data integrity validation and poisoning detection techniques (e.g., statistical analysis, outlier detection, embedding analysis) to identify potential data poisoning or unintentional corruption in training data, including detection of poisoned RLHF/DPO preference pairs designed to train the model to comply with harmful instructions or bypass safety alignment. | 2 |
 | **1.4.3** | **Verify that** automatically generated labels (e.g., via models or weak supervision) are subject to confidence thresholds and consistency checks to detect misleading or low-confidence labels. | 2 |
 | **1.4.4** | **Verify that** appropriate defenses, such as adversarial training, data augmentation with perturbed inputs, or robust optimization techniques, are implemented and tuned for relevant models based on risk assessment. | 3 |
 | **1.4.5** | **Verify that** automated tests catch label skews on every ingest or significant data transformation. | 2 |

--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -15,7 +15,7 @@ Training data must be sourced, handled, and maintained in a way that preserves o
 Maintain a verifiable inventory of all datasets, accept only trusted sources, and log every change for auditability.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **1.1.1** | **Verify that** an up-to-date inventory of every training-data source (origin, responsible party, license, collection method, intended use constraints, and processing history) is maintained. | 1 |
 | **1.1.2** | **Verify that** training data processes exclude unnecessary features, attributes, or fields (e.g., unused metadata, sensitive PII, leaked test data). | 1 |
 | **1.1.3** | **Verify that** all dataset changes are subject to a logged approval workflow. | 1 |
@@ -28,7 +28,7 @@ Maintain a verifiable inventory of all datasets, accept only trusted sources, an
 Restrict access to training data, encrypt it at rest and in transit, and validate its integrity to prevent tampering, theft, or data poisoning.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **1.2.1** | **Verify that** access controls protect training data storage and pipelines. | 1 |
 | **1.2.2** | **Verify that** all access to training data is logged, including user, time, and action. | 1 |
 | **1.2.3** | **Verify that** training datasets are encrypted in transit and at rest, using current recommended cryptographic algorithms and key management practices. | 1 |
@@ -44,7 +44,7 @@ Restrict access to training data, encrypt it at rest and in transit, and validat
 Ensure labeling and annotation processes are access-controlled and auditable.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **1.3.1** | **Verify that** labeling interfaces and platforms enforce access controls that restrict who can create, modify, or approve annotations. | 1 |
 | **1.3.2** | **Verify that** all labeling activities are recorded in audit logs, including the annotator identity, timestamp, and action performed. | 1 |
 | **1.3.3** | **Verify that** annotator identity metadata is exported and retained alongside the dataset so that every annotation or preference pair can be attributed to a specific, verified human annotator throughout the training pipeline. | 1 |
@@ -58,7 +58,7 @@ Ensure labeling and annotation processes are access-controlled and auditable.
 Combine automated validation, manual spot-checks, and logged remediation to guarantee dataset reliability.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **1.4.1** | **Verify that** automated tests catch format errors and nulls on every ingest or significant data transformation. | 1 |
 | **1.4.2** | **Verify that** training and fine-tuning pipelines implement data integrity validation and poisoning detection techniques (e.g., statistical analysis, outlier detection, embedding analysis) to identify potential data poisoning or unintentional corruption in training data, including detection of poisoned RLHF/DPO preference pairs designed to train the model to comply with harmful instructions or bypass safety alignment. | 2 |
 | **1.4.3** | **Verify that** automatically generated labels (e.g., via models or weak supervision) are subject to confidence thresholds and consistency checks to detect misleading or low-confidence labels. | 2 |
@@ -73,7 +73,7 @@ Combine automated validation, manual spot-checks, and logged remediation to guar
 Track the full journey of each dataset from source to model input for auditability and incident response.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **1.5.1** | **Verify that** the lineage of each dataset and its components, including all transformations, augmentations, and merges, is recorded and can be reconstructed. | 1 |
 | **1.5.2** | **Verify that** lineage records are immutable, securely stored, and accessible for audits. | 2 |
 | **1.5.3** | **Verify that** lineage tracking covers synthetic data generated via augmentation, synthesis, or privacy-preserving techniques. | 2 |

--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -90,8 +90,6 @@ Fine-tuning pipelines are high-privilege operations that can alter deployed mode
 | **3.6.3** | **Verify that** RLHF training stages include automated detection of reward hacking or reward model over-optimization (e.g., held-out human-preference probe sets, divergence thresholds, or KL penalty monitoring), with the run blocked from promotion if detection thresholds are exceeded. | 3 |
 | **3.6.4** | **Verify that** in multi-stage fine-tuning pipelines, each stage's output is integrity-verified before the next stage consumes it, and intermediate checkpoints are registered as distinct artifacts enabling per-stage rollback. | 3 |
 
-> **Cross-reference -- fine-tuning data security.** Fine-tuning data (including RLHF preference pairs and DPO data) is explicitly covered by existing controls: C1.3.4 (integrity of fine-tuning feedback records including RLHF preference pairs), C1.4.2 (poisoning detection in fine-tuning pipelines), C3.4.5 (integrity checks on data used for fine-tuning), C5.2.1 (access controls on datasets), C12.5 (consent for user data), and C12.2.1 (deletion propagation to raw datasets). These controls apply to fine-tuning data with the same force as to initial training data.
-
 ---
 
 ## References

--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -90,6 +90,8 @@ Fine-tuning pipelines are high-privilege operations that can alter deployed mode
 | **3.6.3** | **Verify that** RLHF training stages include automated detection of reward hacking or reward model over-optimization (e.g., held-out human-preference probe sets, divergence thresholds, or KL penalty monitoring), with the run blocked from promotion if detection thresholds are exceeded. | 3 |
 | **3.6.4** | **Verify that** in multi-stage fine-tuning pipelines, each stage's output is integrity-verified before the next stage consumes it, and intermediate checkpoints are registered as distinct artifacts enabling per-stage rollback. | 3 |
 
+> **Cross-reference -- fine-tuning data security.** Fine-tuning data (including RLHF preference pairs and DPO data) is explicitly covered by existing controls: C1.3.4 (integrity of fine-tuning feedback records including RLHF preference pairs), C1.4.2 (poisoning detection in fine-tuning pipelines), C3.4.5 (integrity checks on data used for fine-tuning), C5.2.1 (access controls on datasets), C12.5 (consent for user data), and C12.2.1 (deletion propagation to raw datasets). These controls apply to fine-tuning data with the same force as to initial training data.
+
 ---
 
 ## References


### PR DESCRIPTION
## Summary
- Adds **cross-reference note** in C3.6 making existing fine-tuning data security coverage discoverable (C1.3.4, C1.4.2, C3.4.5, C5.2.1, C12.5, C12.2.1)
- Adds **alignment-manipulation example** to C1.4.2: poisoned RLHF/DPO preference pairs designed to train models to comply with harmful instructions or bypass safety alignment

## Rationale
Per reviewer analysis in #670, fine-tuning data security is already covered by existing controls across C01, C03, C05, and C12, but the coverage is not discoverable from C3.6. No new controls are needed — a cross-reference note makes the existing coverage explicit.

The preference-pair poisoning angle (alignment manipulation via poisoned preference data) is a meaningful refinement of the poisoning threat that fits as an example in C1.4.2 rather than a new standalone control.

## Test plan
- [ ] Verify all cross-referenced control IDs are accurate
- [ ] Confirm the preference-pair poisoning example is appropriate for C1.4.2

Closes #670