### PR TITLE
Reduction pass C05

### DIFF
--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -2,107 +2,79 @@
 
 ## Control Objective
 
-Effective access control for AI systems requires robust identity management, context-aware authorization, and runtime enforcement following zero-trust principles. These controls ensure that humans, services, and autonomous agents only interact with models, data, and computational resources within explicitly granted scopes, with continuous verification and audit capabilities.
+AI systems introduce access control challenges beyond traditional application security: classification labels must follow data through AI-specific transformations (embeddings, caches, model outputs), multi-tenant inference infrastructure creates novel side channels, and retrieval-augmented pipelines must enforce caller entitlements at every stage. 
+
+This chapter addresses AI-specific access control and identity concerns only. General identity management and authentication (centralized IdP, federation, MFA, step-up authentication) are covered by ASVS v5 V6. General authorization patterns (RBAC/ABAC design, externalized PDP, dynamic attribute evaluation, policy caching), access control audit logging, and multi-tenant networking are covered by ASVS v5 V8, V14, and V16. 
+
+Agent-specific authorization policies and delegation are covered in C9.6; single-system agent identity is in C9.4.1; this chapter covers runtime isolation of the policy decision point from agent execution (complementing C9.6.4). Vector database scope enforcement is in C8.1 and C8.5. General output safety filtering (PII redaction, content moderation, confidential data blocking) is in C7.3; this chapter covers authorization-aware output filtering where entitlements vary per caller.
 
 ---
 
-## C5.1 Identity Management & Authentication
-
-Establish verified identities for all entities interacting with AI systems, with authentication strength appropriate to the risk level.
+## C5.1 Authentication
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
-| **5.1.1** | **Verify that** all human users and service principals authenticate through a centralized identity provider using industry-standard federation protocols (e.g., OIDC, SAML). | 1 |
-| **5.1.2** | **Verify that** high-risk operations (model deployment, weight export, training data access, production configuration changes) require multi-factor authentication or step-up authentication with session re-validation. | 2 |
-| **5.1.3** | **Verify that** AI agents in federated or multi-system deployments authenticate via short-lived, cryptographically signed authentication tokens (e.g., signed JWT assertions) with a maximum lifetime appropriate to the risk level and including cryptographic proof of origin. | 3 |
+| **5.1.1** | **Verify that** high-risk AI operations (model deployment, weight export, training data access, production configuration changes) require step-up authentication with session re-validation. | 2 |
+| **5.1.2** | **Verify that** AI agents in federated or multi-system deployments authenticate via short-lived, cryptographically signed authentication tokens (e.g., signed JWT assertions) with a maximum lifetime appropriate to the risk level and including cryptographic proof of origin. | 3 |
 
 ---
 
