### PR TITLE
Reduction pass C11

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -4,7 +4,7 @@
 
 Ensure that AI systems remain reliable, privacy-preserving, and abuse-resistant when facing evasion, inference, extraction, or poisoning attacks. These controls cover model alignment testing, adversarial hardening, privacy attack resistance, model theft deterrence, and security adaptation for autonomous agents.
 
-Generic application security controls (configuration management, secret and key management, signed artifacts, audit logging, change control, transport security, generic anti-automation rate limiting) are covered by ASVS v5 (V11, V13, V14, V15, V16) and are not repeated here. Logging of AI security events, AI incident response planning, and human-oversight escalation are covered by AISVS C13 and C14. Inversion-specific (C11.4) and extraction-specific (C11.5) throttling controls do not substitute for generic API rate limiting (ASVS v5 V2.4) or orchestration runtime budgets (C9.1). C11.7 is scoped to protecting the security review mechanism itself from adversarial bypass; the runtime gate that blocks high-impact agent actions is defined in C9.2 and C9.7.
+Generic application security controls (configuration management, secret and key management, signed artifacts, audit logging, change control, transport security, generic anti-automation rate limiting) are covered by ASVS v5 (V11, V13, V14, V15, V16) and are not repeated here. Logging of AI security events, AI incident response planning, and human-oversight escalation are covered by AISVS C13 and C14. Inversion-specific (C11.4) and extraction-specific (C11.5) throttling controls do not substitute for generic API rate limiting (ASVS v5 V2.4) or orchestration runtime budgets (C9.1). C11.8 (agent self-review) covers AI-augmented review of proposed agent actions and protection of that review mechanism from prompt-injection bypass; the deterministic runtime gate that blocks high-impact agent actions is governed by C9.2 and C9.7.
 
 ---
 
@@ -65,7 +65,7 @@ Detect and deter unauthorized model cloning through API abuse. Rate limiting, qu
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **11.5.1** | **Verify that** inference endpoints enforce per-principal and global rate limits sized to the extraction threat model (e.g., the number of queries required to approximate the model), and not solely as a generic API throttle. | 1 |
+| **11.5.1** | **Verify that** inference endpoints enforce per-principal and global rate limits sized to the extraction threat model, and not solely as a generic API throttle. | 1 |
 | **11.5.2** | **Verify that** extraction-alert events include offending query metadata (e.g., source principal, query volume, input distribution statistics) to support investigation. | 2 |
 | **11.5.3** | **Verify that** query-pattern analysis (e.g., query diversity, input distribution anomalies) feeds an automated extraction-attempt detector. | 2 |
 | **11.5.4** | **Verify that** model watermarking or fingerprinting techniques are applied so that unauthorized copies can be identified. | 3 |
@@ -88,11 +88,14 @@ Identify and neutralize backdoored or poisoned inputs at inference time, particu
 
 ## C11.7 Security Policy Adaptation
 
-Maintain the ability to update AI safety and guardrail policies rapidly in response to evolving jailbreak techniques and adversarial campaigns.
+Maintain the ability to update AI safety and guardrail policies rapidly in response to threat intelligence and behavioral analysis.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **11.7.1** | **Verify that** AI safety and guardrail policies (e.g., content filters, refusal categories, prompt-injection signatures, rate-limit thresholds applied to model endpoints) can be updated and propagated to running inference services without full system redeployment, and that the active policy version is recorded with each inference decision. | 2 |
+| **11.7.1** | **Verify that** security policies (e.g., content filters, rate-limit thresholds, guardrail configurations) can be updated without full system redeployment, and that policy versions are tracked. | 1 |
+| **11.7.2** | **Verify that** policy updates are authorized, integrity-protected (e.g., cryptographically signed), and validated before application. | 2 |
+| **11.7.3** | **Verify that** rollback procedures exist for policy changes and are tested to confirm they restore the previous policy state. | 2 |
+| **11.7.4** | **Verify that** threat-detection sensitivity can be adjusted based on risk context (e.g., elevated threat level, incident response) with appropriate authorization. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -4,6 +4,8 @@
 
 Ensure that AI systems remain reliable, privacy-preserving, and abuse-resistant when facing evasion, inference, extraction, or poisoning attacks. These controls cover model alignment testing, adversarial hardening, privacy attack resistance, model theft deterrence, and security adaptation for autonomous agents.
 
