### PR TITLE
C12 fixes for issue 715

### DIFF
--- a/.github/workflows/config/local-custom.txt
+++ b/.github/workflows/config/local-custom.txt
@@ -115,3 +115,6 @@ logprob
 logprobs
 SLSA
 SCVS
+Clopper
+Pearson
+f-DP

--- a/1.0/en/0x10-C12-Privacy.md
+++ b/1.0/en/0x10-C12-Privacy.md
@@ -16,8 +16,8 @@ Remove or transform personal identifiers before training to prevent re-identific
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.1.1** | **Verify that** direct and quasi-identifiers in training and fine-tuning datasets are removed, hashed, or generalized before the data is used to fit or update a model. | 1 |
 | **12.1.2** | **Verify that** automated audits measure k-anonymity or l-diversity on training datasets and alert when thresholds drop below policy. | 2 |
-| **12.1.3** | **Verify that** model feature-importance reports prove no identifier leakage beyond ε = 0.01 mutual information. | 2 |
-| **12.1.4** | **Verify that** formal proofs or synthetic-data certification show re-identification risk ≤ 0.05 even under linkage attacks. | 3 |
+| **12.1.3** | **Verify that** model feature-importance or attribution analyses are run on trained models to confirm that no removed identifier or quasi-identifier has been reconstructed as a high-importance feature. | 2 |
+| **12.1.4** | **Verify that** formal proofs or synthetic-data certification show re-identification risk against trained models remains below a documented policy threshold even under linkage attacks. | 3 |
 
 ---
 
@@ -28,8 +28,8 @@ Ensure data-subject deletion requests propagate across all AI artifacts and that
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.2.1** | **Verify that** data-subject deletion requests propagate to AI-derived artifacts including training and fine-tuning datasets, model checkpoints, evaluation sets, derived caches, and feature stores within a service level agreement of less than 30 days. Embedding and RAG index propagation is governed by C8.3. | 1 |
-| **12.2.2** | **Verify that** "machine-unlearning" routines physically re-train or approximate removal using certified unlearning algorithms. | 2 |
-| **12.2.3** | **Verify that** shadow-model evaluation proves forgotten records influence less than 1% of outputs after unlearning. | 2 |
+| **12.2.2** | **Verify that** machine-unlearning routines, when claimed, either physically retrain the affected model on the retained data or apply a certified unlearning algorithm with documented (ε, δ) guarantees. | 3 |
+| **12.2.3** | **Verify that** shadow-model or membership-inference evaluation demonstrates that forgotten records influence less than a documented policy threshold of model outputs after unlearning. | 2 |
 
 ---
 
@@ -40,8 +40,8 @@ Track and enforce privacy budgets to provide formal guarantees against individua
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.3.1** | **Verify that** differential privacy budget consumption (both ε and δ values) is tracked and recorded per training round, and that cumulative consumption triggers an alert when ε exceeds defined policy thresholds. | 2 |
-| **12.3.2** | **Verify that** black-box privacy audits estimate ε̂ within 10% of declared value. | 2 |
-| **12.3.3** | **Verify that** formal proofs cover all post-training fine-tunes and embeddings. | 3 |
+| **12.3.2** | **Verify that** black-box privacy audits empirically estimate ε̂ as a lower bound at a stated confidence level (e.g., Clopper-Pearson or f-DP confidence intervals), and that the estimate is consistent with the declared budget within documented tolerance. | 2 |
+| **12.3.3** | **Verify that** formal privacy proofs cover all post-training fine-tunes and embedding generation steps that consume the same source data. | 3 |
 
 ---
 
@@ -51,7 +51,7 @@ Prevent models and datasets from being used beyond their originally consented pu
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.4.1** | **Verify that** every dataset and model checkpoint carries a machine-readable purpose tag aligned to the original consent. | 1 |
+| **12.4.1** | **Verify that** every dataset and model checkpoint carries a machine-readable purpose tag aligned to the original consent and lawful basis under which the source data was collected. | 1 |
 | **12.4.2** | **Verify that** runtime monitors detect queries inconsistent with the declared purpose of the dataset or model, and that detected queries trigger a soft refusal or are blocked pending review. | 1 |
 | **12.4.3** | **Verify that** policy-as-code gates block redeployment of models to new domains without DPIA review. | 3 |
 | **12.4.4** | **Verify that** formal traceability proofs show every personal data lifecycle remains within consented scope. | 3 |
