### PR TITLE
Reduction pass C09

### DIFF
--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -6,7 +6,7 @@ AI systems introduce access control challenges beyond traditional application se
 
 This chapter addresses AI-specific access control and identity concerns only. General identity management and authentication (centralized IdP, federation, MFA, step-up authentication) are covered by ASVS v5 V6. General authorization patterns (RBAC/ABAC design, externalized PDP, dynamic attribute evaluation, policy caching), access control audit logging, and multi-tenant networking are covered by ASVS v5 V8, V14, and V16. 
 
-Agent-specific authorization policies and delegation are covered in C9.6; single-system agent identity is in C9.4.1; this chapter covers runtime isolation of the policy decision point from agent execution (complementing C9.6.4). Vector database scope enforcement is in C8.1 and C8.5. General output safety filtering (PII redaction, content moderation, confidential data blocking) is in C7.3; this chapter covers authorization-aware output filtering where entitlements vary per caller.
+Agent-specific authorization policies and delegation are covered in C9.6; single-system agent identity is in C9.4.1; this chapter covers runtime isolation of the policy decision point from agent execution (complementing C9.6.3). Vector database scope enforcement is in C8.1 and C8.5. General output safety filtering (PII redaction, content moderation, confidential data blocking) is in C7.3; this chapter covers authorization-aware output filtering where entitlements vary per caller.
 
 ---
 

--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -2,7 +2,9 @@
 
 ## Control Objective
 
-Autonomous and multi-agent systems must execute only **authorized, intended, and bounded** actions. This control family reduces risk from tool misuse, privilege escalation, uncontrolled recursion/cost growth, protocol manipulation, and cross-agent or cross-tenant interference by enforcing: explicit authorization, sandboxed execution, cryptographic identity and tamper-evident audit, message security, and intent/constraint gates.
+Autonomous and multi-agent systems must execute only authorized, intended, and bounded actions. This chapter focuses on controls unique to agentic AI execution: agent-as-principal identity, agent action chains, model-output-driven authorization risk, intent verification of LLM-decided actions, and multi-agent swarm dynamics. Generic application security controls (transport encryption, schema validation, message integrity, log integrity, concurrency safety, supply chain integrity, service-account rotation, multi-tenant isolation, contextual authorization, and API-edge rate limiting) are covered by ASVS v5 (V2, V4, V8, V11, V12, V13, V15, V16), AISVS C13.1.6, and OWASP SCVS, and are not repeated here.
+
+Boundaries with adjacent controls determine what evidence satisfies each requirement. C9.1 execution budgets apply inside the orchestration runtime and do not substitute for API-edge rate limiting (ASVS v5 V2.4) or anti-extraction/anti-inversion throttling (C11.4, C11.5). C9.2 governs the runtime gate that blocks high-impact actions until approval is received; C14.2 defines the policy that classifies actions as high-risk and assigns approval authority; C13.7.4 covers logging of approval events. C9.5 covers semantic validation of agent-generated outputs flowing into downstream agents, while transport, schema, and replay protections are in ASVS v5 V4/V11/V12 and MCP-specific message and schema controls are in C10.4.
 
 ---
 
@@ -10,15 +12,11 @@ Autonomous and multi-agent systems must execute only **authorized, intended, and
 
 Bound runtime expansion (recursion, concurrency, cost) and halt safely on runaway behavior.
 
-> **Scope note:** Controls in this section govern internal orchestration runtime budgets: per-task recursion depth, concurrency, wall-clock time, token spend, and monetary limits. They apply inside the agentic execution layer, not at the API ingress edge (see ASVS v5 V2.4 for generic rate limiting) and not in response to adversarial probing patterns (C11.4, C11.5). A single token-spend cap at the API gateway does not satisfy C9.1 budget enforcement, which requires enforcement within the orchestration runtime itself.
-
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.1.1** | **Verify that** per-execution budgets (max recursion depth, max fan-out/concurrency, wall-clock time, tokens, and monetary spend) are configured and enforced by the orchestration runtime. | 1 |
-| **9.1.2** | **Verify that** cumulative resource/spend counters are tracked per request chain and hard-stop the chain when thresholds are exceeded. | 2 |
-| **9.1.3** | **Verify that** circuit breakers terminate execution on budget violations. | 2 |
-| **9.1.4** | **Verify that** security testing covers runaway loops, budget exhaustion, and partial-failure scenarios, confirming safe termination and consistent state. | 3 |
-| **9.1.5** | **Verify that** budget and circuit-breaker policies are expressed as policy-as-code and are validated in CI/CD to prevent drift and unsafe configuration changes. | 3 |
+| **9.1.2** | **Verify that** cumulative resource and spend counters are tracked per request chain and that exceeding any configured threshold hard-stops the chain via a circuit breaker. | 2 |
+| **9.1.3** | **Verify that** security testing covers runaway loops, budget exhaustion, and partial-failure scenarios, confirming safe termination and consistent state. | 3 |
 
 ---
 