+Generic application security controls (configuration management, secret and key management, signed artifacts, audit logging, change control, transport security, generic anti-automation rate limiting) are covered by ASVS v5 (V11, V13, V14, V15, V16) and are not repeated here. Logging of AI security events, AI incident response planning, and human-oversight escalation are covered by AISVS C13 and C14. Inversion-specific (C11.4) and extraction-specific (C11.5) throttling controls do not substitute for generic API rate limiting (ASVS v5 V2.4) or orchestration runtime budgets (C9.1). C11.7 is scoped to protecting the security review mechanism itself from adversarial bypass; the runtime gate that blocks high-impact agent actions is defined in C9.2 and C9.7.
+
 ---
 
 ## C11.1 Model Alignment & Safety
@@ -50,13 +52,10 @@ Limit the ability to determine whether a specific record was in the training dat
 
 Prevent reconstruction of private training data or sensitive attributes from model outputs.
 
-> **Scope note:** Rate limiting in C11.4 is scoped specifically to inversion attack resistance: throttling repeated adaptive queries from the same principal to raise the cost of reconstructing training data or sensitive attributes. It is not a substitute for generic API rate limiting (see ASVS v5 V2.4) or orchestration execution budgets (C9.1). Generic abuse prevention cannot double-count as inversion resistance.
-
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **11.4.1** | **Verify that** sensitive attributes are never directly output; where needed, outputs use generalized categories (e.g., ranges, buckets) or one-way transforms. | 1 |
-| **11.4.2** | **Verify that** query-rate limits throttle repeated adaptive queries from the same principal to raise the cost of inversion attacks. | 1 |
-| **11.4.3** | **Verify that** models handling sensitive data are trained with privacy-preserving techniques (e.g., differential privacy, gradient clipping) to limit information leakage through outputs. | 2 |
+| **11.4.1** | **Verify that** model-inferred sensitive attributes are not directly returned in outputs; where such attributes must be exposed, they are returned as generalized categories (e.g., ranges, buckets) or one-way transforms to limit reconstruction of underlying training records. | 1 |
+| **11.4.2** | **Verify that** query-rate limits throttle repeated adaptive queries from the same principal at thresholds calibrated to the inversion threat model (e.g., the number of queries required to reconstruct training data or sensitive attributes), and not solely as a generic anti-automation control. | 1 |
 
 ---
 
@@ -64,16 +63,12 @@ Prevent reconstruction of private training data or sensitive attributes from mod
 
 Detect and deter unauthorized model cloning through API abuse. Rate limiting, query-pattern analysis, and watermarking are recommended defenses.
 
-> **Scope note:** Rate limits in C11.5 are calibrated specifically to make large-scale query harvesting for model cloning impractical -- they are not general-purpose API throttles (see ASVS v5 V2.4). Satisfying C11.5.1 requires demonstrating that limits are sized to the extraction threat model (e.g., number of queries required to approximate the model), not merely that any rate limit is present.
-
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **11.5.1** | **Verify that** inference endpoints enforce per-principal and global rate limits designed to make large-scale query harvesting impractical. | 1 |
+| **11.5.1** | **Verify that** inference endpoints enforce per-principal and global rate limits sized to the extraction threat model (e.g., the number of queries required to approximate the model), and not solely as a generic API throttle. | 1 |
 | **11.5.2** | **Verify that** extraction-alert events include offending query metadata (e.g., source principal, query volume, input distribution statistics) to support investigation. | 2 |
-| **11.5.6** | **Verify that** extraction-alert events are integrated with incident-response playbooks that define escalation and remediation steps. | 2 |
 | **11.5.3** | **Verify that** query-pattern analysis (e.g., query diversity, input distribution anomalies) feeds an automated extraction-attempt detector. | 2 |
 | **11.5.4** | **Verify that** model watermarking or fingerprinting techniques are applied so that unauthorized copies can be identified. | 3 |
-| **11.5.5** | **Verify that** watermark verification keys and trigger sets are protected with access controls equivalent to other critical cryptographic material. | 3 |
 
 ---
 
@@ -93,27 +88,22 @@ Identify and neutralize backdoored or poisoned inputs at inference time, particu
 
 ## C11.7 Security Policy Adaptation
 
