### PR TITLE
Add scope note to C13.2.10: token-level metadata exfiltration

### DIFF
--- a/.github/workflows/config/local-custom.txt
+++ b/.github/workflows/config/local-custom.txt
@@ -111,3 +111,5 @@ PATE
 TOCTOU
 jailbreaking
 jailbreak
+logprob
+logprobs

--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -34,6 +34,8 @@ This section provides requirements for delivering real-time and forensic visibil
 | **13.2.9** | **Verify that** per-user and per-session token consumption triggers an alert when consumption exceeds defined thresholds. | 2 |
 | **13.2.10** | **Verify that** LLM API traffic is monitored for covert channel indicators, including Base64-encoded payloads, structured non-human query patterns, and communication signatures consistent with malware command-and-control activity using LLM endpoints. | 3 |
 
+> **Scope note -- C13.2.10 token-level metadata.** Monitoring under C13.2.10 should include token-level metadata access patterns (e.g., high-frequency logprob API requests, systematic enumeration of token probabilities) as a signal for data exfiltration via timing or token-probability side channels. Anomalous logprob access patterns fall within the "structured non-human query patterns" indicator. C4.7.8 covers accelerator-level side-channel telemetry; C13.2.4 covers behavioral anomaly detection for systematic probing.
+
 ---
 
 ## C13.3 Model, Data, and Performance Drift Detection

--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -21,6 +21,8 @@ This section provides requirements for delivering real-time and forensic visibil
 
 ## C13.2 Abuse Detection and Alerting
 
+> **Scope note:** Monitoring under C13.2.10 should include token-level metadata access patterns (e.g., high-frequency logprob API requests, systematic enumeration of token probabilities) as a signal for data exfiltration via timing or token-probability side channels. Anomalous logprob access patterns fall within the "structured non-human query patterns" indicator. C4.7.8 covers accelerator-level side-channel telemetry; C13.2.4 covers behavioral anomaly detection for systematic probing.
+
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **13.2.1** | **Verify that** the system detects and alerts on known jailbreak patterns, prompt injection attempts, and adversarial inputs using signature-based detection. | 1 |
@@ -33,8 +35,6 @@ This section provides requirements for delivering real-time and forensic visibil
 | **13.2.8** | **Verify that** session-level conversation trajectory analysis detects multi-turn jailbreak patterns where no individual turn is overtly malicious in isolation but the aggregate conversation exhibits attack indicators. | 3 |
 | **13.2.9** | **Verify that** per-user and per-session token consumption triggers an alert when consumption exceeds defined thresholds. | 2 |
 | **13.2.10** | **Verify that** LLM API traffic is monitored for covert channel indicators, including Base64-encoded payloads, structured non-human query patterns, and communication signatures consistent with malware command-and-control activity using LLM endpoints. | 3 |
-
-> **Scope note -- C13.2.10 token-level metadata.** Monitoring under C13.2.10 should include token-level metadata access patterns (e.g., high-frequency logprob API requests, systematic enumeration of token probabilities) as a signal for data exfiltration via timing or token-probability side channels. Anomalous logprob access patterns fall within the "structured non-human query patterns" indicator. C4.7.8 covers accelerator-level side-channel telemetry; C13.2.4 covers behavioral anomaly detection for systematic probing.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds **scope note** to C13.2.10 clarifying that covert channel monitoring should include token-level metadata access patterns (logprob API requests, systematic token probability enumeration) as data exfiltration signals
- Cross-references C4.7.8 (accelerator-level telemetry) and C13.2.4 (behavioral anomaly detection)

## Rationale
The original proposal (#672) suggested a new standalone control for timing and token-probability side-channel detection. Reviewer feedback identified partial overlap with C13.2.10 (covert channel monitoring), C13.2.4 (behavioral anomaly detection), and C4.7.8 (accelerator-level telemetry). The two sub-requirements (rate limiting on metadata API access and bounding response timing variance) were assessed as either not AI-specific or not clearly verifiable.

A narrower scope note in C13.2.10 pointing to token-level metadata access as a monitored signal is the cleaner approach per reviewer recommendation.

## Test plan
- [ ] Verify scope note accurately describes the monitoring signal
- [ ] Confirm cross-references to C4.7.8 and C13.2.4 are accurate

Closes #672