### PR TITLE
Reduction pass C06

### DIFF
--- a/.github/workflows/config/local-custom.txt
+++ b/.github/workflows/config/local-custom.txt
@@ -113,3 +113,5 @@ jailbreaking
 jailbreak
 logprob
 logprobs
+SLSA
+SCVS

--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -35,15 +35,14 @@ Allow AI artifact downloads only from organization-approved sources and verify m
 
 ## C6.3 Third-Party Dataset Risk Assessment
 
-Evaluate external datasets for poisoning, bias, and legal compliance, and monitor them throughout their lifecycle.
+Evaluate external datasets for poisoning and legal compliance, and monitor them throughout their lifecycle.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **6.3.1** | **Verify that** disallowed content (e.g., copyrighted material, PII) is detected and removed via automated scrubbing prior to training. | 1 |
 | **6.3.2** | **Verify that** external datasets undergo poisoning risk assessment (e.g., data fingerprinting, outlier detection). | 2 |
 | **6.3.3** | **Verify that** origin, lineage, and license terms for datasets are captured in AI BOM entries. | 2 |
-| **6.3.4** | **Verify that** bias metrics (e.g., demographic parity, equal opportunity) are calculated before dataset approval. | 2 |
-| **6.3.5** | **Verify that** periodic monitoring detects drift or corruption in hosted datasets. | 3 |
+| **6.3.4** | **Verify that** periodic monitoring detects drift or corruption in hosted datasets. | 3 |
 
 ---
 
@@ -65,7 +64,7 @@ Generate and sign detailed AI-specific bills of materials (AI BOMs) so downstrea
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **6.5.1** | **Verify that** every model artifact publishes a version-controlled AI BOM that lists datasets, weights, hyperparameters, licenses, export-control tags, and data-origin statements. | 1 |
-| **6.5.2** | **Verify that** AI BOM generation and cryptographic signing are automated in CI and required for merge. | 2 |
+| **6.5.2** | **Verify that** AI BOMs are cryptographically signed before deployment. | 2 |
 | **6.5.3** | **Verify that** AI BOM completeness checks fail the build if any component metadata (hash and license) is missing. | 2 |
 | **6.5.4** | **Verify that** downstream consumers can query AI BOMs via API to validate imported models at deploy time. | 2 |
 

--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -2,106 +2,72 @@
 
 ## Control Objective
 
-AI supply-chain attacks exploit third-party models, frameworks, or datasets to embed backdoors, bias, or exploitable code. These controls provide end-to-end traceability, vulnerability management, and monitoring to protect the entire model lifecycle.
+AI supply-chain attacks exploit third-party models, frameworks, or datasets to embed backdoors, bias, or exploitable code. These controls ensure traceability, vetting, and monitoring of AI-specific supply chain artifacts throughout the model lifecycle.
+
+Generic software supply chain controls (dependency scanning, version pinning, lockfile enforcement, container digest pinning, build attestation, reproducible builds, SBOM generation, CI/CD audit logging, etc.) are covered by ASVS v5 (V13, V15), OWASP SCVS, SLSA, and CIS Controls, and are not repeated here. This chapter focuses on supply chain risks unique to AI: model artifact integrity, backdoor detection in pretrained weights, dataset poisoning, AI-specific bills of materials, and model-publisher trust.
 
 ---
 
 ## C6.1 Pretrained Model Vetting & Origin Integrity
 
-Assess and authenticate third-party model origins, licenses, and hidden behaviors before any fine-tuning or deployment.
+Assess and authenticate third-party model origins and hidden behaviors before any fine-tuning or deployment.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **6.1.1** | **Verify that** every third-party model artifact includes a signed origin-and-integrity record identifying its source, version, and integrity checksum. | 1 |
 | **6.1.2** | **Verify that** models are scanned for malicious layers or Trojan triggers using automated tools before import. | 1 |