-Real-time security policy updates based on threat intelligence and behavioral analysis.
+Maintain the ability to update AI safety and guardrail policies rapidly in response to evolving jailbreak techniques and adversarial campaigns.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **11.7.1** | **Verify that** security policies (e.g., content filters, rate-limit thresholds, guardrail configurations) can be updated without full system redeployment, and that policy versions are tracked. | 1 |
-| **11.7.2** | **Verify that** policy updates are authorized, integrity-protected (e.g., cryptographically signed), and validated before application. | 2 |
-| **11.7.3** | **Verify that** policy changes are logged with audit trails including timestamp, author, and justification. | 2 |
-| **11.7.5** | **Verify that** rollback procedures exist for policy changes and are tested to confirm they restore the previous policy state. | 2 |
-| **11.7.4** | **Verify that** threat-detection sensitivity can be adjusted based on risk context (e.g., elevated threat level, incident response) with appropriate authorization. | 3 |
+| **11.7.1** | **Verify that** AI safety and guardrail policies (e.g., content filters, refusal categories, prompt-injection signatures, rate-limit thresholds applied to model endpoints) can be updated and propagated to running inference services without full system redeployment, and that the active policy version is recorded with each inference decision. | 2 |
 
 ---
 
 ## C11.8 Agent Security Self-Assessment
 
-For agentic AI systems, validate that the agent's reasoning and actions are subject to security-focused review mechanisms.
+For agentic AI systems, supplement deterministic policy gates (C9.2, C9.7) with AI-augmented review of proposed actions, and protect that review mechanism from adversarial bypass.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **11.8.1** | **Verify that** agentic systems include a mechanism to review planned high-risk actions against security policy before execution (e.g., a secondary model, rule-based checker, or structured self-review step). | 2 |
-| **11.8.2** | **Verify that** security review mechanisms are protected against manipulation by adversarial inputs (e.g., the review step cannot be overridden or bypassed through prompt injection). | 2 |
-| **11.8.3** | **Verify that** security review warnings trigger enhanced monitoring or human intervention workflows for the affected session or task. | 3 |
+| **11.8.1** | **Verify that** agentic systems include an AI-augmented review of planned high-risk actions before execution (e.g., a secondary model, structured self-review step, or ensemble-of-judges check) that operates in addition to and not in place of the deterministic policy gate in C9.7.1. | 2 |
+| **11.8.2** | **Verify that** the AI-augmented review mechanism in 11.8.1 is protected against manipulation by adversarial inputs, so that the review step cannot be overridden or bypassed through prompt injection or instruction smuggling in agent context. | 2 |
 
 ---
 
@@ -125,10 +115,10 @@ Security controls for systems where the AI can modify its own configuration, pro
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.9.1** | **Verify that** any self-modification capability (e.g., prompt rewriting, tool-list changes, parameter updates) is restricted to explicitly designated areas with enforced boundaries. | 2 |
 | **11.9.2** | **Verify that** proposed self-modifications undergo security impact assessment or policy validation before taking effect. | 2 |
-| **11.9.3** | **Verify that** all self-modifications are logged with sufficient detail to reconstruct what changed, when, and under what authorization. | 2 |
-| **11.9.6** | **Verify that** self-modifications are reversible and subject to integrity verification, so that rollback to a known-good state is possible and can be confirmed. | 2 |
-| **11.9.4** | **Verify that** self-modification scope is bounded (e.g., maximum change magnitude, rate limits on updates, prohibited modification targets) to prevent runaway or adversarially induced changes. | 3 |
-| **11.9.5** | **Verify that** when safety violation data (blocked inputs, filtered outputs, flagged hallucinations) is used as training signal for model improvement, the feedback pipeline includes integrity verification, poisoning detection, and human review gates to prevent adversarial manipulation of the improvement mechanism. | 3 |
+| **11.9.3** | **Verify that** self-modifications are explicitly classified as security-relevant events and logged with sufficient detail to reconstruct what changed, when, by which agent or principal, and under what authorization, regardless of whether self-modification is otherwise documented as a logged event. | 2 |
+| **11.9.4** | **Verify that** self-modifications are reversible and subject to integrity verification, so that rollback to a known-good state is possible and can be confirmed. | 2 |
+| **11.9.5** | **Verify that** self-modification scope is bounded (e.g., maximum change magnitude, rate limits on updates, prohibited modification targets) to prevent runaway or adversarially induced changes. | 3 |
+| **11.9.6** | **Verify that** when safety violation data (blocked inputs, filtered outputs, flagged hallucinations) is used as training signal for model improvement, the feedback pipeline includes integrity verification, poisoning detection, and human review gates to prevent adversarial manipulation of the improvement mechanism. | 3 |
 
 ## C11.10 Adversarial Bias Exploitation Defense
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -114,7 +114,6 @@ Manage cryptographic keys, secrets, and credentials throughout their lifecycle.
 | Automated key and secret rotation | 4.4.5 |
 | Agent identity credential rotation with rapid revocation | 9.4.4 |
 | MCP runtime credential injection (no plaintext secrets) | 10.1.2 |
