### PR TITLE
Add architectural note to C9.6: evaluation-only policy components

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -87,6 +87,8 @@ Protect agent-to-agent and agent-to-tool communications from hijacking, injectio
 
 Ensure every action is authorized at execution time and constrained by scope.
 
+> **Architectural note -- evaluation-only policy components.** Policy decision components used for agent authorization (C9.6.4, C5.6.4, C5.2.6) should be evaluation-only: they evaluate proposed actions against policy rules and return permit/deny decisions, but do not themselves execute actions, invoke tools, or modify external resources. This separation follows the NIST SP 800-207 control-plane/data-plane principle. Standard purpose-built policy engines (e.g., OPA, Cedar) are evaluation-only by design.
+
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.6.1** | **Verify that** agent actions are authorized against fine-grained policies enforced by the runtime that restrict which tools an agent may invoke, which parameter values it may supply (e.g., allowed resources, data scopes, action types), and that policy violations are blocked. | 1 |


### PR DESCRIPTION
## Summary
- Adds **architectural note** in C9.6 clarifying that policy decision components for agent authorization should be evaluation-only: they evaluate proposed actions and return permit/deny decisions, but do not execute actions, invoke tools, or modify resources
- References NIST SP 800-207 control-plane/data-plane separation principle

## Rationale
The original proposal (#675) suggested a standalone verifiable control requiring governance components to not possess execution ability. Reviewer feedback identified two issues: (1) the constraint is not clearly verifiable as a standalone control (an auditor cannot reliably enumerate all execution pathways), and (2) it is not AI-specific — control-plane/data-plane separation is a general NIST SP 800-207 principle.

The existing C9.6.4, C5.6.4, and C5.2.6 already push implementers toward purpose-built evaluation components. An architectural note makes this design expectation explicit without creating a control that is hard to audit independently.

## Test plan
- [ ] Verify the architectural note is consistent with C9.6.4, C5.6.4, C5.2.6
- [ ] Confirm NIST SP 800-207 reference is appropriate

Closes #675