-## C5.2 Authorization & Policy
-
-Implement access controls for all AI resources with explicit permission models and audit trails.
-
-> **Scope note:** ASVS v5 14.1.1 requires all sensitive data to be identified and classified into protection levels. C5.2.11 extends this to AI-specific data types not enumerated in ASVS. C5.2.4 and C5.2.7 assume a classification scheme exists but do not require it to be defined for AI-specific data types.
+## C5.2 AI Resource Authorization & Classification
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.2.1** | **Verify that** every AI resource (datasets, models, endpoints, vector collections, embedding indices, compute instances) enforces access controls (e.g., RBAC, ABAC) with explicit allow-lists and default-deny policies. | 1 |
-| **5.2.2** | **Verify that** all access control modifications are logged with timestamps, actor identities, resource identifiers, and permission changes. | 1 |
-| **5.2.3** | **Verify that** access control audit logs are stored immutably and are tamper-evident. | 2 |
-| **5.2.4** | **Verify that** data classification labels (PII, PHI, proprietary, etc.) automatically propagate to derived resources (embeddings, prompt caches, model outputs). | 2 |
-| **5.2.5** | **Verify that** unauthorized access attempts and privilege escalation events trigger real-time alerts with contextual metadata. | 2 |
-| **5.2.6** | **Verify that** authorization decisions are externalized to a dedicated policy decision point (e.g., OPA, Cedar, or equivalent). | 3 |
-| **5.2.7** | **Verify that** policies evaluate dynamic attributes at runtime including user role or group, resource classification, request context, tenant isolation, and temporal constraints. | 3 |
-| **5.2.8** | **Verify that** policy cache TTL values are defined based on resource sensitivity, with shorter TTLs for high-sensitivity resources, and that cache invalidation capabilities are available. | 3 |
-| **5.2.9** | **Verify that** privileged access to model weights, training pipelines, and production AI configuration is provisioned on a just-in-time basis with a defined maximum session duration and automatic expiry, and permanent standing privileged access to these resources is not permitted. | 2 |
-| **5.2.10** | **Verify that** authorization policies governing AI agent tool access and action permissions include defined validity periods, and that expired policies are automatically revoked or excluded from evaluation rather than persisting as default-allow, ensuring that permission scope remains bounded as available tools and capabilities evolve. | 3 |
-| **5.2.11** | **Verify that** a documented data classification taxonomy covering AI-specific data types (embeddings, model weights, prompt templates, RAG context assemblies, fine-tuning datasets, agent tool schemas) is defined, and that AI assets are labeled in accordance with this taxonomy. | 2 |
+| **5.2.2** | **Verify that** privileged access to model weights, training pipelines, and production AI configuration is provisioned on a just-in-time basis with a defined maximum session duration and automatic expiry, and permanent standing privileged access to these resources is not permitted. | 2 |
+| **5.2.3** | **Verify that** data classification labels (PII, PHI, proprietary, etc.) automatically propagate to derived resources (embeddings, prompt caches, model outputs). | 3 |
+| **5.2.4** | **Verify that** a documented data classification taxonomy covering AI-specific data types (embeddings, model weights, prompt templates, RAG context assemblies, fine-tuning datasets, agent tool schemas) is defined, and that AI assets are labeled in accordance with this taxonomy. | 2 |
 
 ---
 
-## C5.3 Query-Time Security Enforcement
+## C5.3 Query-Time Authorization
 
-Enforce authorization at the data access layer to prevent unauthorized data retrieval through AI queries.
+Enforce the caller's authorization context through AI-specific query pipelines (RAG retrieval, embedding lookups, inference chains) so that the AI system does not return data the caller is not entitled to access.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
-| **5.3.1** | **Verify that** all data store queries (e.g., vector databases, SQL databases, search indices) include mandatory security filters (tenant ID, sensitivity labels, user scope) enforced at the data access layer. | 1 |
-| **5.3.2** | **Verify that** failed authorization evaluations immediately abort queries and return explicit authorization error codes. | 1 |
-| **5.3.3** | **Verify that** row-level security policies are enabled for all data stores containing sensitive data used by AI systems. | 2 |
-| **5.3.4** | **Verify that** query retry mechanisms re-evaluate authorization policies to account for dynamic permission changes within active sessions. | 3 |
-| **5.3.5** | **Verify that** field-level masking is applied to sensitive fields in all data stores used by AI systems, restricting access to only authorized principals. | 2 |
-| **5.3.6** | **Verify that** row-level security and field-level masking policies are inherited by derived or replicated data stores and are not bypassed by replication or ETL processes. | 2 |
+| **5.3.1** | **Verify that** AI inference and retrieval pipelines (e.g., RAG queries, embedding lookups) enforce the end-user's authorization context at each retrieval and assembly stage, rather than relying solely on the service account's permissions. | 1 |
 
 ---
 
-## C5.4 Output Filtering & Data Loss Prevention
+## C5.4 Output Entitlement Enforcement
 
-Deploy post-processing controls to prevent unauthorized data exposure in AI-generated content.
+Ensure that AI-generated outputs, including citations and source attributions, respect the caller's data entitlements.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.4.1** | **Verify that** post-inference filtering mechanisms prevent responses from including classified information or proprietary data that the requestor is not authorized to receive. | 1 |
 | **5.4.2** | **Verify that** citations, references, and source attributions in model outputs are validated against caller entitlements and removed if unauthorized access is detected. | 2 |