-| Watermark verification key and trigger set protection | 11.5.5 |
 | Separate backup credentials from production | 4.6.3 |
 | User-space key inaccessibility on mobile | 4.8.8 |
 
@@ -205,6 +204,7 @@ Constrain, filter, and validate model outputs before they reach users or downstr
 | MCP error response sanitization (no stack traces, tokens, internal paths) | 10.4.6 |
 | Statistical steganographic covert channel detection in generated outputs | 7.3.9 |
 | RAG attribution derived from retrieval metadata, not model-generated | 7.8.3 |
+| Generalization or one-way transformation of model-inferred sensitive attributes (ranges, buckets) to limit reconstruction of training records | 11.4.1 |
 
 **Common pitfalls:** redacting PII in text but not in structured data fields; not enforcing stop sequences on streaming outputs; leaking internal architecture through error messages.
 
@@ -391,9 +391,11 @@ Test for and defend against evasion, extraction, inversion, poisoning, and align
 | Model extraction detection (query-pattern analysis, diversity measurement) | 11.5.3 |
 | Statistical outlier and consistency scoring on external inputs | 11.6.1 |
 | Adaptive attack evasion testing | 11.6.4 |
-| Security-focused secondary review mechanisms (second model, rule-based) | 11.8.1 |
-| Self-modification restriction with scope bounds and rate limits | 11.9.1, 11.9.4 |
-| Self-modification reversibility and integrity verification enabling rollback to known-good state | 11.9.6 |
+| AI-augmented review of high-risk agent actions (secondary model, structured self-review, ensemble-of-judges) supplementing the deterministic policy gate (C9.7.1) | 11.8.1 |
+| AI-augmented review mechanism protected against prompt-injection bypass | 11.8.2 |
+| Self-modification restriction with scope bounds and rate limits | 11.9.1, 11.9.5 |
+| Self-modification reversibility and integrity verification enabling rollback to known-good state | 11.9.4 |
+| Safety-violation feedback pipeline integrity, poisoning detection, and human review gates | 11.9.6 |
 | Data augmentation with perturbed inputs for training robustness | 1.4.4 |
 | RONI (Reject On Negative Influence) filtering -- influence-score each training sample and reject those that degrade held-out performance beyond a threshold (implementation example for 1.4.2) | 1.4.2 |
 | Gradient fingerprinting / per-sample gradient analysis — detect abnormal gradient norms or directions indicating poisoned samples during training (implementation example for 1.4.2) | 1.4.2 |
@@ -423,9 +425,7 @@ Capture security-relevant events with integrity protection for forensic analysis
 | Detection rules for anomalous package pulls and tampered build steps | ASVS v5 V16.3.3 |
 | DAG visualization with access controls and tamper evidence | 13.7.1, 13.7.2, 13.7.3 |
 | Safety violation metrics logging | 7.6.1 |
-| MCP policy change audit logging (timestamp, author, justification) | 11.7.3 |
-| Policy change rollback procedures and testing | 11.7.5 |
-| Self-modification detailed logging (what changed, when, under what authorization) | 11.9.3 |
+| Self-modification logging classified as security event with what/when/by-whom/authorization detail | 11.9.3 |
 
 **Common pitfalls:** logging prompts without redacting PII; using mutable log storage without integrity protection; not including sufficient context for forensic reconstruction.
 