-| **6.1.3** | **Verify that** model licenses, export-control tags, and data-origin statements are recorded in an AI BOM entry. | 2 |
-| **6.1.4** | **Verify that** high-risk models (e.g., publicly uploaded weights, unverified creators) remain quarantined until human review and sign-off. | 2 |
+| **6.1.3** | **Verify that** high-risk models (e.g., publicly uploaded weights, unverified creators) remain quarantined until human review and sign-off. | 2 |
+| **6.1.4** | **Verify that** third-party or open-source models pass a defined behavioral acceptance test suite (covering safety, alignment, and capability boundaries relevant to the deployment context) before being imported or promoted to any non-development environment. | 2 |
 | **6.1.5** | **Verify that** transfer-learning fine-tunes pass adversarial evaluation to detect hidden behaviors. | 3 |
-| **6.1.6** | **Verify that** third-party or open-source models pass a defined behavioral acceptance test suite (covering safety, alignment, and capability boundaries relevant to the deployment context) before being imported or promoted to any non-development environment. | 2 |
 
 ---
 
-## C6.2 Framework & Library Scanning
+## C6.2 Trusted Source Enforcement for AI Artifacts
 
-Continuously scan AI frameworks and libraries for vulnerabilities and malicious code to keep the runtime stack secure.
+Allow AI artifact downloads only from organization-approved sources and verify model publisher identity.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.2.1** | **Verify that** CI pipelines run dependency scanners on AI frameworks and critical libraries. | 1 |
-| **6.2.2** | **Verify that** critical and high-severity vulnerabilities block promotion to production images. | 2 |
-| **6.2.3** | **Verify that** static code analysis runs on forked or vendored AI libraries. | 2 |
-| **6.2.4** | **Verify that** framework upgrade proposals include a security impact assessment referencing public vulnerability feeds. | 2 |
-| **6.2.5** | **Verify that** runtime sensors alert on unexpected dynamic library loads that deviate from the signed SBOM. | 3 |
+| **6.2.1** | **Verify that** model weights, datasets, and fine-tuning adapters are downloaded only from approved sources or internal registries. | 1 |
+| **6.2.2** | **Verify that** cryptographic signing keys used to authenticate model publishers are pinned per source registry, and that key rotation events require explicit re-approval before updated keys are trusted. | 3 |
 
 ---
 
-## C6.3 Dependency Pinning & Verification
-
-Pin every dependency to immutable digests and verify builds to guarantee tamper-free artifacts.
-
-| # | Description | Level |
-| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.3.1** | **Verify that** all package managers enforce version pinning via lockfiles. | 1 |
-| **6.3.2** | **Verify that** immutable digests are used instead of mutable tags in container references. | 1 |
-| **6.3.3** | **Verify that** expired or unmaintained dependencies trigger automated notifications to update or replace pinned versions. | 2 |
-| **6.3.4** | **Verify that** build attestations are retained for a period defined by organizational policy for audit traceability. | 3 |
-| **6.3.5** | **Verify that** reproducible-build checks compare hashes across CI runs to ensure identical outputs. | 3 |
-
----
-
-## C6.4 Trusted Source Enforcement
-
-Allow artifact downloads only from cryptographically verified, organization-approved sources and block everything else.
-
-| # | Description | Level |
-| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.4.1** | **Verify that** model weights, datasets, and containers are downloaded only from approved sources or internal registries. | 1 |
-| **6.4.2** | **Verify that** cryptographic signatures validate publisher identity before artifacts are cached locally. | 1 |
-| **6.4.3** | **Verify that** egress controls block unauthenticated artifact downloads to enforce trusted-source policy. | 2 |
-| **6.4.4** | **Verify that** repository allow-lists are reviewed periodically with evidence of business justification for each entry. | 3 |
-| **6.4.5** | **Verify that** policy violations trigger quarantining of artifacts and rollback of dependent pipeline runs. | 3 |
-| **6.4.6** | **Verify that** cryptographic signing keys used to authenticate model publishers are pinned per source registry (e.g., Hugging Face, internal registry), and that key rotation events require explicit re-approval before updated keys are trusted. | 3 |
-
----
-
-## C6.5 Third-Party Dataset Risk Assessment
+## C6.3 Third-Party Dataset Risk Assessment
 
 Evaluate external datasets for poisoning, bias, and legal compliance, and monitor them throughout their lifecycle.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.5.1** | **Verify that** external datasets undergo poisoning risk assessment (e.g., data fingerprinting, outlier detection). | 1 |