@@ -26,16 +24,12 @@ Bound runtime expansion (recursion, concurrency, cost) and halt safely on runawa
 
 Require explicit checkpoints for privileged or irreversible outcomes.
 
-> **Scope note:** C9.2 governs the runtime execution gate: the mechanism by which the agent system blocks a privileged or irreversible action and waits for an explicit approval signal before proceeding. Organizational policy that defines which decisions qualify as high-risk and what approval authority is required is in C14.2. Logging and auditing of approval events is in C13.7.4. All three controls address different aspects of the same workflow and require separate evidence.
-
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.2.1** | **Verify that** the agent runtime enforces an execution gate that blocks privileged or irreversible actions (e.g., code merges/deploys, financial transfers, user access changes, destructive deletes, external notifications) until an explicit human approval is received and verified. | 1 |
 | **9.2.2** | **Verify that** approval requests display canonicalized and complete action parameters (diff, command, recipient, amount, scope) without truncation or transformation. | 2 |
-| **9.2.3** | **Verify that** approvals are cryptographically bound (e.g., signed or MACed) to the exact action parameters, requester identity, and execution context. | 2 |
-| **9.2.4** | **Verify that** approvals include a unique nonce and are single-use to prevent replay or substitution. | 2 |
-| **9.2.5** | **Verify that** approvals expire within a defined maximum time-to-live (TTL) and are rejected after expiration. | 2 |
-| **9.2.6** | **Verify that** where rollback is feasible, compensating actions are defined and tested (transactional semantics), and failures trigger rollback or safe containment. | 3 |
+| **9.2.3** | **Verify that** approvals are cryptographically bound (e.g., signed or MACed) to the exact action parameters, requester identity, and execution context, include a unique single-use nonce, and expire within a defined maximum time-to-live (TTL). | 2 |
+| **9.2.4** | **Verify that** where rollback is feasible, compensating actions are defined and tested (transactional semantics), and failures trigger rollback or safe containment. | 3 |
 
 ---
 
@@ -46,12 +40,10 @@ Constrain tool execution, loading, and outputs to prevent unauthorized system ac
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.3.1** | **Verify that** each tool/plugin executes in an isolated sandbox (container/VM/WASM/OS sandbox) with least-privilege filesystem, network egress, and syscall permissions appropriate to the tool's function. | 1 |
-| **9.3.2** | **Verify that** per-tool quotas and timeouts (CPU, memory, disk, egress, execution time) are enforced and logged. | 1 |
-| **9.3.7** | **Verify that** quota or timeout breaches fail closed, terminating the tool execution rather than continuing with degraded or uncontrolled behavior. | 1 |
+| **9.3.2** | **Verify that** per-tool quotas and timeouts (CPU, memory, disk, egress, execution time) are enforced and logged, and that quota or timeout breaches fail closed by terminating the tool execution rather than continuing with degraded or uncontrolled behavior. | 1 |
 | **9.3.3** | **Verify that** tool outputs are validated against strict schemas and security policies before being incorporated into downstream reasoning or follow-on actions. | 1 |
-| **9.3.4** | **Verify that** tool binaries or packages are integrity-verified (e.g., signatures, checksums) prior to loading. | 2 |
-| **9.3.5** | **Verify that** tool manifests declare required privileges, side-effect level, resource limits, and output validation requirements, and that the runtime enforces these declarations. | 2 |
-| **9.3.6** | **Verify that** sandbox escape indicators or policy violations trigger automated containment (tool disabled/quarantined). | 3 |
+| **9.3.4** | **Verify that** tool manifests declare required privileges, side-effect level, resource limits, and output validation requirements, and that the runtime enforces these declarations. | 2 |
+| **9.3.5** | **Verify that** sandbox escape indicators or policy violations trigger automated containment (tool disabled/quarantined). | 3 |
 
 ---
 
