### PR TITLE
Reduction pass C08

### DIFF
--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -4,6 +4,8 @@
 
 Embeddings and vector stores act as semi-persistent and persistent "memory" for AI systems via Retrieval-Augmented Generation (RAG). This memory can become a high-risk data sink and data exfiltration path. This control family hardens memory pipelines and vector databases so that access is least-privilege, data is sanitized before vectorization, retention is explicit, and systems are resilient to embedding inversion, membership inference, and cross-tenant leakage.
 
+General authorization (RBAC/ABAC, scoped tokens, cross-tenant controls), data-at-rest cryptography and key management, generic data-retention and secure-deletion, generic input validation, and session lifecycle management are out of scope and are covered by OWASP ASVS v5 chapters V8, V11, V13, V14, V2, and V7.
+
 ---
 
 ## C8.1 Access Controls on Memory & RAG Indices
@@ -13,12 +15,10 @@ Enforce fine-grained access controls and query-time scope enforcement for every 
 | # | Description | Level |
 | :--: | --- | :---: |
 | **8.1.1** | **Verify that** vector insert, update, delete, and query operations are enforced with namespace/collection/document-tag scope controls (e.g., tenant ID, user ID, data classification labels) with default-deny. | 1 |
-| **8.1.2** | **Verify that** API credentials used for vector operations carry **scoped claims** (e.g., permitted collections, allowed verbs, tenant binding). | 1 |
-| **8.1.3** | **Verify that** cross-scope access attempts (e.g., cross-tenant similarity queries, namespace traversal, tag bypass) are detected and rejected. | 2 |
-| **8.1.4** | **Verify that** every ingested document is tagged at write time with source, writer identity (authenticated user or system principal), timestamp, batch ID, and embedding model version. | 2 |
-| **8.1.7** | **Verify that** document metadata tags applied at ingestion are immutable after initial write and cannot be modified by subsequent pipeline stages or user operations. | 2 |
-| **8.1.5** | **Verify that** RAG pipeline retrieval events log the query issued, the documents or chunks retrieved, similarity scores, the knowledge source, and whether retrieved content passed prompt injection scanning before being incorporated into model context. | 2 |
-| **8.1.6** | **Verify that** retrieval anomaly detection identifies embedding density outliers, repeated dominance of specific documents in similarity results, and sudden shifts in retrieval bias distribution that may indicate vector database poisoning. | 3 |
+| **8.1.2** | **Verify that** every ingested document is tagged at write time with source, writer identity (authenticated user or system principal), timestamp, batch ID, and embedding model version. | 2 |
+| **8.1.3** | **Verify that** document metadata tags applied at ingestion are immutable after initial write and cannot be modified by subsequent pipeline stages or user operations. | 2 |
+| **8.1.4** | **Verify that** RAG pipeline retrieval events log the query issued, the documents or chunks retrieved, similarity scores, the knowledge source, and whether retrieved content passed prompt injection scanning before being incorporated into model context. | 2 |
+| **8.1.5** | **Verify that** retrieval anomaly detection identifies embedding density outliers, repeated dominance of specific documents in similarity results, and sudden shifts in retrieval bias distribution that may indicate vector database poisoning. | 3 |
 
 ---
 
@@ -28,8 +28,8 @@ Pre-screen content before vectorization; treat memory writes as untrusted inputs
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.2.1** | **Verify that** regulated data and sensitive fields are detected prior to embedding and are masked, tokenized, transformed, or dropped based on policy. | 1 |
-| **8.2.2** | **Verify that** embedding ingestion rejects or quarantines inputs that violate required content constraints (e.g., non-UTF-8, malformed encodings, oversized payloads, invisible Unicode characters, or executable content intended to poison retrieval). | 1 |
+| **8.2.1** | **Verify that** regulated data and sensitive fields are detected prior to embedding and are masked, tokenized, transformed, or dropped based on policy, recognising that data once embedded cannot be reliably redacted from the resulting index. | 1 |
+| **8.2.2** | **Verify that** content intended to poison retrieval (e.g., text crafted to project to attacker-chosen embedding neighborhoods, hidden instructions intended for downstream model context, or steganographic payloads in non-text inputs) is detected and rejected or quarantined before vectorization. | 1 |
 | **8.2.3** | **Verify that** vectors that fall outside normal clustering patterns are flagged and quarantined before entering production indices. | 2 |
 | **8.2.4** | **Verify that** an agent's own outputs are not automatically written back into its trusted memory without explicit validation (such as content-origin checks or write-authorization controls that verify the content's source before committing writes). | 2 |
 | **8.2.5** | **Verify that** new content written to memory is checked for contradictions with what is already stored and that conflicts trigger alerts. | 3 |