-| **5.4.3** | **Verify that** output format restrictions (sanitized documents, metadata-stripped images, approved file types) are enforced based on user permission levels and data classifications. | 2 |
 
 ---
 
-## C5.5 Multi-Tenant Isolation
+## C5.5 Policy Decision Point Isolation
 
-Ensure logical and cryptographic isolation between tenants in shared AI infrastructure.
+Ensure that authorization decision infrastructure for AI agents is protected from compromise and manipulation by the agents it governs.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
-| **5.5.1** | **Verify that** network policies implement default-deny rules for cross-tenant communication. | 2 |
-| **5.5.2** | **Verify that** every API request includes an authenticated tenant identifier that is cryptographically validated against session context and user entitlements. | 1 |
-| **5.5.3** | **Verify that** memory spaces, embedding stores, cache entries (e.g., result caches, embedding caches), and temporary files are namespace-segregated per tenant so that one tenant cannot access another tenant's data. | 2 |
-| **5.5.6** | **Verify that** per-tenant memory spaces, embedding stores, cache entries, and temporary files are securely purged on tenant deletion or session termination. | 2 |
-| **5.5.4** | **Verify that** encryption keys are unique per tenant with customer-managed key (CMK) support and cryptographic isolation between tenant data stores. | 3 |
-| **5.5.5** | **Verify that** inference-time KV-cache entries are partitioned by authenticated session or tenant identity and that automatic prefix caching does not share cached prefixes across distinct security principals, to prevent timing-based prompt reconstruction attacks. | 2 |
+| **5.5.1** | **Verify that** the policy decision point for agent authorization is isolated from the agent's execution environment such that a compromised agent runtime cannot influence or bypass evaluation. | 3 |
+| **5.5.2** | **Verify that** the policy decision point receives structured action descriptions (e.g., action type, target resource, parameters) rather than the agent's raw reasoning context. | 3 |
 
 ---
 
-## C5.6 Autonomous Agent Authorization
+## C5.6 Multi-Tenant Isolation
 
-Control permissions for AI agents and autonomous systems through scoped capability tokens and continuous authorization.
-
-> **Scope note:** Runtime isolation of the policy decision point from the agent execution environment complements C9.6.4 (model cannot make access control decisions) and C14.2 (human oversight escalation for high-risk actions).
+Prevent cross-tenant information leakage through AI-specific shared infrastructure components such as inference caches and shared model state.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
-| **5.6.1** | **Verify that** autonomous agents receive scoped capability tokens that explicitly enumerate permitted actions, accessible resources, time boundaries, and operational constraints. | 1 |
-| **5.6.2** | **Verify that** high-risk capabilities (file system access, code execution, external API calls, financial transactions) are disabled by default and require explicit authorization. | 1 |
-| **5.6.3** | **Verify that** capability tokens are bound to user sessions, include cryptographic integrity protection, and cannot be persisted or reused across sessions. | 2 |
-| **5.6.4** | **Verify that** agent-initiated actions undergo authorization through a policy decision point that evaluates contextual attributes (e.g., user identity, resource sensitivity, action type, environmental context). | 3 |
-| **5.6.5** | **Verify that** the policy decision point for agent authorization is isolated from the agent's execution environment such that a compromised agent runtime cannot influence or bypass evaluation. | 3 |
-| **5.6.6** | **Verify that** the policy decision point receives structured action descriptions (e.g., action type, target resource, parameters) rather than the agent's raw reasoning context. | 3 |
+| **5.6.1** | **Verify that** inference-time KV-cache entries are partitioned by authenticated session or tenant identity and that automatic prefix caching does not share cached prefixes across distinct security principals, to prevent timing-based prompt reconstruction attacks. | 2 |
+| **5.6.2** | **Verify that** shared model serving infrastructure prevents one tenant's fine-tuning, inference, or embedding operations from influencing or observing another tenant's operations through shared model state, adapter weights, or compute resources. | 2 |
 
 ---
 
 ## References
 