@@ -63,23 +55,19 @@ Make every action attributable and every mutation detectable.
 | :--: | --- | :---: |
 | **9.4.1** | **Verify that** each agent instance (and orchestrator/runtime) has a unique cryptographic identity and authenticates as a first-class principal to downstream systems (no reuse of end-user credentials). | 1 |
 | **9.4.2** | **Verify that** agent-initiated actions are cryptographically bound to the execution chain (chain ID) and are signed and timestamped for non-repudiation and traceability. | 2 |
-| **9.4.3** | **Verify that** audit logs are tamper-evident via append-only/WORM/immutable log store, cryptographic hash chaining where each record includes the hash of the prior record, or equivalent integrity guarantees that can be independently verified. | 2 |
-| **9.4.5** | **Verify that** audit log records include sufficient context to reconstruct who/what acted, the initiating user identifier, delegation scope, authorization decision (policy/version), tool parameters, approvals (where applicable), and outcomes. | 2 |
+| **9.4.3** | **Verify that** audit log records include sufficient context to reconstruct who/what acted, the initiating user identifier, delegation scope, authorization decision (policy/version), tool parameters, approvals (where applicable), and outcomes. | 2 |
 | **9.4.4** | **Verify that** agent identity credentials (keys/certs/tokens) rotate on a defined schedule and on compromise indicators, with rapid revocation and quarantine on suspected compromise or spoofing attempts. | 3 |
-| **9.4.6** | **Verify that** agent state persisted between invocations (including memory, task context, goals, and partial results) is integrity-protected (e.g., via cryptographic MACs or signatures), and that the runtime rejects or quarantines state that fails integrity verification before resuming execution. | 3 |
+| **9.4.5** | **Verify that** agent state persisted between invocations (including memory, task context, goals, and partial results) is integrity-protected (e.g., via cryptographic MACs or signatures), and that the runtime rejects or quarantines state that fails integrity verification before resuming execution. | 3 |
 
 ---
 
 ## C9.5 Secure Messaging and Protocol Hardening
 
-Protect agent-to-agent and agent-to-tool communications from hijacking, injection, replay, and desynchronization.
+Protect agent-to-agent and agent-to-tool communications from hijacking, injection, and unauthorized modifications.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.5.1** | **Verify that** agent-to-agent and agent-to-tool channels enforce mutual authentication and encryption using current recommended protocols (e.g., TLS 1.3 or later) with strong certificate/token validation. | 1 |
-| **9.5.2** | **Verify that** all messages are strictly schema-validated; unknown fields, malformed payloads, and oversized frames are rejected. | 1 |
-| **9.5.3** | **Verify that** message integrity covers the full payload including tool parameters, and that replay protections (nonces/sequence numbers/timestamp windows) are enforced. | 2 |
-| **9.5.4** | **Verify that** agent outputs propagated to downstream agents are validated against semantic constraints (e.g., value ranges, logical consistency) in addition to schema validation. | 2 |
+| **9.5.1** | **Verify that** agent outputs propagated to downstream agents are validated against semantic constraints (e.g., value ranges, logical consistency) in addition to schema validation. | 2 |
 
 ---
 
@@ -91,11 +79,10 @@ Ensure every action is authorized at execution time and constrained by scope.
 | :--: | --- | :---: |
 | **9.6.1** | **Verify that** agent actions are authorized against fine-grained policies enforced by the runtime that restrict which tools an agent may invoke, which parameter values it may supply (e.g., allowed resources, data scopes, action types), and that policy violations are blocked. | 1 |
 | **9.6.2** | **Verify that** when an agent acts on a user's behalf, the runtime propagates an integrity-protected delegation context (user ID, tenant, session, scopes) and enforces that context at every downstream call without using the user's credentials. | 2 |
