### PR TITLE
Reduction pass C07

### DIFF
--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -2,9 +2,9 @@
 
 ## Control Objective
 
-This control category ensures that model outputs are technically constrained, validated, and monitored so that unsafe, malformed, or high-risk responses cannot reach users or downstream systems.
+This control category ensures that model outputs are technically constrained, validated, and monitored so that unsafe, malformed, or high-risk responses cannot reach users or downstream systems. The chapter focuses on AI-specific output handling concerns and intentionally avoids duplicating controls that already exist in OWASP ASVS v5 or in other AISVS chapters.
 
-This chapter covers AI-specific output handling concerns. General application output controls (output encoding and escaping, parameterized queries, safe deserialization, anti-automation, security event logging, error handling) are addressed by OWASP ASVS v5 chapters V1, V2, V14, and V16. Per-execution and per-agent budgets, human-approval gates for high-impact actions, and recursion/fan-out limits for orchestrated or agentic workflows are covered in C9 (Autonomous Orchestration & Agentic Action Security). Logging and SIEM integration for AI events, alerting on safety-violation rates, and model-version metadata in logs are covered in C13 (Monitoring, Logging & Anomaly Detection).
+General application output controls such as output encoding and escaping, parameterized queries, safe deserialization, anti-automation, security event logging, and error handling are addressed by ASVS v5 chapters V1, V2, V14, and V16.
 
 ---
 
@@ -38,8 +38,6 @@ Detect when the model produces potentially inaccurate or fabricated content and 
 
 Technical controls to detect and scrub bad content before it is shown to the user.
 
-> **Scope note:** Authorization-based filtering of outputs against the caller's data entitlements is covered by C5.4. Generic minimum-disclosure of sensitive data on the request path is covered by ASVS V14.2.6. Privacy-driven personal data handling obligations (data minimization, lawful basis, consent) are covered by C12 and by external privacy regimes (GDPR, CCPA).
-
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **7.3.1** | **Verify that** automated classifiers scan every response and block content that matches hate, harassment, or sexual violence categories. | 1 |
@@ -63,8 +61,6 @@ Ensure the user knows why a decision was made.
 ## C7.5 Generative Media Safeguards
 
 Provide cryptographic provenance for synthetic media so that downstream consumers can distinguish AI-generated content from authentic content.
-
-> **Scope note:** Input-side content screening (blocking prompts that request explicit, non-consensual, or illegal content) is covered by C2.3.1. Approval gates for sensitive generation actions are covered by C9.2. Logging of filter-bypass attempts is covered by C13.2.1 and ASVS V16.3.3.
 
 | # | Description | Level |
 | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -4,6 +4,8 @@
 
 This control category ensures that model outputs are technically constrained, validated, and monitored so that unsafe, malformed, or high-risk responses cannot reach users or downstream systems.
 
+This chapter covers AI-specific output handling concerns. General application output controls (output encoding and escaping, parameterized queries, safe deserialization, anti-automation, security event logging, error handling) are addressed by OWASP ASVS v5 chapters V1, V2, V14, and V16. Per-execution and per-agent budgets, human-approval gates for high-impact actions, and recursion/fan-out limits for orchestrated or agentic workflows are covered in C9 (Autonomous Orchestration & Agentic Action Security). Logging and SIEM integration for AI events, alerting on safety-violation rates, and model-version metadata in logs are covered in C13 (Monitoring, Logging & Anomaly Detection).
+
 ---
 
 ## C7.1 Output Format Enforcement
@@ -14,8 +16,7 @@ Ensure the model outputs data in a way that helps prevent injection.
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **7.1.1** | **Verify that** the application validates all model outputs against a strict schema (like JSON Schema) and rejects any output that does not match. | 1 |
 | **7.1.2** | **Verify that** the system uses "stop sequences" or token limits to strictly cut off generation before it can overflow buffers or executes unintended commands. | 1 |
