### PR TITLE
Reduction pass C12

### DIFF
--- a/1.0/en/0x10-C12-Privacy.md
+++ b/1.0/en/0x10-C12-Privacy.md
@@ -2,7 +2,9 @@
 
 ## Control Objective
 
-Maintain rigorous privacy assurances across the entire AI lifecycle (collection, training, inference, and incident response) so that personal data is only processed with clear consent, minimum necessary scope, provable erasure, and formal privacy guarantees.
+Maintain rigorous privacy assurances across the entire AI lifecycle (collection, training, inference, and incident response) so that personal data is only processed with clear consent, minimum necessary scope, provable erasure, and formal privacy guarantees. This chapter focuses on AI-specific privacy concerns: privacy properties of training data and derived model artifacts, deletion and unlearning across ML artifacts, differential privacy budget management for training, purpose binding for datasets and models, consent-aware inference gating, and federated-learning privacy controls.
+
+Generic data protection controls (sensitive data classification, encryption at rest and in transit, retention scheduling, secure deletion of conventional storage, audit log immutability, and the existence and operation of a Consent Management Platform or equivalent record of opt-in, purpose, and retention metadata) are covered by ASVS v5 V14 and V16 and are not repeated here.
 
 ---
 
@@ -12,8 +14,8 @@ Remove or transform personal identifiers before training to prevent re-identific
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.1.1** | **Verify that** direct and quasi-identifiers are removed, hashed. | 1 |
-| **12.1.2** | **Verify that** automated audits measure k-anonymity/l-diversity and alert when thresholds drop below policy. | 2 |
+| **12.1.1** | **Verify that** direct and quasi-identifiers in training and fine-tuning datasets are removed, hashed, or generalized before the data is used to fit or update a model. | 1 |
+| **12.1.2** | **Verify that** automated audits measure k-anonymity or l-diversity on training datasets and alert when thresholds drop below policy. | 2 |
 | **12.1.3** | **Verify that** model feature-importance reports prove no identifier leakage beyond ε = 0.01 mutual information. | 2 |
 | **12.1.4** | **Verify that** formal proofs or synthetic-data certification show re-identification risk ≤ 0.05 even under linkage attacks. | 3 |
 
@@ -25,10 +27,9 @@ Ensure data-subject deletion requests propagate across all AI artifacts and that
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.2.1** | **Verify that** data-subject deletion requests propagate to raw datasets, checkpoints, embeddings, logs, and backups within service level agreements of less than 30 days. | 1 |
+| **12.2.1** | **Verify that** data-subject deletion requests propagate to AI-derived artifacts including training and fine-tuning datasets, model checkpoints, evaluation sets, derived caches, and feature stores within a service level agreement of less than 30 days. Embedding and RAG index propagation is governed by C8.3. | 1 |
 | **12.2.2** | **Verify that** "machine-unlearning" routines physically re-train or approximate removal using certified unlearning algorithms. | 2 |
 | **12.2.3** | **Verify that** shadow-model evaluation proves forgotten records influence less than 1% of outputs after unlearning. | 2 |
-| **12.2.4** | **Verify that** deletion events are immutably logged and auditable for regulators. | 3 |
 
 ---
 
@@ -38,11 +39,9 @@ Track and enforce privacy budgets to provide formal guarantees against individua
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.3.1** | **Verify that** differential privacy budget consumption (both ε and δ values) is tracked and recorded per training round. | 2 |
-| **12.3.5** | **Verify that** cumulative differential privacy budget dashboards alert when ε exceeds defined policy thresholds. | 2 |
+| **12.3.1** | **Verify that** differential privacy budget consumption (both ε and δ values) is tracked and recorded per training round, and that cumulative consumption triggers an alert when ε exceeds defined policy thresholds. | 2 |
 | **12.3.2** | **Verify that** black-box privacy audits estimate ε̂ within 10% of declared value. | 2 |
 | **12.3.3** | **Verify that** formal proofs cover all post-training fine-tunes and embeddings. | 3 |
-| **12.3.4** | **Verify that** federated learning systems implement canary-based privacy auditing to empirically bound privacy leakage, with audit results logged and reviewed per training cycle. | 3 |
 
 ---
 
@@ -53,8 +52,7 @@ Prevent models and datasets from being used beyond their originally consented pu
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.4.1** | **Verify that** every dataset and model checkpoint carries a machine-readable purpose tag aligned to the original consent. | 1 |
-| **12.4.2** | **Verify that** runtime monitors detect queries inconsistent with the declared purpose of the dataset or model. | 1 |
-| **12.4.5** | **Verify that** queries detected as inconsistent with declared purpose trigger a soft refusal or are blocked pending review. | 1 |
+| **12.4.2** | **Verify that** runtime monitors detect queries inconsistent with the declared purpose of the dataset or model, and that detected queries trigger a soft refusal or are blocked pending review. | 1 |
 | **12.4.3** | **Verify that** policy-as-code gates block redeployment of models to new domains without DPIA review. | 3 |
 | **12.4.4** | **Verify that** formal traceability proofs show every personal data lifecycle remains within consented scope. | 3 |
 