@@ -449,7 +449,6 @@ Detect anomalies, alert on threats, and respond to security incidents in AI syst
 | Hallucination rate time-series tracking | 13.3.11 |
 | Data drift and concept drift detection | 13.6.2, 13.6.3 |
 | Model extraction alert generation with query metadata logging | 11.5.2 |
-| Model extraction alert IR playbook integration | 11.5.6 |
 | Emergent multi-agent behavior detection (oscillation, deadlock, broadcast storms) | 9.8.4 |
 | AI-specific incident response plans (model compromise, data poisoning, adversarial attack) | 13.5.1 |
 | AI-specific forensic tools for model behavior investigation | 13.5.2 |
@@ -499,7 +498,6 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 | Human approval for high-risk content generation | 7.3.5 |
 | Human review on uncertainty threshold breach | 14.6.2 |
 | Human review on anomaly detection | 11.6.3 |
-| Enhanced monitoring and human intervention on security warnings | 11.8.3 |
 | Security-critical proactive action approval with approval chain logging | 13.8.4 |
 | High-risk model quarantine with human review and sign-off | 6.1.3 |
 | Post-condition outcome checking with containment on mismatch | 9.7.2 |

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -224,7 +224,7 @@ Enforce consumption bounds to prevent abuse, runaway execution, and denial-of-se
 | Cumulative resource counters with hard-stop thresholds and circuit breaker enforcement | 9.1.2 |
 | Per-tool CPU, memory, disk, egress, and execution time limits with fail-closed termination on breach | 9.3.2 |
 | Sub-task delegation chain depth limit per execution | 7.4.4 |
-| Query-rate limiting for model extraction and inversion defense | 11.4.2, 11.5.1 |
+| Query-rate limiting for model extraction and inversion defense, sized to the threat model (e.g., the number of queries required to approximate the model or to reconstruct training records) rather than as a generic API throttle | 11.4.2, 11.5.1 |
 | MCP outbound execution limits, timeouts, recursion limits, and circuit breakers | 10.5.2 |
 | Anomalous usage pattern detection and blocking | 13.2.4, ASVS v5 V2.4 |
 | Resource quotas (CPU, memory, GPU) for infrastructure | 4.6.1 |
@@ -454,6 +454,7 @@ Detect anomalies, alert on threats, and respond to security incidents in AI syst
 | AI-specific forensic tools for model behavior investigation | 13.5.2 |
 | Safety violation rate alerting | 7.6.2 |
 | Real-time security policy updates without full redeployment | 11.7.1 |
+| Policy change rollback procedures and testing | 11.7.3 |
 | Accelerator telemetry and side-channel anomaly detection | 4.7.8 |
 | Proactive agent behavior validation with risk assessment | 13.8.1, 13.8.2 |
 


### PR DESCRIPTION
Reduces C11 from 44 requirements to 39 by removing requirements that are clearly duplicated by ASVS v5 (V11, V13) or by other AISVS chapters (C13.5.1). Tightens wording on several remaining requirements to make their AI-specific scope explicit, so they cannot be confused with generic ASVS controls.

Replaces the per-section scope notes in C11.4 and C11.5 with a consolidated boundary statement in the Control Objective.

Section structure is preserved (10 sections, no renumbering of sections). Requirement IDs within C11.7 and C11.9 are renumbered sequentially after deletions.

## Changes by section

### C11.1 Model Alignment & Safety (5 -> 5)

No changes. All five requirements are AI-specific and not duplicated by ASVS or other AISVS chapters.

### C11.2 Adversarial-Example Hardening (5 -> 5)

No changes. All five requirements are AI-specific.

### C11.3 Membership-Inference Mitigation (3 -> 3)

No changes. All three requirements are AI-specific.

### C11.4 Model-Inversion Resistance (3 -> 2)

Two requirements retained, wording tightened on both to make AI-specific scope explicit. Per-section scope note removed (consolidated into Control Objective).