-| **7.1.3** | **Verify that** components processing model output treat it as untrusted input (e.g., using parameterized queries or safe de-serializers). | 1 |
-| **7.1.4** | **Verify that** the system logs the specific error type when an output is rejected for bad formatting. | 2 |
+| **7.1.3** | **Verify that** model outputs crossing a trust boundary into downstream interpreters (e.g., databases, shells, deserializers, template engines, browsers) are treated as untrusted input and processed using the corresponding safe APIs as defined in OWASP ASVS v5 chapters V1.2 and V1.5. | 1 |
 
 ---
 
@@ -37,80 +38,49 @@ Detect when the model produces potentially inaccurate or fabricated content and 
 
 Technical controls to detect and scrub bad content before it is shown to the user.
 
+> **Scope note:** Authorization-based filtering of outputs against the caller's data entitlements is covered by C5.4. Generic minimum-disclosure of sensitive data on the request path is covered by ASVS V14.2.6. Privacy-driven personal data handling obligations (data minimization, lawful basis, consent) are covered by C12 and by external privacy regimes (GDPR, CCPA).
+
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **7.3.1** | **Verify that** automated classifiers scan every response and block content that matches hate, harassment, or sexual violence categories. | 1 |
-| **7.3.2** | **Verify that** the system scans every response for PII (like credit cards or emails) and automatically redacts it before display. | 1 |
-| **7.3.3** | **Verify that** PII detection and redaction events are logged without including the redacted PII values themselves, to maintain an audit trail without creating secondary PII exposure. | 1 |
-| **7.3.4** | **Verify that** data labeled as "confidential" in the system remains blocked or redacted. | 2 |
-| **7.3.5** | **Verify that** safety filters can be configured differently based on the user's role or location (e.g., stricter filters for minors) as appropriate. | 2 |
-| **7.3.6** | **Verify that** the system requires a human approval step or re-authentication if the model generates high-risk content. | 3 |
-| **7.3.7** | **Verify that** output filters detect and block responses that reproduce verbatim segments of system prompt content. | 2 |
-| **7.3.8** | **Verify that** LLM client applications prevent model-generated output from triggering automatic outbound requests (e.g., auto-rendered images, iframes, or link prefetching) to attacker-controlled endpoints, for example by disabling automatic external resource loading or restricting it to explicitly allowlisted origins as appropriate. | 2 |
-| **7.3.9** | **Verify that** generated outputs are analyzed for statistical steganographic covert channels (e.g., biased token-choice patterns or output distribution anomalies) that could encode hidden data across the model's valid output space, and that detections are flagged for review. | 3 |
+| **7.3.2** | **Verify that** output filters detect and block responses that reproduce verbatim segments of system prompt content. | 2 |
+| **7.3.3** | **Verify that** LLM client applications prevent model-generated output from triggering automatic outbound requests (e.g., auto-rendered images, iframes, or link prefetching) to attacker-controlled endpoints, for example by disabling automatic external resource loading or restricting it to explicitly allowlisted origins as appropriate. | 2 |
+| **7.3.4** | **Verify that** generated outputs are analyzed for statistical steganographic covert channels (e.g., biased token-choice patterns or output distribution anomalies) that could encode hidden data across the model's valid output space, and that detections are flagged for review. | 3 |
 
 ---
 
-## C7.4 Output & Action Limiting
-
-Prevent the model from doing too much, too fast, or accessing things it should not.
-
-| # | Description | Level |
-| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.4.1** | **Verify that** the system enforces hard limits on requests and tokens per user to prevent cost spikes and denial of service. | 1 |
-| **7.4.2** | **Verify that** the model cannot execute high-impact actions (like writing files, sending emails, or executing code) without explicit user confirmation. | 1 |
-| **7.4.3** | **Verify that** the application or orchestration framework explicitly configures and enforces a maximum depth for recursive calls to prevent unbounded recursion. | 2 |
-| **7.4.4** | **Verify that** the application or orchestration framework explicitly configures and enforces a maximum number of sequential or nested sub-task delegations within a single execution chain, and that chains exceeding this limit are halted. For agent-specific tool and action authorization, see C9.6. | 2 |
-
----
-
-## C7.5 Explainability & Transparency
+## C7.4 Explainability & Transparency
 
 Ensure the user knows why a decision was made.
 
 | # | Description | Level |
 | :-------: | ------------------------------------------------------------------------------------------------------------------------------ | :---: |
