### PR TITLE
C02 - Reduction

### DIFF
--- a/1.0/en/0x10-C02-User-Input-Validation.md
+++ b/1.0/en/0x10-C02-User-Input-Validation.md
@@ -33,8 +33,7 @@ AI models process text through tokenizers and embeddings that can be exploited v
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.2.1** | **Verify that** input normalization (Unicode NFC canonicalization, homoglyph mapping, removal of control and invisible Unicode characters, and bidirectional text neutralization) is applied before tokenization or embedding, and that inputs which still contain suspicious encoding artifacts after normalization are rejected or flagged for review. | 1 |
-| **2.2.2** | **Verify that** suspected adversarial inputs are quarantined and logged. | 1 |
-| **2.2.3** | **Verify that** encoding and representation smuggling in both inputs and outputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) are detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
+| **2.2.2** | **Verify that** encoding and representation smuggling in both inputs and outputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) are detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C02-User-Input-Validation.md
+++ b/1.0/en/0x10-C02-User-Input-Validation.md
@@ -33,7 +33,8 @@ AI models process text through tokenizers and embeddings that can be exploited v
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.2.1** | **Verify that** input normalization (Unicode NFC canonicalization, homoglyph mapping, removal of control and invisible Unicode characters, and bidirectional text neutralization) is applied before tokenization or embedding, and that inputs which still contain suspicious encoding artifacts after normalization are rejected or flagged for review. | 1 |
-| **2.2.2** | **Verify that** encoding and representation smuggling in both inputs and outputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) are detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
+| **2.2.2** | **Verify that** inputs identified as adversarial by any detection mechanism are blocked from inclusion in prompts or execution of actions. | 1 |
+| **2.2.3** | **Verify that** encoding and representation smuggling in both inputs and outputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) are detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
 
 ---
 


### PR DESCRIPTION
Removed 1 control from "C2.2 Pre-Tokenization Input Normalization"

* Control 2.2.2 ("Verify that suspected adversarial inputs are quarantined and logged") duplicates monitoring/logging concerns that are already comprehensively covered in C13 (Monitoring, Logging & Anomaly Detection)
* The logging and quarantine function is a cross-cutting control that applies across inputs in all stages
* Keeping it in C2.2 creates unnecessary redundancy when C13 already specifies detailed logging requirements (13.1.1-13.1.8) and abuse detection/alerting (13.2.1-13.2.10)