@@ -38,18 +38,13 @@ Pre-screen content before vectorization; treat memory writes as untrusted inputs
 
 ## C8.3 Memory Expiry, Revocation & Deletion
 
-Retention must be explicit and enforceable; deletions must propagate to derived indices and caches.
+Retention and revocation must be explicit and enforceable for memory and RAG indices, and deletions must propagate through derivative indices and caches within a measured propagation window.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.3.1** | **Verify that** retention times are applied to every stored vector and related metadata across memory storage. | 1 |
-| **8.3.2** | **Verify that** only information required for the system's defined function is persisted in memory (such as user preferences and conversation decisions, not credentials or full conversation transcripts). | 1 |
-| **8.3.7** | **Verify that** context not needed beyond the current session is discarded at session end and is not accessible in subsequent sessions. | 1 |
-| **8.3.3** | **Verify that** deletion requests purge vectors, metadata, cache copies, and derivative indices within an organization-defined maximum time. | 1 |
-| **8.3.4** | **Verify that** deleted or expired vectors are removed reliably and are unrecoverable. | 2 |
-| **8.3.5** | **Verify that** expired vectors are excluded from retrieval results within a measured and monitored propagation window. | 2 |
-| **8.3.6** | **Verify that** memory can be reset for security reasons (quarantine, selective purge, full reset) through an operation that is separate and independent from the retention deletion process. | 2 |
-| **8.3.8** | **Verify that** quarantined content is retained for investigation but is excluded from all retrieval results while under quarantine. | 2 |
+| **8.3.1** | **Verify that** expired vectors are excluded from retrieval results within a measured and monitored propagation window. | 2 |
+| **8.3.2** | **Verify that** memory can be reset for security reasons (quarantine, selective purge, full reset) through an operation that is separate and independent from the retention deletion process. | 2 |
+| **8.3.3** | **Verify that** quarantined content is retained for investigation but is excluded from all retrieval results while under quarantine. | 2 |
 
 ---
 
@@ -59,8 +54,7 @@ Address inversion, membership inference, and attribute inference with explicit t
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.4.1** | **Verify that** sensitive vector collections are protected against direct read access by infrastructure administrators via technical controls such as application-layer encryption, envelope encryption with strict KMS policies, or equivalent compensating controls. | 2 |
-| **8.4.2** | **Verify that** privacy/utility targets for embedding leakage resistance are **defined and measured**, and that changes to embedding models, tokenizers, retrieval settings, or privacy transforms are gated by regression tests against those targets. | 3 |
+| **8.4.1** | **Verify that** privacy/utility targets for embedding leakage resistance are **defined and measured**, and that changes to embedding models, tokenizers, retrieval settings, or privacy transforms are gated by regression tests against those targets. | 3 |
 
 ---
 
@@ -70,12 +64,9 @@ Prevent cross-tenant and cross-user leakage in retrieval and prompt assembly.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.5.1** | **Verify that** every retrieval operation enforces scope constraints (tenant/user/classification) **in the vector engine query** and verifies them again **before prompt assembly** (post-filter). | 1 |
+| **8.5.1** | **Verify that** every retrieval operation enforces scope constraints (tenant/user/classification) **in the vector engine query** and verifies them again **before prompt assembly** (post-filter), discarding results that match similarity criteria but fail scope checks. | 1 |
 | **8.5.2** | **Verify that** vector identifiers, namespaces, and metadata indexing prevent cross-scope collisions and enforce uniqueness per tenant. | 1 |