-| **7.5.1** | **Verify that** explanations provided to the user are sanitized to remove system prompts or backend data. | 1 |
-| **7.5.2** | **Verify that** the UI displays a confidence score or "reasoning summary" to the user for critical decisions. | 2 |
-| **7.5.3** | **Verify that** technical evidence of the model's decision, such as model interpretability artifacts (e.g., attention maps, feature attributions), are logged. | 3 |
+| **7.4.1** | **Verify that** explanations provided to the user are sanitized to remove system prompts or backend data. | 1 |
+| **7.4.2** | **Verify that** technical evidence of the model's decision, such as model interpretability artifacts (e.g., attention maps, feature attributions), are logged. | 3 |
 
 ---
 
-## C7.6 Monitoring Integration
+## C7.5 Generative Media Safeguards
 
-Ensure the application sends the right signals for security teams to watch.
+Provide cryptographic provenance for synthetic media so that downstream consumers can distinguish AI-generated content from authentic content.
+
+> **Scope note:** Input-side content screening (blocking prompts that request explicit, non-consensual, or illegal content) is covered by C2.3.1. Approval gates for sensitive generation actions are covered by C9.2. Logging of filter-bypass attempts is covered by C13.2.1 and ASVS V16.3.3.
 
 | # | Description | Level |
 | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.6.1** | **Verify that** the system logs real-time metrics for safety violations (e.g., "Hallucination Detected", "PII Blocked"). | 1 |
-| **7.6.2** | **Verify that** the system triggers an alert if safety violation rates exceed a defined threshold within a specific time window. | 2 |
-| **7.6.3** | **Verify that** logs include the specific model version and other details necessary to investigate potential abuse. | 2 |
+| **7.5.1** | **Verify that** all generated media includes an invisible watermark or cryptographic signature to prove it was AI-generated. | 3 |
 
 ---
 
-## C7.7 Generative Media Safeguards
-
-Prevent the creation of illegal or fake media.
-
-| # | Description | Level |
-| :-------: | -------------------------------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.7.1** | **Verify that** input filters block prompts requesting explicit or non-consensual synthetic content before the model processes them. | 1 |
-| **7.7.2** | **Verify that** the system refuses to generate media (images/audio) that depicts real people without verified consent. | 2 |
-| **7.7.3** | **Verify that** the system checks generated content for copyright violations before releasing it. | 2 |
-| **7.7.4** | **Verify that** attempts to bypass filters are detected and logged as security events. | 2 |
-| **7.7.5** | **Verify that** all generated media includes an invisible watermark or cryptographic signature to prove it was AI-generated. | 3 |
-
----
-
-## C7.8 Source Attribution & Citation Integrity
+## C7.6 Source Attribution & Citation Integrity
 
 Ensure RAG-grounded outputs are traceable to their source documents and that cited claims are verifiably supported by retrieved content.
 
 | # | Description | Level |
 | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.8.1** | **Verify that** responses generated using retrieval-augmented generation (RAG) include attribution to the source documents that grounded the response. | 1 |
-| **7.8.2** | **Verify that** each sourced claim in a RAG-grounded response can be traced to a specific retrieved chunk, and that the system detects and flags responses where claims are not supported by any retrieved content before the response is served. | 3 |
-| **7.8.3** | **Verify that** RAG attributions are derived from retrieval metadata and are not generated by the model, ensuring provenance cannot be fabricated. | 1 |
+| **7.6.1** | **Verify that** responses generated using retrieval-augmented generation (RAG) include attribution to the source documents that grounded the response. | 1 |
+| **7.6.2** | **Verify that** each sourced claim in a RAG-grounded response can be traced to a specific retrieved chunk, and that the system detects and flags responses where claims are not supported by any retrieved content before the response is served. | 3 |
+| **7.6.3** | **Verify that** RAG attributions are derived from retrieval metadata and are not generated by the model, ensuring provenance cannot be fabricated. | 1 |
 
 ---
 