-| **9.6.3** | **Verify that** authorization is re-evaluated on every call (continuous authorization) using current context (user, tenant, environment, data classification, time, risk). | 2 |
-| **9.6.4** | **Verify that** all access control decisions are enforced by application logic or a policy engine, never by the AI model itself, and that model-generated output (e.g., "the user is allowed to do this") cannot override or bypass access control checks. | 2 |
-| **9.6.5** | **Verify that** secrets and credentials required by an agent at runtime are not exposed within the model's observable context, including the context window, system prompts, or tool call parameters, and are instead provided via out-of-band mechanisms such as credential proxies, secrets manager injection, runtime sidecar authentication, or short-lived scoped tokens. | 2 |
-| **9.6.6** | **Verify that** when an agent acts under delegated authority, the policy decision point evaluates both the agent's own granted permissions and the initiating principal's delegated scope as independent constraints, denying the action if either is insufficient for the requested operation. | 2 |
-| **9.6.7** | **Verify that** agent-to-agent task delegation is restricted by an explicit peer authorization policy (e.g., an approved agent registry or allowlist) so that even authenticated agents can only delegate to or accept delegations from pre-approved peers, with delegation attempts from unlisted agents rejected by default. | 2 |
+| **9.6.3** | **Verify that** all access control decisions are enforced by application logic or a policy engine, never by the AI model itself, and that model-generated output (e.g., "the user is allowed to do this") cannot override or bypass access control checks. | 2 |
+| **9.6.4** | **Verify that** secrets and credentials required by an agent at runtime are not exposed within the model's observable context, including the context window, system prompts, or tool call parameters, and are instead provided via out-of-band mechanisms such as credential proxies, secrets manager injection, runtime sidecar authentication, or short-lived scoped tokens. | 2 |
+| **9.6.5** | **Verify that** when an agent acts under delegated authority, the policy decision point evaluates both the agent's own granted permissions and the initiating principal's delegated scope as independent constraints, denying the action if either is insufficient for the requested operation. | 2 |
+| **9.6.6** | **Verify that** agent-to-agent task delegation is restricted by an explicit peer authorization policy (e.g., an approved agent registry or allowlist) so that even authenticated agents can only delegate to or accept delegations from pre-approved peers, with delegation attempts from unlisted agents rejected by default. | 2 |
 
 ---
 
@@ -106,12 +93,10 @@ Prevent "technically authorized but unintended" actions by binding execution to 
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.7.1** | **Verify that** pre-execution gates evaluate proposed actions and parameters against hard policy constraints (deny rules, data handling constraints, allow-lists, side-effect budgets) and block execution on any violation. | 1 |
-| **9.7.2** | **Verify that** post-execution checks confirm the intended outcome was achieved. | 2 |
-| **9.7.3** | **Verify that** post-execution checks detect unintended side effects. | 2 |
-| **9.7.4** | **Verify that** any mismatch between intended outcome and actual results triggers containment and, where supported, compensating actions. | 2 |
+| **9.7.2** | **Verify that** post-execution checks confirm the intended outcome was achieved and detect unintended side effects, and that any mismatch triggers containment and, where supported, compensating actions. | 2 |
+| **9.7.3** | **Verify that** all write operations to persistent external state are authorized by either explicit human approval or an independent policy-based authorization mechanism that evaluates the operation against the original user intent, and not solely on agent-generated output. | 2 |
+| **9.7.4** | **Verify that** when the policy decision point (PDP) used for governance evaluation is unavailable (e.g., timeout, network partition, service failure), agent execution fails closed by blocking the proposed action, and the unavailability event is logged with sufficient detail for incident investigation. | 2 |
 | **9.7.5** | **Verify that** prompt templates and agent policy configurations retrieved from a remote source are integrity-verified at load time against their approved versions (e.g., via hashes or signatures). | 3 |
-| **9.7.6** | **Verify that** all write operations to persistent external state are authorized by either explicit human approval or an independent policy-based authorization mechanism that evaluates the operation against the original user intent, and not solely on agent-generated output. | 2 |
-| **9.7.7** | **Verify that** when the policy decision point (PDP) used for governance evaluation is unavailable (e.g., timeout, network partition, service failure), agent execution fails closed by blocking the proposed action, and the unavailability event is logged with sufficient detail for incident investigation. | 2 |
 
 ---
 