@@ -62,26 +60,24 @@ Prevent models and datasets from being used beyond their originally consented pu
 
 ## C12.5 Consent Management & Lawful-Basis Tracking
 
-Record, enforce, and revoke consent across AI processing pipelines.
+Enforce consent at AI-specific decision points (training data ingestion, inference) and propagate withdrawal across AI artifacts.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.5.1** | **Verify that** a Consent-Management Platform (CMP) records opt-in status, purpose, and retention period per data-subject. | 1 |
-| **12.5.2** | **Verify that** APIs expose consent tokens that encode the data subject's opt-in status, purpose, and retention period. | 2 |
-| **12.5.4** | **Verify that** models validate consent token scope before inference and refuse processing when the token is absent, invalid, or does not cover the requested operation. | 2 |
-| **12.5.3** | **Verify that** denied or withdrawn consent halts processing pipelines within 24 hours. | 2 |
+| **12.5.1** | **Verify that** models validate consent token scope before inference and refuse processing when the token is absent, invalid, or does not cover the requested operation. | 2 |
+| **12.5.2** | **Verify that** denied or withdrawn consent halts processing pipelines within 24 hours. | 2 |
 
 ---
 
 ## C12.6 Federated Learning with Privacy Controls
 
-Apply differential privacy and poisoning-resistant aggregation to federated learning to protect individual participant data.
+Apply differential privacy and privacy auditing to federated learning to protect individual participant data. Robust aggregation and anti-poisoning aggregator selection (e.g., Krum, Trimmed-Mean) are integrity controls and are covered by C1 (training data integrity) and C11 (adversarial robustness).
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.6.1** | **Verify that** client updates employ local differential privacy noise addition before aggregation. | 1 |
 | **12.6.2** | **Verify that** training metrics are differentially private and never reveal single-client loss. | 2 |
-| **12.6.3** | **Verify that** poisoning-resistant aggregation (e.g., Krum/Trimmed-Mean) is enabled. | 2 |
+| **12.6.3** | **Verify that** federated learning systems implement canary-based privacy auditing to empirically bound privacy leakage, with audit results logged and reviewed per training cycle. | 3 |
 | **12.6.4** | **Verify that** formal proofs demonstrate overall ε budget with less than 5 utility loss. | 3 |
 
 ---

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -348,18 +348,21 @@ Protect personal data and enforce data subject rights throughout the AI lifecycl
 | Labeled data anonymization and granular redaction | 1.3.5 |
 | Direct and quasi-identifier removal | 12.1.1 |
 | k-anonymity and l-diversity measurement with automated audits | 12.1.2 |
+| Feature-importance leakage check on trained models | 12.1.3 |
 | Synthetic data with formal re-identification risk bounds | 12.1.4 |
-| Data deletion propagation (datasets, checkpoints, embeddings, logs, backups) | 12.2.1 |
+| Data deletion propagation across AI artifacts (datasets, checkpoints, caches) | 12.2.1 |
 | Machine unlearning with certified algorithms | 12.2.2 |
 | Shadow-model evaluation of unlearning effectiveness | 12.2.3 |
-| Privacy-loss accounting with epsilon budget tracking and alerts | 12.3.1, 12.3.5 |
+| Privacy-loss accounting with epsilon budget tracking and alerts | 12.3.1 |
+| Empirical (black-box) differential privacy audits | 12.3.2 |
 | Formal differential privacy proofs (including post-training and embeddings) | 12.3.3 |
-| Purpose tags with machine-readable alignment and runtime enforcement | 12.4.1, 12.4.2, 12.4.5 |
-| Consent Management Platform (CMP) with opt-in tracking | 12.5.1 |
-| Consent token API exposure and model-side scope validation | 12.5.2, 12.5.4 |
-| Consent withdrawal processing (< 24 hour SLA) | 12.5.3 |
+| Purpose tags with machine-readable alignment and runtime enforcement | 12.4.1, 12.4.2 |
+| Models validate consent token scope before inference | 12.5.1 |
+| Consent withdrawal halts processing pipelines | 12.5.2 |
 | Local differential privacy in federated learning (client-side noise) | 12.6.1 |
-| Poisoning-resistant aggregation (Krum, Trimmed-Mean) | 12.6.3 |
+| Differentially private training metrics | 12.6.2 |
+| Federated canary-based privacy auditing | 12.6.3 |
+| Federated training utility-loss bound against ε budget | 12.6.4 |
 | PII detection and removal in external datasets | 6.3.2 |
 | Session context discard at session end (not accessible in subsequent sessions) | 8.3.7 |
 | Quarantined content excluded from retrieval results while under quarantine | 8.3.8 |