### PR DESCRIPTION
Tightens C7 to focus on AI-specific output controls and removes requirements that are either fully covered by ASVS v5 or that duplicate other AISVS chapters (notably C9 Orchestration & Agentic Action, C13 Monitoring & Logging, and C2 User Input Validation). Adds a chapter scope note pointing to ASVS for general output handling.

## Per-section changes

### C7.1 Output Format Enforcement
- **7.1.1 (schema validation)**: keep. AI-specific (free-form generation routinely breaks schemas; ASVS V2 input validation does not address this).
- **7.1.2 (stop sequences / token limits)**: keep. AI-specific.
- **7.1.3 (treat outputs as untrusted, parameterized queries, safe deserializers)**: rewrite. The implementation guidance (parameterized queries, safe deserializers) duplicates ASVS V1.2.4 and V1.5. Reframe to the AI-specific principle (model output is attacker-influenceable and must cross a trust boundary) and point to ASVS for the implementation pattern.
- **7.1.4 (log error type when output rejected)**: remove. Generic security logging is covered by ASVS V16.3.3 (logging attempts to bypass input validation) and AISVS C13.1 logging requirements.

### C7.2 Hallucination Detection & Mitigation
- All five requirements are AI-specific (hallucination is an LLM-only failure mode). Keep as-is.

### C7.3 Output Safety & Privacy Filtering
- **7.3.1 (classifier scans for hate/harassment/sexual violence)**: keep. AI-specific output safety classification.
- **7.3.2 (PII redaction in outputs)**: remove. The control itself is generic data-minimization on the output path (covered by ASVS V14.2.6) and the source of the data (memorization, hallucination, or input echo) does not change the control. The driver is primarily compliance (GDPR data minimization, CCPA disclosure limits) rather than a security control with a clear CIA impact under the ASVS scope test, so it belongs in C12 / external privacy regimes rather than C7.
- **7.3.3 (log redaction events without the PII values)**: remove. Fully covered by ASVS V16.2.5 (sensitive-data logging rules).
- **7.3.4 (data labeled "confidential" remains blocked or redacted)**: remove. Generic data-classification enforcement, covered by ASVS V14.1.1 and V14.2.4. Authorization-based output filtering against caller entitlements is already in AISVS C5.4.1.
- **7.3.5 (filters configurable by role/location)**: remove. Generic configurability; not a security requirement under the ASVS scope test ("absence of the requirement makes the application less secure"). Also weakened by "as appropriate".
- **7.3.6 (human approval / re-auth for high-risk content)**: remove. Duplicates AISVS C9.2.1 (runtime execution gate for irreversible/high-risk actions) and C14.2 (oversight policy).
- **7.3.7 (block verbatim system prompt content in output)**: keep. AI-specific (system-prompt extraction).
- **7.3.8 (prevent auto outbound requests triggered by model output)**: keep, reframe slightly. The browser/client side is generic frontend security (ASVS V3, CSP), but the AI-specific bug class (markdown/HTML emitted by an LLM auto-loading attacker-controlled URLs to exfiltrate context) recurs in chat UIs and warrants explicit coverage.
- **7.3.9 (statistical steganographic covert channels)**: keep at L3. Tooling exists only at research/alpha stage (e.g., phantom-detect 0.1.0, EMNLP 2025 work on tokenization-inconsistency detection); L3 is consistent with other low-tooling-maturity controls.