-| **8.5.3** | **Verify that** retrieval results that match similarity criteria but fail scope checks are discarded. | 1 |
-| **8.5.4** | **Verify that** multi-tenant tests simulate adversarial retrieval attempts (prompt-based and query-based) and demonstrate zero out-of-scope document inclusion in prompts and outputs. | 2 |
-| **8.5.5** | **Verify that** in multi-agent systems, each agent's memory namespace is isolated and enforced through access control, not just organizational naming conventions. | 2 |
-| **8.5.6** | **Verify that** encryption keys and access policies are segregated per tenant for memory/vector storage, providing cryptographic isolation in shared infrastructure. | 3 |
+| **8.5.3** | **Verify that** multi-tenant tests simulate adversarial retrieval attempts (prompt-based and query-based) and demonstrate zero out-of-scope document inclusion in prompts and outputs. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -4,7 +4,7 @@
 
 Embeddings and vector stores act as semi-persistent and persistent "memory" for AI systems via Retrieval-Augmented Generation (RAG). This memory can become a high-risk data sink and data exfiltration path. This control family hardens memory pipelines and vector databases so that access is least-privilege, data is sanitized before vectorization, retention is explicit, and systems are resilient to embedding inversion, membership inference, and cross-tenant leakage.
 
-General authorization (RBAC/ABAC, scoped tokens, cross-tenant controls), data-at-rest cryptography and key management, generic data-retention and secure-deletion, generic input validation, and session lifecycle management are out of scope and are covered by OWASP ASVS v5 chapters V8, V11, V13, V14, V2, and V7.
+> **Scope note:** General authorization (RBAC/ABAC, scoped tokens, cross-tenant controls), data-at-rest cryptography and key management, generic data-retention and secure-deletion, generic input validation, and session lifecycle management are out of scope and are covered by OWASP ASVS v5 chapters V8, V11, V13, V14, V2, and V7. End-user authorization context propagation through RAG retrieval is covered by AISVS C5.3. Personal-data deletion propagation across AI artifacts (including embeddings) is covered by AISVS C12.2. Per-agent memory namespace isolation in multi-agent systems is covered by AISVS C9.8.3. This chapter focuses on AI-specific concerns: scope enforcement at the vector-engine layer, AI-specific data lineage (embedding model version, ingestion provenance), embedding-pipeline poisoning resistance, retrieval-time anomaly detection, RAG-specific deletion propagation windows, and embedding inversion / membership-inference resistance.
 
 ---
 
@@ -64,9 +64,10 @@ Prevent cross-tenant and cross-user leakage in retrieval and prompt assembly.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.5.1** | **Verify that** every retrieval operation enforces scope constraints (tenant/user/classification) **in the vector engine query** and verifies them again **before prompt assembly** (post-filter), discarding results that match similarity criteria but fail scope checks. | 1 |
+| **8.5.1** | **Verify that** every retrieval operation enforces scope constraints (tenant/user/classification) **in the vector engine query** and verifies them again **before prompt assembly** (post-filter). | 1 |
 | **8.5.2** | **Verify that** vector identifiers, namespaces, and metadata indexing prevent cross-scope collisions and enforce uniqueness per tenant. | 1 |
-| **8.5.3** | **Verify that** multi-tenant tests simulate adversarial retrieval attempts (prompt-based and query-based) and demonstrate zero out-of-scope document inclusion in prompts and outputs. | 2 |
+| **8.5.3** | **Verify that** retrieval results that match similarity criteria but fail scope checks are discarded. | 1 |
+| **8.5.4** | **Verify that** multi-tenant tests simulate adversarial retrieval attempts (prompt-based and query-based) and demonstrate zero out-of-scope document inclusion in prompts and outputs. | 2 |
 
 ---
 


### PR DESCRIPTION
Tightens C8 to focus on AI-specific memory, embedding, and vector-database controls and removes requirements that are either fully covered by ASVS v5 (V8 Authorization, V14 Data Protection, V13 Configuration, V11 Cryptography, V7 Session Management) or that duplicate other AISVS chapters (C5 Access Control, C9 Orchestration & Agentic Action, C12 Privacy). Adds a scope note to the Control Objective to consolidate out-of-scope pointers.