@@ -420,7 +423,7 @@ Capture security-relevant events with integrity protection for forensic analysis
 | Audit log context fields sufficient for forensic reconstruction (actor, delegation, policy, parameters, outcomes) | 9.4.3 |
 | Agent action signing with chain ID binding and timestamps | 9.4.2 |
 | Immutable audit records for model changes (actor, change type, before/after) | 3.2.5 |
-| Immutable deletion logging for regulatory audit trails | 12.2.4 |
+| Generic audit log immutability and tamper-evidence | ASVS v5 V16.4.2 |
 | CI/CD audit log streaming to SIEM | ASVS v5 V16.4.3 |
 | Detection rules for anomalous package pulls and tampered build steps | ASVS v5 V16.3.3 |
 | DAG visualization with access controls and tamper evidence | 13.7.1, 13.7.2, 13.7.3 |


### PR DESCRIPTION
Reduces C12 to AI-specific privacy controls and removes content covered by ASVS v5 (V14, V16) or by other AISVS chapters (C8, C13, C14). Adds a top-level scope note in the style of the recent C8/C9/C11 reduction passes, merges duplicates, and rebalances levels against an implementability check.

Out-of-scope wording, threshold, and metric concerns surfaced during the review are tracked separately in #715 and intentionally not changed in this PR.

Net change: 26 → 20 requirements (no level changes; the 12.2.2 L2 → L3 rebalancing is tracked in #715 alongside the wording anchor).

## Changes by section

### Top-level scope note (new)
States that generic data classification, encryption, retention scheduling, secure deletion, audit log immutability, and CMP/consent-record plumbing are covered by ASVS v5 V14/V16; embedding/RAG deletion by C8.3; AI-event logging by C13; consent communication by C14.7.

### C12.1 Anonymization & Data Minimization
- **12.1.1**: Reframed to training and fine-tuning data context. Generic enterprise pseudonymization is left to ASVS V14.
- **12.1.2**: Scoped to training datasets.

### C12.2 Right-to-be-Forgotten & Deletion Enforcement
- **12.2.1**: Reframed as AI-artifact propagation (training/fine-tuning datasets, model checkpoints, evaluation sets, derived caches, feature stores). Embedding and RAG index propagation explicitly delegated to C8.3. Generic backup/log retention left to ASVS V14.2.7.
- **12.2.4 (REMOVED)**: Generic immutable audit logs are covered by ASVS v5 V16.4.2 and V16.3.

### C12.3 Differential-Privacy Safeguards
- **12.3.1 + 12.3.5 (MERGED into 12.3.1)**: Per-round ε/δ tracking and cumulative alerting are tightly coupled and exposed as one mechanism by e.g. Opacus and TensorFlow Privacy accountants.
- **12.3.4 (MOVED to C12.6.3)**: Federated canary auditing belongs in the federated section.

### C12.4 Purpose-Limitation & Scope-Creep Protection
- **12.4.2 + 12.4.5 (MERGED into 12.4.2)**: Detection and refusal of off-purpose queries are a single control loop.

### C12.5 Consent Management & Lawful-Basis Tracking
- Section intro reframed to scope C12.5 to AI-specific decision points (training data ingestion, inference) and consent-withdrawal propagation. Generic CMP record-keeping is delegated to privacy-program standards (GDPR, ISO/IEC 27701).
- **12.5.1 (REMOVED)**: CMP existence and opt-in record-keeping is a generic privacy-program control. ASVS v5 explicitly defers privacy-law plumbing to privacy specialists; an AI-specific technical standard should not duplicate it.
- **12.5.2 (REMOVED)**: Exposing consent tokens via APIs is a combination of generic self-contained-token mechanics (ASVS v5 V9) and privacy-token semantics that are not AI-specific.
- **12.5.4 → 12.5.1**, **12.5.3 → 12.5.2**: Renumbered.

### C12.6 Federated Learning with Privacy Controls
- Section intro redirects readers to C1 and C11 for robust aggregation and anti-poisoning.
- **12.6.3 (REPLACED)**: Krum/Trimmed-Mean removed from this chapter (it is an integrity / anti-poisoning control, not privacy). Slot now holds the canary-based federated privacy auditing requirement moved from 12.3.4.

### Appendix D — AI Security Controls Inventory
- `AD.14`: rows updated to match renumbering and removals.
- `AD.16`: cross-reference to deleted 12.2.4 replaced with a direct pointer to ASVS v5 V16.4.2.

## Implementability evidence

- DP budget tracking (ε, δ): production-ready (Opacus, TensorFlow Privacy). Confirms L2 for 12.3.1.
- Federated DP and aggregation: production-ready in Flower. Confirms L1/L2 for 12.6.1/12.6.2.