### C7.4 Output & Action Limiting
This entire section duplicates C9. Recommend removing the section.
- **7.4.1 (rate limit requests/tokens per user)**: remove. ASVS V2.4.1 covers anti-automation generally; AISVS C9.1.1 covers per-execution token/spend budgets explicitly; C13.2.9 covers per-user/session token consumption alerts.
- **7.4.2 (high-impact actions need user confirmation)**: remove. Direct duplicate of C9.2.1.
- **7.4.3 (max recursion depth)**: remove. Direct duplicate of C9.1.1 (which lists "max recursion depth" verbatim).
- **7.4.4 (max sub-task delegations)**: remove. Direct duplicate of C9.1.1 (fan-out/concurrency budgets); the requirement itself already cross-references C9.6.

### C7.5 Explainability & Transparency
- **7.5.1 (sanitize explanations to remove system prompts/backend data)**: keep. AI-specific.
- **7.5.2 (UI displays confidence score / reasoning summary)**: remove. UX/transparency requirement, not security; fails ASVS scope test (no demonstrable confidentiality, integrity, or availability impact). Belongs in trustworthy-AI guidance, not a verification standard.
- **7.5.3 (log interpretability artifacts)**: keep. AI-specific forensic capture (attention maps, feature attributions).

### C7.6 Monitoring Integration
This entire section duplicates C13. Recommend removing the section.
- **7.6.1 (log safety violation metrics)**: remove. Duplicate of C13.1.5.
- **7.6.2 (alert on safety violation rate threshold)**: remove. Duplicate of C13.2.5.
- **7.6.3 (logs include model version / abuse-investigation detail)**: remove. Duplicate of C13.1.1 and C13.1.7.

### C7.7 Generative Media Safeguards
- **7.7.1 (input filters block prompts requesting explicit/non-consensual content)**: remove. Duplicate of C2.3.1 (input-side content classifier covering violence, self-harm, hate, sexual content, illegal requests).
- **7.7.2 (refuse to generate media of real people without verified consent)**: remove. Not implementable or testable today: reliably identifying that generated media depicts a specific real person requires biometric matching against a reference set (which itself raises privacy issues and fails on people not in the set), and there is no widely deployed mechanism for "verified consent" of a likeness or voice. The closest existing controls are content provenance (C2PA, SynthID) and bilateral licensing, neither of which give an auditor a pass/fail line on this requirement. The compound nature ("is it a real person" + "did they consent") also fails the testability and compound-requirement checks. Where this concern is regulated, it is governance/policy (EU AI Act Article 50, right-of-publicity laws), not a runtime technical control. The defensible AI-specific control in this space is provenance/disclosure, which is retained at L3 in 7.5.1 (renumbered from 7.7.5).
- **7.7.3 (check generated content for copyright violations)**: remove. Primarily a legal/IP requirement, not a security control under the ASVS scope test.
- **7.7.4 (filter bypass attempts logged as security events)**: remove. Covered by ASVS V16.3.3 and C13.2.1.
- **7.7.5 (invisible watermark / cryptographic signature on AI-generated media)**: keep at L3, renumbered to 7.5.1. AI-specific provenance control with current tooling support (C2PA, SynthID).

### C7.8 Source Attribution & Citation Integrity
- All three are RAG-specific. Keep as-is.

## Result
- C7.1 Output Format Enforcement: 4 → 3 requirements
- C7.2 Hallucination Detection & Mitigation: 5 → 5 requirements (unchanged)
- C7.3 Output Safety & Privacy Filtering: 9 → 4 requirements
- C7.4 Output & Action Limiting: 4 → 0 requirements (section removed, covered by C9)
- C7.5 Explainability & Transparency: 3 → 2 requirements (renumbered to C7.4)
- C7.6 Monitoring Integration: 3 → 0 requirements (section removed, covered by C13)
- C7.7 Generative Media Safeguards: 5 → 1 requirement (renumbered to C7.5)
- C7.8 Source Attribution & Citation Integrity: 3 → 3 requirements (renumbered to C7.6)

Total: 36 → 18 requirements. Two sections removed (C7.4, C7.6) because every requirement was either covered by C9 or by C13. C7.7 Generative Media reduced to a single provenance/watermarking requirement at L3.