@@ -64,8 +64,8 @@ Enforce consent at AI-specific decision points (training data ingestion, inferen
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.5.1** | **Verify that** models validate consent token scope before inference and refuse processing when the token is absent, invalid, or does not cover the requested operation. | 2 |
-| **12.5.2** | **Verify that** denied or withdrawn consent halts processing pipelines within 24 hours. | 2 |
+| **12.5.1** | **Verify that** model inference validates consent scope before processing and refuses or downgrades the response when the scope does not cover the requested operation, the data subjects whose data materially influences the response, or both. | 2 |
+| **12.5.2** | **Verify that** withdrawal of consent triggers the same AI-artifact propagation pipeline as a deletion request (see 12.2.1), and that inference paths relying on the withdrawn data are disabled within the same SLA. | 2 |
 
 ---
 
@@ -75,10 +75,10 @@ Apply differential privacy and privacy auditing to federated learning to protect
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.6.1** | **Verify that** client updates employ local differential privacy noise addition before aggregation. | 1 |
-| **12.6.2** | **Verify that** training metrics are differentially private and never reveal single-client loss. | 2 |
+| **12.6.1** | **Verify that** client updates apply local differential privacy noise addition before aggregation, or that a documented central differential privacy mechanism is enforced at the aggregator. | 1 |
+| **12.6.2** | **Verify that** training metrics shared with the aggregator or with clients are differentially private and never reveal single-client loss or single-client gradients. | 2 |
 | **12.6.3** | **Verify that** federated learning systems implement canary-based privacy auditing to empirically bound privacy leakage, with audit results logged and reviewed per training cycle. | 3 |
-| **12.6.4** | **Verify that** formal proofs demonstrate overall ε budget with less than 5 utility loss. | 3 |
+| **12.6.4** | **Verify that** formal proofs document the overall ε budget and the corresponding utility loss against a declared baseline. | 3 |
 
 ---
 

--- a/1.0/en/0x90-Appendix-A_Glossary.md
+++ b/1.0/en/0x90-Appendix-A_Glossary.md
@@ -74,6 +74,8 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 
 * **DoS (Denial of Service)** – An attack that attempts to make a system unavailable by overwhelming it with requests or exhausting its resources.
 
+* **Downgrade (response)** – Returning a model response that is less specific, less personalized, or otherwise reduced in scope when full processing would exceed an authorization or consent boundary. Examples include filtering out retrieval chunks sourced from non-consenting data subjects, suppressing personalized fields, or returning a generic answer instead of one that materially relies on restricted data. Refusal is always a valid downgrade. Acceptable downgrade behaviors should be documented per inference path.
+
 * **DPIA (Data Protection Impact Assessment)** – A formal assessment required under regulations such as GDPR to evaluate and mitigate risks to personal data before processing begins.
 
 * **DP-SGD (Differentially Private Stochastic Gradient Descent)** – A training algorithm that adds calibrated noise to gradient updates during model training to provide formal differential privacy guarantees.

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -357,9 +357,9 @@ Protect personal data and enforce data subject rights throughout the AI lifecycl
 | Empirical (black-box) differential privacy audits | 12.3.2 |
 | Formal differential privacy proofs (including post-training and embeddings) | 12.3.3 |
 | Purpose tags with machine-readable alignment and runtime enforcement | 12.4.1, 12.4.2 |
-| Models validate consent token scope before inference | 12.5.1 |
-| Consent withdrawal halts processing pipelines | 12.5.2 |
-| Local differential privacy in federated learning (client-side noise) | 12.6.1 |
+| Consent-aware inference scope validation (refuse or downgrade off-scope responses) | 12.5.1 |
+| Consent withdrawal propagation through AI artifacts (aligned with deletion SLA) | 12.5.2 |
+| Local or central differential privacy in federated learning | 12.6.1 |
 | Differentially private training metrics | 12.6.2 |
 | Federated canary-based privacy auditing | 12.6.3 |
 | Federated training utility-loss bound against ε budget | 12.6.4 |


### PR DESCRIPTION
Resolves #715. Applies the twelve C12 wording, threshold, level, and metric corrections agreed in the issue thread as reviewed by @RicoKomenda.

No requirements added or removed; level changes limited to one (12.2.2 L2 → L3).

## Changes

### C12.1 Anonymization & Data Minimization
- **12.1.3**: Replaced the `ε = 0.01 mutual information` bound. The MI-DP framing is legitimate but not consistently measurable from generic feature-importance reports across architectures. Rephrased as a positive testable check that removed identifiers do not reappear as high-importance features.
- **12.1.4**: Replaced the literal `≤ 0.05` with a documented policy threshold. The 5% figure has precedent in HIPAA expert determination but is not universal across regulators (GDPR, CCPA do not set a number).

### C12.2 Right-to-be-Forgotten & Deletion Enforcement
- **12.2.2**: L2 → L3 plus reworded to anchor the "certified" claim to documented `(ε, δ)` guarantees. Certified machine unlearning is research-grade in 2025 (Koloskova et al. ICML 2025; Mu and Klabjan NeurIPS 2025; ERASURE/Erasus); no production-ready framework exists for general-purpose LLMs or large vision models. Physical retraining is retained as the L3 baseline alternative.
- **12.2.3**: Replaced the literal `< 1%` with a documented policy threshold and broadened the evaluation method to include MIA-style tests, matching how the unlearning evaluation literature (NeurIPS 2023 Unlearning Competition, OpenUnlearning, TOFU, MUSE, WMDP) actually measures forgetting.

### C12.3 Differential-Privacy Safeguards
- **12.3.2**: Replaced the literal `within 10%`. Reworded to require lower bounds at a stated confidence level (e.g., Clopper-Pearson or f-DP intervals), matching how SOTA DP auditing actually reports results (Nasr et al. USENIX Security 2023; Steinke, Nasr and Jagielski NeurIPS 2023).
- **12.3.3**: Tightened to make explicit that proofs must cover post-training fine-tunes and embedding generation steps that consume the same source data, closing the common gap where the base-model proof is treated as covering downstream derivatives.

### C12.4 Purpose-Limitation & Scope-Creep Protection
- **12.4.1**: Tightened to bind purpose tags to consent and lawful basis. Consent is only one of six lawful bases under GDPR Art. 6; a purpose tag that records only the consent fingerprint will not survive a non-consent processing context.

### C12.5 Consent Management & Lawful-Basis Tracking
- **12.5.1**: Reworded to cover both the requesting party's scope and the data subjects whose data materially influences the response. The RAG case where contributing data subjects have not consented is a genuine AI-specific gap not covered by the previous wording.
- **12.5.2**: Aligned to the 12.2.1 deletion SLA (less than 30 days) instead of a separate 24-hour clock. The 24h timer was inconsistent with the deletion pipeline it logically triggers; in practice withdrawal is treated by privacy programs as triggering the same propagation as a deletion request.

### Appendix A — Glossary
- Added a "Downgrade (response)" entry per @RicoKomenda's suggestion to define the operational meaning of "downgrade" used in 12.5.1 (filtering retrieval chunks from non-consenting subjects, suppressing personalized fields, returning generic answers; refusal is always a valid downgrade). Placed in the glossary instead of as a chapter scope note in line with the project direction to phase scope notes out.

### C12.6 Federated Learning with Privacy Controls
- **12.6.1**: Allowed either local DP at the client or a documented central DP mechanism at the aggregator. Both are first-class strategies in production federated frameworks (e.g., Flower's `DifferentialPrivacyServerSide*` and `DifferentialPrivacyClientSide*` wrappers); central DP gives better utility for the same budget when a trusted aggregator exists.
- **12.6.2**: Tightened to cover both single-client loss and single-client gradient leakage. Gradient-inversion attacks reconstruct training samples from per-client gradients; restricting the requirement to "loss" left this attack vector out of scope.
- **12.6.4**: Removed the `< 5 utility loss` figure. The original was missing a unit and no community-standard utility-loss bar exists for federated DP (real studies report 10–90% degradation depending on ε, model size, IID/non-IID — Pustozerova et al. IEEE TrustCom 2023; Basu et al. 2021). Reframed as a documented utility-loss measurement against a declared baseline.

### Appendix D — AI Security Controls Inventory (`AD.14 Privacy & Data Minimization`)
- Updated three rows whose descriptions no longer matched the rewritten chapter wording: 12.5.1 (consent-aware inference scope validation), 12.5.2 (withdrawal aligned with deletion SLA), 12.6.1 (local or central DP).