-| **6.5.2** | **Verify that** disallowed content (e.g., copyrighted material, PII) is detected and removed via automated scrubbing prior to training. | 1 |
-| **6.5.3** | **Verify that** origin, lineage, and license terms for datasets are captured in AI BOM entries. | 2 |
-| **6.5.4** | **Verify that** bias metrics (e.g., demographic parity, equal opportunity) are calculated before dataset approval. | 2 |
-| **6.5.5** | **Verify that** periodic monitoring detects drift or corruption in hosted datasets. | 3 |
+| **6.3.1** | **Verify that** disallowed content (e.g., copyrighted material, PII) is detected and removed via automated scrubbing prior to training. | 1 |
+| **6.3.2** | **Verify that** external datasets undergo poisoning risk assessment (e.g., data fingerprinting, outlier detection). | 2 |
+| **6.3.3** | **Verify that** origin, lineage, and license terms for datasets are captured in AI BOM entries. | 2 |
+| **6.3.4** | **Verify that** bias metrics (e.g., demographic parity, equal opportunity) are calculated before dataset approval. | 2 |
+| **6.3.5** | **Verify that** periodic monitoring detects drift or corruption in hosted datasets. | 3 |
 
 ---
 
-## C6.6 Supply Chain Attack Monitoring
+## C6.4 Supply Chain Attack Monitoring
 
-Detect supply-chain threats early through vulnerability feeds, audit-log analytics, and incident response readiness.
+Detect AI-specific supply-chain threats through threat intelligence enrichment and incident response readiness.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.6.1** | **Verify that** incident response playbooks include rollback procedures for compromised models or libraries. | 2 |
-| **6.6.2** | **Verify that** CI/CD audit logs are streamed to centralized security monitoring in real time. | 2 |
-| **6.6.3** | **Verify that** threat-intelligence enrichment tags AI-specific indicators (e.g., model-poisoning indicators of compromise) in alert triage. | 3 |
-| **6.6.4** | **Verify that** security monitoring includes detection rules for anomalous package pulls and tampered or unexpected build steps in the CI/CD pipeline. | 2 |
+| **6.4.1** | **Verify that** incident response playbooks include procedures specific to compromised AI artifacts, such as rollback of poisoned models, revocation of model signatures, and re-evaluation of downstream systems that consumed affected artifacts. | 2 |
+| **6.4.2** | **Verify that** threat-intelligence enrichment tags AI-specific indicators (e.g., model-poisoning indicators of compromise) in alert triage. | 3 |
 
 ---
 
-## C6.7 AI BOM for Model Artifacts
+## C6.5 AI BOM for Model Artifacts
 
 Generate and sign detailed AI-specific bills of materials (AI BOMs) so downstream consumers can verify component integrity at deploy time.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.7.1** | **Verify that** every model artifact publishes an AI BOM that lists datasets, weights, hyperparameters, and licenses. | 1 |
-| **6.7.2** | **Verify that** AI BOM generation and cryptographic signing are automated in CI and required for merge. | 2 |
-| **6.7.3** | **Verify that** AI BOM completeness checks fail the build if any component metadata (hash and license) is missing. | 2 |
-| **6.7.4** | **Verify that** downstream consumers can query AI BOMs via API to validate imported models at deploy time. | 2 |
-| **6.7.5** | **Verify that** AI BOMs are version-controlled and diffed to detect unauthorized modifications. | 3 |
+| **6.5.1** | **Verify that** every model artifact publishes a version-controlled AI BOM that lists datasets, weights, hyperparameters, licenses, export-control tags, and data-origin statements. | 1 |
+| **6.5.2** | **Verify that** AI BOM generation and cryptographic signing are automated in CI and required for merge. | 2 |
+| **6.5.3** | **Verify that** AI BOM completeness checks fail the build if any component metadata (hash and license) is missing. | 2 |
+| **6.5.4** | **Verify that** downstream consumers can query AI BOMs via API to validate imported models at deploy time. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -310,7 +310,7 @@ Verify origin and authenticity, scan dependencies, and enforce integrity of mode
 | External dataset poisoning assessment (fingerprinting, outlier detection) | 6.3.1 |
 | Copyright and PII detection in external datasets | 6.3.2 |
 | Dataset origin and lineage documentation | 6.3.3 |