- **Tighten 11.4.1**: Original "sensitive attributes are never directly output; where needed, outputs use generalized categories" reads as generic data minimization (overlaps ASVS V14.2.6). Reworded to "model-inferred sensitive attributes are not directly returned in outputs ... to limit reconstruction of underlying training records" so it is clearly about ML-inferred attributes (the inversion attack surface), not about returned database fields.
- **Tighten 11.4.2**: Original "throttle repeated adaptive queries from the same principal to raise the cost of inversion attacks" did not differentiate from generic anti-automation rate limits (ASVS V2.4). Reworded to require thresholds calibrated to the inversion threat model.
- **Remove 11.4.3** (privacy-preserving training with DP/gradient clipping): Direct content duplicate of 11.3.2 (DP-SGD with documented epsilon). Both require differentially-private training on sensitive data; testable as one check.

### C11.5 Model-Extraction Defense (6 -> 4)

Tightening on 11.5.1 (calibration to extraction threat model made explicit, replacing the per-section scope note). Two removals.

- **Tighten 11.5.1**: Inline the calibration-to-threat-model requirement that was previously in the scope note, so the requirement text itself prevents satisfying it with any generic API throttle. Threat-model sizing example moved to Appendix D AD.9 to keep the requirement text concise.
- **Remove 11.5.5** (watermark verification keys protected with access controls equivalent to other critical cryptographic material): Generic cryptographic key protection. ASVS v5 V13.3.1 explicitly enumerates "key material, ... seeds for time-based tokens, other internal secrets" as in scope for vault management; V11.1.1 covers key management policy. The "watermark key" framing does not change what the requirement asks.
- **Remove 11.5.6** (extraction alerts integrated with IR playbooks): Direct duplicate of AISVS C13.5.1, which explicitly enumerates "model extraction" with required containment and investigation steps.

### C11.6 Inference-Time Poisoned-Data Detection (5 -> 5)

No changes.

### C11.7 Security Policy Adaptation (5 -> 4)

Section description broadened to "threat intelligence and behavioral analysis" so as not to exclude attacks unrelated to jailbreaks. One requirement removed (audit log) and IDs renumbered sequentially.

- **Remove 11.7.3** (policy changes logged with timestamp, author, justification): Generic audit logging of administrative changes, the least AI-specific of the section. Covered by ASVS v5 V16.2.1 (log entries include when/where/who/what) and V16.3.3.
- **Renumber within section** (no semantic changes):
  - 11.7.1 (hot-reload of policies) -> 11.7.1
  - 11.7.2 (signed/validated policy updates) -> 11.7.2
  - 11.7.5 (rollback procedures tested) -> 11.7.3
  - 11.7.4 (sensitivity adjustable based on risk context) -> 11.7.4

### C11.8 Agent Security Self-Assessment (3 -> 2)

Two requirements retained with tightened wording to clarify the AI-specific complement to C9. One removal.

- **Keep and tighten 11.8.1** (review of high-risk actions before execution): Reworded to specify "AI-augmented review" (secondary model, structured self-review, ensemble-of-judges) and to state explicitly that this operates in addition to and not in place of the deterministic policy gate in C9.7.1. Without this tightening, 11.8.1 looked like a duplicate of C9.7.1; the AI-augmented framing makes them complementary.
- **Keep 11.8.2** (review mechanism protected from prompt-injection bypass): No content change. Reworded slightly to refer back to 11.8.1 by ID for clarity.
- **Remove 11.8.3** (security review warnings trigger enhanced monitoring or human intervention): Duplicates C13.2.5 (real-time alerting on policy violations / attack attempts) and C14 (Human Oversight) escalation patterns. Generic incident workflow.

### C11.9 Self-Modification & Autonomous Update Security (6 -> 6)

Section retained in full. IDs renumbered to be sequential (the original order had 11.9.6 between 11.9.3 and 11.9.4). One requirement (11.9.3 self-modification logging) tightened to make it explicitly AI-agent-scoped.

- **Tighten 11.9.3** (self-modification logging): Generic logging requirements (ASVS V16.3.3) only require logging events that an organization has documented as security-relevant. Self-modification by an AI agent is unusual enough that an organization following V16.3.3 alone could comply by simply not classifying it as a security event. Reworded to make explicit that self-modifications must be classified as security-relevant events and logged with what/when/by-whom/authorization detail, regardless of whether self-modification is otherwise documented as a logged event.

### C11.10 Adversarial Bias Exploitation Defense (3 -> 3)

No changes.

## Net change

- Requirements: 44 -> 39 (11% reduction)