@@ -122,13 +107,11 @@ Reduce cross-domain interference and emergent unsafe collective behavior.
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.8.1** | **Verify that** agents in different tenants, security domains, or environments (dev/test/prod) run in isolated runtimes and network segments, with default-deny controls that prevent cross-domain discovery and calls. | 1 |
-| **9.8.2** | **Verify that** runtime monitoring detects unsafe emergent behavior (oscillation, deadlocks, uncontrolled broadcast, abnormal call graphs) and automatically applies corrective actions (throttle, isolate, terminate). | 3 |
-| **9.8.3** | **Verify that** each agent is restricted to its own memory namespace and is technically prevented from reading or modifying peer agent state, preventing unauthorized cross-agent access within the same swarm. | 2 |
-| **9.8.4** | **Verify that** each agent operates with an isolated context window that peer agents cannot read or influence, preventing unauthorized cross-agent context access within the same swarm. | 3 |
-| **9.8.7** | **Verify that** each agent is issued dedicated credentials scoped to its role that are not shared with or accessible to peer agents within the same swarm. | 3 |
+| **9.8.2** | **Verify that** each agent is restricted to its own memory namespace and is technically prevented from reading or modifying peer agent state, preventing unauthorized cross-agent access within the same swarm. | 2 |
+| **9.8.3** | **Verify that** each agent operates with an isolated context window that peer agents cannot read or influence, preventing unauthorized cross-agent context access within the same swarm. | 3 |
+| **9.8.4** | **Verify that** runtime monitoring detects unsafe emergent behavior (oscillation, deadlocks, uncontrolled broadcast, abnormal call graphs) and automatically applies corrective actions (throttle, isolate, terminate). | 3 |
 | **9.8.5** | **Verify that** swarm-level aggregate action rate limits (e.g., total external API calls, file writes, or network requests per time window across all agents) are enforced to prevent bursts that cause denial-of-service or abuse of external systems. | 3 |
 | **9.8.6** | **Verify that** a swarm-level shutdown capability exists that can halt all active agent instances or selected problematic instances in an organized fashion and prevents new agent spawning, with shutdown completable within a pre-defined response time. | 3 |
-| **9.8.8** | **Verify that** when multiple agents concurrently access shared mutable state, authorization checks and the state mutations they gate are executed atomically (e.g., via transactions, optimistic locking, or compare-and-swap) to prevent TOCTOU vulnerabilities where a concurrent state change invalidates a prior authorization decision before the guarded action completes. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -42,8 +42,7 @@ Enforce access decisions across users, agents, tools, data, and MCP resources us
 | Caller authorization context enforcement through AI query pipelines | 5.3.1 |
 | Fine-grained agent action authorization (tool, parameters, resources, data scope) | 9.6.1 |
 | Delegation context propagation with integrity protection (user, tenant, scopes) | 9.6.2 |
-| Continuous authorization re-evaluation (context, time, risk) | 9.6.3 |
-| Application-layer policy enforcement (model output cannot bypass) | 9.6.4 |
+| Application-layer policy enforcement (model output cannot bypass) | 9.6.3 |
 | Pre-execution policy constraint gates (deny rules, allow-lists, budgets) | 9.7.1 |
 | Scope-filtered MCP tool discovery (tools/list) | 10.2.6 |
 | Per-tool MCP invocation access control (argument, token scope) | 10.2.7 |
@@ -57,8 +56,7 @@ Enforce access decisions across users, agents, tools, data, and MCP resources us
 | KV-cache partitioning by session/tenant to prevent prompt reconstruction | 5.6.1 |
 | Shared model serving tenant isolation (fine-tuning, inference, embeddings) | 5.6.2 |
 | MCP tool namespace collision detection and trust-ranked shadowing prevention | 10.6.5 |
-| Peer authorization policy (approved agent registry) for agent-to-agent task delegation | 9.6.7 |
-| Dedicated scoped credentials per agent, not shared across swarm peers | 9.8.7 |
+| Peer authorization policy (approved agent registry) for agent-to-agent task delegation | 9.6.6 |
 
 **Common pitfalls:** granting broad OAuth scopes instead of minimal required; not re-evaluating authorization when context changes mid-session; allowing model-generated output to override hard policy decisions.
 
@@ -92,7 +90,6 @@ Protect data moving between services, agents, tools, and edge devices.
 | Control / Technique | Requirement IDs |
 | --- | --- |
 | Mutual TLS with certificate validation for inter-service communication | 4.3.4 |