-* [NIST SP 800-162: Guide to Attribute Based Access Control (ABAC)](https://csrc.nist.gov/pubs/sp/800/162/final)
 * [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final)
 * [NIST SP 800-63-3: Digital Identity Guidelines](https://csrc.nist.gov/pubs/sp/800/63/3/final)
-* [NIST IR 8360: Machine Learning for Access Control Policy Verification](https://csrc.nist.gov/pubs/ir/8360/final)
 * [I Know What You Asked: Prompt Leakage via KV-Cache Sharing in Multi-Tenant LLM Serving (NDSS 2025)](https://www.ndss-symposium.org/ndss-paper/i-know-what-you-asked-prompt-leakage-via-kv-cache-sharing-in-multi-tenant-llm-serving/)

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -12,9 +12,8 @@ Verify the identity of users, agents, services, MCP clients/servers, and edge de
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Centralized identity provider (OIDC, SAML) | 5.1.1 |
-| Multi-factor authentication for high-risk operations | 5.1.2 |
-| Signed JWT tokens for identity proof | 5.1.3 |
+| Step-up authentication for high-risk AI operations (model deployment, weight export, training data access) | 5.1.1 |
+| Short-lived signed tokens for federated AI agent authentication | 5.1.2 |
 | Unique cryptographic agent and orchestrator identity | 9.4.1 |
 | First-class principal authentication (no end-user credential reuse) | 9.4.1 |
 | Agent identity credential rotation and rapid revocation | 9.4.4 |
@@ -36,15 +35,11 @@ Enforce access decisions across users, agents, tools, data, and MCP resources us
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| RBAC / ABAC / zero-trust authorization models | 5.2.1, 5.2.7 |
-| Policy decision engines (OPA, Cedar) | 5.2.6 |
-| Least-privilege resource access | 5.2.1, 5.6.2 |
-| Row-level security | 5.3.3 |
-| Field-level masking for sensitive fields | 5.3.5 |
-| Row-level and field-level policy inheritance by derived data stores | 5.3.6 |
-| Classification label propagation on outputs | 5.2.4 |
-| Session-based authorization binding | 5.5.2 |
-| Scoped capability tokens for agents | 5.6.1 |
+| Access controls on AI resources (datasets, models, endpoints, vector collections, compute) | 5.2.1 |
+| Just-in-time privileged access for AI resources (model weights, training pipelines) | 5.2.2 |
+| Classification label propagation to derived AI resources (embeddings, caches, outputs) | 5.2.3 |
+| AI-specific data classification taxonomy | 5.2.4 |
+| Caller authorization context enforcement through AI query pipelines | 5.3.1 |
 | Fine-grained agent action authorization (tool, parameters, resources, data scope) | 9.6.1 |
 | Delegation context propagation with integrity protection (user, tenant, scopes) | 9.6.2 |
 | Continuous authorization re-evaluation (context, time, risk) | 9.6.3 |
@@ -55,9 +50,13 @@ Enforce access decisions across users, agents, tools, data, and MCP resources us
 | Minimum scope requests with step-up authorization | 10.2.11 |
 | Wildcard and overly broad scope rejection | 10.2.14 |
 | MCP policy enforcement that model output cannot bypass | 10.2.4 |
-| Output format restriction by permission level | 5.4.3 |
+| Authorization-aware post-inference filtering (per-caller entitlement enforcement) | 5.4.1 |
+| Citation and attribution validation against caller entitlements | 5.4.2 |
+| Agent PDP runtime isolation from agent execution environment | 5.5.1 |
+| Structured action descriptions to PDP (not raw agent reasoning context) | 5.5.2 |
+| KV-cache partitioning by session/tenant to prevent prompt reconstruction | 5.6.1 |
+| Shared model serving tenant isolation (fine-tuning, inference, embeddings) | 5.6.2 |
 | MCP tool namespace collision detection and trust-ranked shadowing prevention | 10.6.5 |
-| Just-in-time access provisioning for model weights, training pipelines, and production AI configuration | 5.2.9 |
 | Peer authorization policy (approved agent registry) for agent-to-agent task delegation | 9.6.7 |
 | Dedicated scoped credentials per agent, not shared across swarm peers | 9.8.7 |
 
@@ -200,13 +199,14 @@ Constrain, filter, and validate model outputs before they reach users or downstr
 | Confidence scoring and uncertainty estimation | 7.2.1 |
 | Confidence threshold gating with fallback messages | 7.2.2 |
 | Output safety classifiers (hate, harassment, violence) | 7.3.1 |
-| PII detection and redaction (post-inference filtering) | 7.3.2, 7.3.3, 5.4.1 |
+| PII detection and redaction (post-inference filtering) | 7.3.2, 7.3.3 |
 | Human approval for high-risk content | 7.3.5 |
 | System prompt and backend data removal from explanations | 7.5.1 |
 | AI-generated media watermarking | 7.7.5 |
 | Copyright violation detection | 7.7.3 |
 | Explicit / non-consensual content filters | 7.7.1 |
-| Citation and attribution validation | 5.4.2 |
+| Authorization-aware post-inference filtering (per-caller entitlement enforcement) | 5.4.1 |
+| Citation and attribution validation against caller entitlements | 5.4.2 |
 | MCP error response sanitization (no stack traces, tokens, internal paths) | 10.4.6 |
 | Statistical steganographic covert channel detection in generated outputs | 7.3.9 |
 | RAG attribution derived from retrieval metadata, not model-generated | 7.8.3 |


### PR DESCRIPTION
Reduces C05 from 30 requirements to 13 by removing requirements that are generic access control / IAM / logging concerns already well-covered by ASVS v5, and by removing requirements that duplicate controls in C8 (Memory/Vector DB) and C9 (Agentic). Scope boundaries with ASVS and other AISVS chapters are consolidated into the Control Objective description.

## Changes by section

### C5.1 Identity Management & Authentication (3 -> 1)

- **Remove 5.1.1** (centralized IdP with OIDC/SAML): Generic IAM. Covered by ASVS V6.8 (Authentication with an Identity Provider) and V13.2.1 (backend component authentication). Passes smoke test: applies equally to any web application.
- **Remove 5.1.2** (MFA for high-risk operations): The mechanism (MFA/step-up auth) is generic, covered by ASVS V6.3.3 (MFA at L2). The AI-specific value (naming which AI operations are high-risk) is better placed as guidance, not a testable requirement separate from ASVS.
- **Keep 5.1.3** (agent authentication with short-lived signed tokens in federated deployments): AI-specific. Renumber to 5.1.1. Add scope note clarifying relationship to C9.4.1 (agent identity). C9.4.1 covers agent identity within a single system; this covers federated/cross-system agent authentication.

### C5.2 Authorization & Policy (11 -> 4)

- **Keep 5.2.1** (access controls on AI resources with enumeration): AI-specific resource enumeration adds value beyond ASVS. Renumber to 5.2.1.
- **Remove 5.2.2** (log access control modifications): Generic logging. Covered by ASVS V16.3.2 (log authorization decisions) and V16.2.1 (log metadata).
- **Remove 5.2.3** (immutable tamper-evident audit logs): Generic log protection. Covered by ASVS V16.4.2.
- **Keep 5.2.4** (classification label propagation to derived AI resources): AI-specific. Research confirms this is not mature/out-of-box -- bump to L3. Renumber to 5.2.3.
- **Remove 5.2.5** (real-time alerts on unauthorized access): Generic security monitoring. ASVS notes alerting as operational concern.
- **Remove 5.2.6** (externalized PDP like OPA/Cedar): Generic architecture pattern. Applies equally to non-AI systems. Research confirms OPA/Cedar are general-purpose tools.
- **Remove 5.2.7** (dynamic ABAC with runtime attributes): Generic ABAC. Covered by ASVS V8.1.3, V8.1.4, V8.2.4.
- **Remove 5.2.8** (policy cache TTL): Generic caching concern. Not AI-specific.
- **Keep 5.2.9** (JIT privileged access to AI resources): AI-specific resources (model weights, training pipelines). Renumber to 5.2.2.
- **Remove 5.2.10** (agent tool authorization validity periods): Overlaps heavily with C9.6 (Authorization, Delegation, and Continuous Enforcement). Agent authorization belongs in C9.
- **Keep 5.2.11** (AI-specific data classification taxonomy): AI-specific data types. Renumber to 5.2.4.

### C5.3 Query-Time Security Enforcement (6 -> 1)

- **Remove 5.3.1** (mandatory security filters on data store queries): Overlaps with C8.1.1 and C8.5.1 for vector stores. The generic database parts are covered by ASVS V8.2.1/V8.2.2.
- **Remove 5.3.2** (abort queries on failed auth): Generic. Covered by ASVS V8.3.1.
- **Remove 5.3.3** (row-level security): Generic database security. Not AI-specific.
- **Remove 5.3.4** (re-evaluate auth on query retry): Generic. Covered by ASVS V8.3.2.
- **Remove 5.3.5** (field-level masking): Generic data protection. Covered by ASVS V8.2.3.
- **Remove 5.3.6** (RLS/masking inheritance to derived stores): Generic data governance. Not AI-specific.
- **Keep one requirement** about AI-specific query-time enforcement: Retain the AI-specific concern of ensuring that AI inference queries (e.g., RAG retrieval, embedding lookups) enforce the caller's authorization context, not just the service account's. This is distinct from C8 (which focuses on vector DB specifics) and from generic ASVS (which doesn't address the AI query pipeline). Renumber as 5.3.1.

### C5.4 Output Filtering & Data Loss Prevention (3 -> 1)

- **Remove 5.4.1** (post-inference filtering for classified info): Overlaps with C7.3.4 (block/redact confidential data in output).
- **Keep 5.4.2** (validate citations/attributions against caller entitlements): AI-specific - source attribution entitlement checking is uniquely an AI/RAG concern. Renumber to 5.4.1.
- **Remove 5.4.3** (output format restrictions by permission level): Generic DLP. Passes smoke test: applies to any system with role-based output filtering.

### C5.5 Multi-Tenant Isolation (6 -> 2)

- **Remove 5.5.1** (default-deny network policies for cross-tenant): Generic multi-tenant networking. Covered by ASVS V8.4.1.
- **Remove 5.5.2** (authenticated tenant identifier in API requests): Generic multi-tenant auth. Covered by ASVS V8.4.1.
- **Remove 5.5.3** (namespace-segregated memory/embedding stores per tenant): Overlaps with C8.5.1/C8.5.2 (scope enforcement for vector stores).
- **Remove 5.5.6** (secure purge on tenant deletion): Overlaps with C8.3.3 (deletion propagation).
- **Remove 5.5.4** (per-tenant encryption keys with CMK): Generic multi-tenant encryption. Not AI-specific.
- **Keep 5.5.5** (KV-cache partitioning by session/tenant): Highly AI-specific (LLM inference). Documented attack (NDSS 2025). Research confirms vLLM cache_salt is production-ready. Renumber to 5.5.1.
- **Add new 5.5.2**: AI-specific multi-tenant concern about shared model/compute isolation - ensure that fine-tuning, inference, or embedding operations for one tenant cannot influence or observe another tenant's operations through shared model state or compute resources. This captures the AI-specific multi-tenant concern that generic ASVS misses.

### C5.6 Autonomous Agent Authorization (4 -> 0, section removed)

- **Remove entire section**: All four requirements overlap heavily with C9.6 (Authorization, Delegation, and Continuous Enforcement) and C9.2 (High-Impact Action Approval). C9 provides more comprehensive and detailed coverage of agent authorization. Add scope note referencing C9.

## Level adjustments

- **5.2.4**: Classification label propagation to derived AI resources: L2 -> L3. Research confirms this is not available out-of-box from any vendor. Requires custom pipeline engineering.