-| Automated AI BOM generation and signing in CI | 6.5.2 |
+| AI BOM cryptographic signing | 6.5.2 |
 | Build attestation retention | SLSA Build Track |
 
 **Common pitfalls:** not scanning fine-tuning datasets for poisoning; lacking rollback procedures when a compromised model is detected; treating AI BOMs as static documents rather than version-controlled artifacts.

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -135,10 +135,10 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 | Cryptographic hashes for training data integrity | 1.2.4, 1.3.4 |
 | Cryptographic model signing | 3.1.2 |
 | Model signature and checksum verification at deployment and load | 3.1.3 |
-| Signed build artifacts with build-origin metadata | 4.2.2 |
-| Build signature validation at deployment | 4.2.3 |
+| Signed build artifacts with build-origin metadata | ASVS v5 V15 / SLSA |
+| Build signature validation at deployment | ASVS v5 V15 / SLSA |
 | Third-party model origin and integrity verification (signed records) | 6.1.1 |
-| Cryptographic signature validation for packages and publishers | 6.4.2 |
+| Cryptographic signature validation for model publishers | 6.2.1, 6.2.2 |
 | Model watermarking and fingerprinting | 7.7.5, 11.5.4 |
 | Execution chain cryptographic signing with non-repudiation timestamps | 9.4.2 |
 | Message integrity with nonce / sequence / timestamp replay protection | 9.5.3 |
@@ -147,7 +147,7 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 | MCP component signature and checksum verification | 10.1.1 |
 | MCP schema integrity signing and tool definition hash tracking | 10.4.2, 10.4.5 |
 | DAG cryptographic signatures and tamper-evident storage | 13.7.3 |
-| Publisher key pinning per source registry with rotation re-approval | 6.4.6 |
+| Publisher key pinning per source registry with rotation re-approval | 6.2.2 |
 | Document metadata tag immutability after initial ingestion write | 8.1.7 |
 | Agent persisted state integrity protection (MAC/signature, rejection on failure) | 9.4.6 |
 
@@ -293,27 +293,27 @@ Verify origin and authenticity, scan dependencies, and enforce integrity of mode
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Model registry with AI BOM (SPDX, CycloneDX) | 3.1.1, 6.7.1 |
+| Model registry with AI BOM (SPDX, CycloneDX) | 3.1.1, 6.5.1 |
 | Model dependency graph tracking (services, agents, environments) | 3.1.4 |
 | Model origin records (source, training data checksums, authorship) | 3.1.5, 6.1.1 |
-| Automated reproducible builds | 4.2.1 |
-| SBOM production from automated builds | 4.2.5 |
-| Reproducible build hash comparison | 6.3.5 |
-| CI pipeline dependency scanning (AI frameworks, critical libraries) | 6.2.1 |
-| Critical / high-severity vulnerability blocking in CI | 6.2.2 |
-| Dependency version pinning with lockfile enforcement | 6.3.1 |
-| Immutable digest references for containers (no mutable tags) | 6.3.2 |
-| Expired and unmaintained dependency detection | 6.3.3 |
-| Approved source and internal registry enforcement | 6.4.1 |
+| Automated reproducible builds | ASVS v5 V15 / SLSA |
+| SBOM production from automated builds | ASVS v5 V15.1.2 / SCVS |
+| Reproducible build hash comparison | SLSA Build L3 |
+| CI pipeline dependency scanning | ASVS v5 V15.2.1 / SCVS V5 |
+| Critical / high-severity vulnerability blocking in CI | ASVS v5 V15.1.1 / SCVS V5 |
+| Dependency version pinning with lockfile enforcement | SCVS V4 / CIS Guide |
+| Immutable digest references for containers (no mutable tags) | SCVS / CIS Guide |
+| Expired and unmaintained dependency detection | ASVS v5 V15.1.1, V15.2.1 |
+| Approved source enforcement for AI artifacts | 6.2.1 |
 | Malicious layer and trojan trigger scanning | 6.1.2 |