## Per-section changes

### C8.1 Access Controls on Memory & RAG Indices
- **8.1.1 (scope-based controls on vector ops with default-deny)**: keep. AI-specific because the scope dimensions (collection, namespace, document tag, embedding similarity) and the operation set (insert/update/query against a vector index) are not addressed by ASVS V8 authorization rules.
- **8.1.2 (API credentials carry scoped claims)**: remove. Generic API authorization / scoped-token guidance, fully covered by ASVS V8 (function-level authorization) and the broader OAuth/JWT scope model in ASVS V9 and V10. Nothing here is AI-specific once 8.1.1 enforces collection-scoped access at the engine.
- **8.1.3 (cross-scope detection and rejection)**: remove. The detection-and-reject control is a restatement of ASVS V8.4.1 (cross-tenant controls). The AI-specific surface (similarity-based inference across scopes) is already covered by 8.5.1 / 8.5.3.
- **8.1.4 (tag every ingested document with source, writer, timestamp, batch ID, embedding model version)**: keep. AI-specific data lineage; embedding model version in particular is an AI-only attribute and is needed for retrieval-side debugging and model-rotation forensics.
- **8.1.7 (metadata tags immutable after write)**: keep. AI-specific in effect: scope tags govern retrieval filters, and pipelines (re-embedders, summarizers) routinely have write paths back into the same store. ASVS V14 does not address tag-mutation in vector pipelines.
- **8.1.5 (log RAG retrieval events including similarity scores and prompt-injection scan outcome)**: keep. AI-specific log fields (similarity scores, retrieval set, injection-scan result) that go beyond ASVS V16 / AISVS C13.1.
- **8.1.6 (retrieval anomaly detection for vector DB poisoning)**: keep. AI-specific signal (embedding density outliers, retrieval bias shifts).

### C8.2 Embedding Sanitization & Validation
- **8.2.1 (regulated/sensitive data detected and masked/tokenized before embedding)**: keep. The masking primitives are generic (ASVS V14) but the requirement that detection-and-transform must occur before vectorization is AI-specific, since once embedded the data is irreversibly entangled with the index and is subject to inversion.
- **8.2.2 (reject inputs that violate constraints, e.g., invisible Unicode, executable poisoning content)**: keep, scope to AI-specific portion. General input validation (oversized payloads, malformed encodings) is ASVS V2 and V5. Invisible-Unicode and homoglyph normalization is already covered by C2.2.1 on the prompt path. The retained AI-specific concern here is content intended to poison the retrieval index (e.g., crafted text whose embedding pulls toward a target neighborhood). Reframed accordingly to avoid duplicating C2.2.1.
- **8.2.3 (vectors outside normal clustering quarantined before production)**: keep. AI-specific.
- **8.2.4 (agent self-outputs not auto-written to trusted memory without validation)**: keep. AI-specific feedback-loop poisoning control.
- **8.2.5 (contradiction detection on memory writes)**: keep at L3. AI-specific; tooling is research-grade, level reflects this.