-| Mutual TLS for agent-to-agent and agent-to-tool communication (TLS 1.3+) | 9.5.1 |
 | Authenticated streamable-HTTP transport with TLS 1.3 for MCP | 10.3.1, 10.3.2 |
 | SSE private channel with TLS enforcement | 10.3.3 |
 | Encrypted TEE communication channels | 4.5.9 |
@@ -140,15 +137,13 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 | Cryptographic signature validation for model publishers | 6.2.1, 6.2.2 |
 | Model watermarking and fingerprinting | 7.7.5, 11.5.4 |
 | Execution chain cryptographic signing with non-repudiation timestamps | 9.4.2 |
-| Message integrity with nonce / sequence / timestamp replay protection | 9.5.3 |
 | Cryptographic log signatures (write-only / append-only) | 13.1.6 |
-| Tamper-evident audit logs (WORM) | 9.4.3 |
 | MCP component signature and checksum verification | 10.1.1 |
 | MCP schema integrity signing and tool definition hash tracking | 10.4.2, 10.4.5 |
 | DAG cryptographic signatures and tamper-evident storage | 13.7.3 |
 | Publisher key pinning per source registry with rotation re-approval | 6.2.2 |
 | Document metadata tag immutability after initial ingestion write | 8.1.7 |
-| Agent persisted state integrity protection (MAC/signature, rejection on failure) | 9.4.6 |
+| Agent persisted state integrity protection (MAC/signature, rejection on failure) | 9.4.5 |
 
 **Common pitfalls:** using mutable `:latest` tags instead of immutable digests; not re-verifying tool definition hashes between MCP invocations; missing replay protection on agent messages.
 
@@ -226,10 +221,8 @@ Enforce consumption bounds to prevent abuse, runaway execution, and denial-of-se
 | Per-agent token, cost, and tool-call budgets | 9.1.1 |
 | Recursion depth and max concurrency / fan-out limits | 9.1.1 |
 | Wall-clock time and monetary spend caps | 9.1.1 |
-| Cumulative resource counters with hard-stop thresholds | 9.1.2 |
-| Circuit breaker enforcement | 9.1.3 |
-| Per-tool CPU, memory, disk, egress, and execution time limits | 9.3.2 |
-| Quota and timeout breach fail-closed termination | 9.3.7 |
+| Cumulative resource counters with hard-stop thresholds and circuit breaker enforcement | 9.1.2 |
+| Per-tool CPU, memory, disk, egress, and execution time limits with fail-closed termination on breach | 9.3.2 |
 | Sub-task delegation chain depth limit per execution | 7.4.4 |
 | Query-rate limiting for model extraction and inversion defense | 11.4.2, 11.5.1 |
 | MCP outbound execution limits, timeouts, recursion limits, and circuit breakers | 10.5.2 |
@@ -254,7 +247,7 @@ Isolate workloads, tools, models, and agents to contain failures and prevent lat
 | TEE / confidential computing with remote attestation | 4.1.5, 4.5.4, 4.5.6, 4.5.8 |
 | Untrusted AI model sandboxing with network isolation | 4.5.1, 4.5.2 |
 | Tool and plugin sandboxing (container, VM, WASM, OS sandbox) | 9.3.1 |
-| Sandbox escape detection with automated tool quarantine | 9.3.6 |
+| Sandbox escape detection with automated tool quarantine | 9.3.5 |
 | Agent isolation across tenants, security domains, and environments | 9.8.1 |
 | GPU memory isolation (MIG / VM partitioning) with peer-to-peer prevention | 4.7.5 |
 | On-device process, memory, and file access isolation | 4.8.7 |
@@ -422,8 +415,7 @@ Capture security-relevant events with integrity protection for forensic analysis
 | PII, credential, and proprietary information redaction in logs | 13.1.4 |
 | Policy decision and safety filtering action logging | 13.1.5 |
 | Cryptographic log signatures with write-only storage | 13.1.6 |
-| Tamper-evident audit log storage (append-only, WORM, hash chaining) | 9.4.3 |
-| Audit log context fields sufficient for forensic reconstruction (actor, delegation, policy, parameters, outcomes) | 9.4.5 |
+| Audit log context fields sufficient for forensic reconstruction (actor, delegation, policy, parameters, outcomes) | 9.4.3 |
 | Agent action signing with chain ID binding and timestamps | 9.4.2 |
 | Immutable audit records for model changes (actor, change type, before/after) | 3.2.5 |
 | Immutable deletion logging for regulatory audit trails | 12.2.4 |