-| Unsafe deserialization format prohibition and format-aware scanning at load time | 4.5.10 |
-| External dataset poisoning assessment (fingerprinting, outlier detection) | 6.5.1 |
-| Copyright and PII detection in external datasets | 6.5.2 |
-| Dataset origin and lineage documentation | 6.5.3 |
-| Automated AI BOM generation and signing in CI | 6.7.2 |
-| Build attestation retention | 6.3.4 |
+| Unsafe deserialization format prohibition and format-aware scanning at load time | 4.1.3 |
+| External dataset poisoning assessment (fingerprinting, outlier detection) | 6.3.1 |
+| Copyright and PII detection in external datasets | 6.3.2 |
+| Dataset origin and lineage documentation | 6.3.3 |
+| Automated AI BOM generation and signing in CI | 6.5.2 |
+| Build attestation retention | SLSA Build Track |
 
-**Common pitfalls:** using mutable `:latest` tags in production; not scanning fine-tuning datasets for poisoning; lacking rollback procedures when a compromised dependency is detected.
+**Common pitfalls:** not scanning fine-tuning datasets for poisoning; lacking rollback procedures when a compromised model is detected; treating AI BOMs as static documents rather than version-controlled artifacts.
 
 ---
 
@@ -339,7 +339,7 @@ Manage model deployment, rollback, retirement, and emergency response.
 | Version control for all development artifacts (hyperparams, scripts, prompts, policies) | 3.4.3 |
 | Secure model artifact wiping and cryptographic erasure on retirement | 3.5.1 |
 | Model signature revocation and registry deny-list on retirement | 3.5.2 |
-| Supply chain incident response playbooks (model and library rollback) | 6.6.1 |
+| AI-specific supply chain incident response (model rollback, signature revocation) | 6.4.1 |
 
 **Common pitfalls:** not testing rollback procedures before they are needed; leaving retired model artifacts in serving caches; missing shutdown cascade to downstream tool and MCP connections.
 
@@ -367,7 +367,7 @@ Protect personal data and enforce data subject rights throughout the AI lifecycl
 | Consent withdrawal processing (< 24 hour SLA) | 12.5.3 |
 | Local differential privacy in federated learning (client-side noise) | 12.6.1 |
 | Poisoning-resistant aggregation (Krum, Trimmed-Mean) | 12.6.3 |
-| PII detection and removal in external datasets | 6.5.2 |
+| PII detection and removal in external datasets | 6.3.2 |
 | Session context discard at session end (not accessible in subsequent sessions) | 8.3.7 |
 | Quarantined content excluded from retrieval results while under quarantine | 8.3.8 |
 
@@ -427,8 +427,8 @@ Capture security-relevant events with integrity protection for forensic analysis
 | Agent action signing with chain ID binding and timestamps | 9.4.2 |
 | Immutable audit records for model changes (actor, change type, before/after) | 3.2.5 |
 | Immutable deletion logging for regulatory audit trails | 12.2.4 |
-| CI/CD audit log streaming to SIEM | 6.6.2 |
-| Detection rules for anomalous package pulls and tampered build steps | 6.6.4 |
+| CI/CD audit log streaming to SIEM | ASVS v5 V16.4.3 |
+| Detection rules for anomalous package pulls and tampered build steps | ASVS v5 V16.3.3 |
 | DAG visualization with access controls and tamper evidence | 13.7.1, 13.7.2, 13.7.3 |
 | Safety violation metrics logging | 7.6.1 |
 | MCP policy change audit logging (timestamp, author, justification) | 11.7.3 |
@@ -509,7 +509,7 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 | Human review on anomaly detection | 11.6.3 |
 | Enhanced monitoring and human intervention on security warnings | 11.8.3 |
 | Security-critical proactive action approval with approval chain logging | 13.8.4 |
-| High-risk model quarantine with human review and sign-off | 6.1.4 |
+| High-risk model quarantine with human review and sign-off | 6.1.3 |
 | Post-condition outcome checking with containment on mismatch | 9.7.3 |
 | Compensating actions and transactional rollback on failure | 9.2.3 |
 | Intermediate operational degradation states (tool disable, model swap, read-only, source removal) | 14.1.5 |


### PR DESCRIPTION
Remove generic software supply chain controls already covered by ASVS v5, OWASP SCVS, SLSA, and CIS Controls. Retain only requirements that are AI-specific or have important AI-specific nuances (model artifacts, datasets, AI BOMs, model poisoning, etc.).

## Changes by section