### C8.3 Memory Expiry, Revocation & Deletion
- **8.3.1 (retention times on stored vectors and metadata)**: remove. Generic retention is ASVS V14.1.2 and V14.2.7, and is also restated in AISVS C12.2.1 for personal data. Nothing here is specific to vectors that is not already implied by the data-classification/retention chain.
- **8.3.2 (persist only what is required for the system's defined function)**: remove. Direct restatement of data minimization, covered by ASVS V14.2.6. The chosen example (no full conversation transcripts, no credentials) is generic data hygiene and not AI-specific.
- **8.3.7 (session context discarded at session end and not accessible in subsequent sessions)**: remove. This is session management, covered by ASVS V7 (session lifecycle and termination). The AI-specific concern (cross-session memory leakage) is already addressed by 8.5.1 / 8.5.2 (scope enforcement at retrieval) for any persistent cross-session store.
- **8.3.3 (deletion purges vectors, metadata, caches, derivative indices within SLA)**: remove. Direct duplicate of AISVS C12.2.1, which already requires propagation to "raw datasets, checkpoints, embeddings, logs, and backups within SLA less than 30 days". Covers the same control surface.
- **8.3.4 (deleted/expired vectors unrecoverable)**: remove. Generic secure-deletion / cryptographic-erasure, covered by ASVS V14.2.4 protection-level enforcement and broadly by storage hygiene. Not AI-specific.
- **8.3.5 (expired vectors excluded from retrieval within a measured propagation window)**: keep. AI-specific (vector indices and read-replicas have non-trivial propagation windows; "deleted but still retrievable" is a real RAG-specific failure mode).
- **8.3.6 (security-driven memory reset is a separate operation from retention deletion)**: keep. AI-specific operational control; the distinction between routine retention purging and security-driven quarantine/reset is specific to memory-augmented systems.
- **8.3.8 (quarantined content excluded from all retrieval while quarantined)**: keep. AI-specific.

### C8.4 Prevent Embedding Inversion & Leakage
- **8.4.1 (sensitive vector collections protected from infrastructure admins via app-layer or envelope encryption)**: remove. The control pattern (envelope encryption, KMS isolation, application-layer encryption to defeat infra admin reads) is generic data-at-rest protection covered by ASVS V11 cryptography and V13.3.3 (isolated security module) plus V14.2.4 protection-level enforcement. Nothing about it is specific to vectors as opposed to any other sensitive data store.
- **8.4.2 (privacy/utility targets for embedding leakage; regression tests gate model/tokenizer/transform changes)**: keep at L3. AI-specific; embedding inversion and membership-inference targets have no analogue outside ML systems. L3 is consistent with current tooling maturity (research-grade auditors such as ML-Doctor, custom inversion attacks).

### C8.5 Scope Enforcement for User-Specific Memory
- **8.5.1 (scope enforced in the vector engine query AND verified again before prompt assembly)**: keep. AI-specific defense-in-depth for RAG (post-filter against scope-bypass via similarity-only retrieval).
- **8.5.2 (vector IDs/namespaces/metadata prevent cross-scope collisions)**: keep. AI-specific data model concern.
- **8.5.3 (results that match similarity but fail scope checks are discarded)**: remove. Direct restatement of the post-filter half of 8.5.1; folding it in avoids a compound-by-split duplication.
- **8.5.4 (multi-tenant tests demonstrate zero out-of-scope inclusion)**: keep. AI-specific testing requirement (covers prompt-based and query-based retrieval bypass).
- **8.5.5 (per-agent memory namespace enforced by access control, not naming)**: remove. Direct duplicate of AISVS C9.8.3, which already requires that "each agent is restricted to its own memory namespace and is technically prevented from reading or modifying peer agent state".
- **8.5.6 (per-tenant encryption keys and access policies for memory/vector storage)**: remove. Generic per-tenant cryptographic isolation pattern, covered by ASVS V11 (key management) and V8.4.1 (cross-tenant controls). The vector-storage qualifier does not introduce an AI-specific implementation concern beyond what 8.1.1 / 8.5.1 already require.

### Control Objective
- Add a scope note (in the standard `> **Scope note:**` blockquote format used elsewhere in AISVS) pointing out that retention/deletion of personal data is in C12, agent memory namespace isolation is in C9.8, and end-user authorization context for retrieval is in C5.3, so individual sections do not need inline cross-references.

## Result
- C8.1 Access Controls on Memory & RAG Indices: 7 → 5 requirements
- C8.2 Embedding Sanitization & Validation: 5 → 5 requirements (8.2.2 reframed; no count change)
- C8.3 Memory Expiry, Revocation & Deletion: 8 → 3 requirements
- C8.4 Prevent Embedding Inversion & Leakage: 2 → 1 requirement
- C8.5 Scope Enforcement for User-Specific Memory: 6 → 4 requirements

Total: 28 → 18 requirements. Removals consolidate into ASVS v5 (V7, V8, V11, V13, V14) and into AISVS C5, C9, and C12 where the same control already exists with appropriate AI framing.