@@ -458,7 +450,7 @@ Detect anomalies, alert on threats, and respond to security incidents in AI syst
 | Data drift and concept drift detection | 13.6.2, 13.6.3 |
 | Model extraction alert generation with query metadata logging | 11.5.2 |
 | Model extraction alert IR playbook integration | 11.5.6 |
-| Emergent multi-agent behavior detection (oscillation, deadlock, broadcast storms) | 9.8.2 |
+| Emergent multi-agent behavior detection (oscillation, deadlock, broadcast storms) | 9.8.4 |
 | AI-specific incident response plans (model compromise, data poisoning, adversarial attack) | 13.5.1 |
 | AI-specific forensic tools for model behavior investigation | 13.5.2 |
 | Safety violation rate alerting | 7.6.2 |
@@ -502,7 +494,7 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 | --- | --- |
 | High-impact action approval gates (deploy, delete, financial, notify) | 9.2.1 |
 | Approval parameter binding (prevent approve-one-execute-another) | 9.2.2 |
-| High-impact intent confirmation with exact parameter binding and quick expiration | 9.7.2 |
+| High-impact intent confirmation with exact parameter binding and quick expiration | 9.2.3 |
 | High-risk MCP action confirmation (data deletion, financial, system config) | 10.5.3 |
 | Human approval for high-risk content generation | 7.3.5 |
 | Human review on uncertainty threshold breach | 14.6.2 |
@@ -510,8 +502,8 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 | Enhanced monitoring and human intervention on security warnings | 11.8.3 |
 | Security-critical proactive action approval with approval chain logging | 13.8.4 |
 | High-risk model quarantine with human review and sign-off | 6.1.3 |
-| Post-condition outcome checking with containment on mismatch | 9.7.3 |
-| Compensating actions and transactional rollback on failure | 9.2.3 |
+| Post-condition outcome checking with containment on mismatch | 9.7.2 |
+| Compensating actions and transactional rollback on failure | 9.2.4 |
 | Intermediate operational degradation states (tool disable, model swap, read-only, source removal) | 14.1.5 |
 
 **Common pitfalls:** not binding approval to exact parameters allowing bait-and-switch; confirmation tokens without quick expiration; missing post-condition checks after approved actions execute.


### PR DESCRIPTION
# Reduction pass C09

Reduces C09 from 41 requirements to 28 by removing requirements that are generic application security concerns already covered by ASVS v5 (V2, V4, V8, V11, V12, V13, V15, V16) or duplicated within AISVS (C13.1.6 log integrity, C4 sandbox/supply chain). Consolidates closely related requirements that are testable as a single check. Replaces the previous per-section scope notes with a consolidated ASVS-and-cross-chapter boundary statement in the Control Objective. 

Renumbers IDs sequentially within each section. Updates cross-references in C05 and Appendix D.

## Changes by section

### C9.1 Execution Budgets, Loop Control, and Circuit Breakers (5 -> 3)

- **Merge 9.1.2 + 9.1.3** into new 9.1.2: Both require hard-stop on budget threshold. 9.1.2 said "hard-stop the chain when thresholds are exceeded"; 9.1.3 said "circuit breakers terminate execution on budget violations." Same testable behavior. Combined into one requirement covering counters, threshold, and circuit-breaker termination.
- **Remove 9.1.5** (policy-as-code in CI/CD): Generic DevSecOps pattern. Policy validation in CI is covered by ASVS V13.1 (configuration documentation) and V15 (secure coding/architecture). Not AI-specific.

### C9.2 High-Impact Action Approval and Irreversibility Controls (6 -> 4)

- **Merge 9.2.3 + 9.2.4 + 9.2.5** into new 9.2.3: All three describe properties of the same approval token (cryptographic binding, single-use nonce, TTL expiration). Testable as a single check on the approval mechanism.

### C9.3 Tool and Plugin Isolation and Safe Integration (7 -> 5)