### C6.1 Pretrained Model Vetting & Origin Integrity
- **No removals.** All requirements are AI-specific (model trojans, transfer-learning evaluation, behavioral acceptance testing).
- **6.1.3**: Merged into C6.7 (AI BOM section) to consolidate AI BOM content requirements. The license/export-control/data-origin metadata belongs with the AI BOM definition rather than as a standalone vetting requirement.

### C6.2 Framework & Library Scanning - SECTION REMOVED
- **All 5 requirements removed.** Every requirement is generic software supply chain security:
  - 6.2.1 (CI dependency scanning) - ASVS 15.2.1, SCVS V5
  - 6.2.2 (vuln blocking in CI) - ASVS 15.1.1, SCVS V5
  - 6.2.3 (static analysis on vendored libs) - ASVS 15.1.4/15.2.5
  - 6.2.4 (framework upgrade security assessment) - general vulnerability management practice
  - 6.2.5 (runtime SBOM deviation detection) - generic runtime integrity monitoring

### C6.3 Dependency Pinning & Verification - SECTION REMOVED
- **All 5 requirements removed.** Every requirement is generic software supply chain security:
  - 6.3.1 (lockfile enforcement) - CIS Software Supply Chain Guide 2.4.2
  - 6.3.2 (immutable container digests) - container best practice, not AI-specific
  - 6.3.3 (unmaintained dependency alerts) - ASVS 15.1.1, 15.2.1
  - 6.3.4 (build attestation retention) - SLSA Build Track
  - 6.3.5 (reproducible builds) - SLSA Build L3

### C6.4 Trusted Source Enforcement - SECTION REDUCED
- **6.4.1**: Kept, narrowed to AI-specific artifacts (model weights, datasets, fine-tuning adapters).
- **6.4.2**: Removed. Generic cryptographic signature validation covered by SLSA L2+, SCVS V6. Model-specific signing is already in 6.1.1.
- **6.4.3**: Removed. Generic egress controls covered by ASVS 13.2.4.
- **6.4.4**: Removed. Generic allow-list review process.
- **6.4.5**: Removed. Generic quarantine/rollback policy.
- **6.4.6**: Kept. AI-specific (model publisher key pinning per registry like Hugging Face).

### C6.5 Third-Party Dataset Risk Assessment
- **No removals.** All requirements are AI-specific (poisoning assessment, bias metrics, dataset drift).

### C6.6 Supply Chain Attack Monitoring - SECTION REDUCED
- **6.6.1**: Kept, refined to emphasize AI-specific aspects (compromised models, poisoned datasets).
- **6.6.2**: Removed. Generic CI/CD audit log streaming covered by ASVS 16.4.3.
- **6.6.3**: Kept. AI-specific (model-poisoning IoCs in threat intelligence).
- **6.6.4**: Removed. Generic CI/CD anomaly detection.

### C6.7 AI BOM for Model Artifacts - SECTION REDUCED
- **6.7.1**: Expanded to absorb content from removed 6.1.3 (license, export-control, data-origin metadata).
- **6.7.4**: Kept but demoted from L2 to L2 (unchanged, API query for deploy-time validation).
- **6.7.5**: Removed / split into two concerns: "version-controlled" included in 6.7.1 (justified on L1 and auditable as one technical implementation); "diffed" is generic SBOM management covered by standard SBOM tooling (sbom-tools, sbomdiff, sbomlyze) and redundant given 6.5.2 already signs AI BOMs - signing is strictly stronger than diffing for tamper detection

### Control Objective
- Updated to add note clarifying that generic supply chain controls are covered by ASVS v5, SCVS, SLSA, and CIS Controls.

### Appendix D updates
- All C6 cross-references updated to match new numbering.
- Removed controls now point to their covering standard (ASVS v5, SCVS, SLSA, CIS).
- Fixed two stale C04 build artifact references (4.2.2, 4.2.3) left over from the C04 reduction pass.
- Note: Many other stale C04 references (4.3.x through 4.8.x) exist in Appendix D from the C04 reduction but are out of scope for this PR. Let's handle in May cleaning up all of this.

## Net effect

- **Before**: 7 sections, 31 requirements
- **After**: 5 sections, 18 requirements (13 removed, all generic supply chain)