- **Merge 9.3.2 + 9.3.7** into new 9.3.2: 9.3.2 required quotas/timeouts enforced and logged; 9.3.7 required fail-closed on breach. Combined into single requirement covering enforcement, logging, and fail-closed semantics.
- **Remove 9.3.4** (tool binary/package integrity verification via signatures and checksums): Generic supply chain. Covered by ASVS V13.3.1 (signed artifacts), V15.1.2 (SBOM), V15.2.1 (verified components), and OWASP SCVS. C6 explicitly defers this to ASVS/SCVS for the same reason.

### C9.4 Agent and Orchestrator Identity, Signing, and Tamper-Evident Audit (6 -> 5)

- **Remove 9.4.3** (audit logs tamper-evident via WORM/hash chaining): Duplicated by ASVS V16.4.2 ("logs are protected from unauthorized access and cannot be modified") and AISVS C13.1.6 ("log integrity is protected through cryptographic signatures or write-only storage"). The AI-specific aspect (chain hashing for agent action sequences) is already in 9.4.2.

### C9.5 Inter-Agent Output Validation (4 -> 1, section refocused)

Section refocused from "Secure Messaging and Protocol Hardening" to "Inter-Agent Output Validation" since the only remaining requirement addresses semantic validation of LLM-generated outputs flowing into downstream agents.

- **Remove 9.5.1** (mutual auth + TLS 1.3 for agent channels): Generic transport security. Fully covered by ASVS V12.3.1 (inbound/outbound TLS), V12.3.5 (mutual auth for intra-service comms). The agent-to-agent framing is just service-to-service communication.
- **Remove 9.5.2** (schema validation, reject malformed): Generic input validation. Covered by ASVS V2.2.1, V4.1, and V4.2. Applies equally to non-AI services.
- **Remove 9.5.3** (message integrity, replay protection with nonces/timestamps): Generic. Covered by ASVS V11 (cryptography), V4.1.5 (per-message signatures), V12.3 (TLS providing integrity). Replay protection is a generic security pattern not unique to AI.

### C9.6 Authorization, Delegation, and Continuous Enforcement (7 -> 6)

- **Remove 9.6.3** (continuous authorization re-evaluation per call): Generic Zero Trust / ABAC pattern. Covered by ASVS V8.3.2 (immediate application of authorization changes) and V8.2.4 (adaptive controls during session). The agent-loop case adds nothing the generic pattern does not already require.

### C9.7 Intent Verification and Constraint Gates (7 -> 5)

- **Merge 9.7.2 + 9.7.3 + 9.7.4** into new 9.7.2: All three are aspects of post-execution verification (confirm intended outcome, detect side effects, trigger containment on mismatch). Testable together as a single post-condition check workflow.

### C9.8 Multi-Agent Domain Isolation and Swarm Risk Controls (8 -> 6)

- **Remove 9.8.7** (dedicated credentials per agent in swarm, not shared with peers): Covered by ASVS V13.2.1 (individual service accounts for backend components) and V13.2.2 (least privilege). The swarm framing does not change what the requirement asks.
- **Remove 9.8.8** (atomic auth + state mutation, TOCTOU): Fully covered by ASVS V15.4.2 ("checks on a resource's state and the actions that depend on them are performed as a single atomic operation to prevent TOCTOU race conditions"). Same exact pattern. Not AI-specific.

## Scope-note consolidation

The previous per-section scope notes (in C9.1, C9.2, and the new ones added during the reduction) are removed and replaced with a consolidated boundary statement in the Control Objective. The combined statement covers:

- ASVS v5 areas covered elsewhere (V2, V4, V8, V11, V12, V13, V15, V16) and AISVS C13.1.6 / OWASP SCVS for log integrity and supply chain.
- The C9.1 vs ASVS V2.4 vs C11.4/C11.5 distinction (orchestration runtime budgets vs API-edge throttling vs anti-extraction throttling).
- The C9.2 vs C14.2 vs C13.7.4 separation (runtime gate vs oversight policy vs approval logging).
- The C9.5 vs ASVS V4/V11/V12 vs C10.4 split (semantic validation vs transport/schema/replay vs MCP-specific message controls).

## Change counts

- Requirements: 41 -> 28 (32% reduction)
- Section count: 8 -> 8 (C9.5 refocused, no sections removed)
- Per-section scope notes replaced by a consolidated boundary statement in the Control Objective.
