### PR TITLE
Add training-process telemetry monitoring for poisoning detection to C13.3

### DIFF
--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -51,8 +51,9 @@ Monitor and detect drift and degradation across model outputs, input distributio
 | **13.3.7** | **Verify that** concept drift detection identifies changes in the relationship between inputs and expected outputs. | 2 |
 | **13.3.8** | **Verify that** performance degradation alerts trigger a defined remediation workflow (e.g., manual review, retraining, or replacement). | 2 |
 | **13.3.9** | **Verify that** hallucination rates are tracked as continuous time-series metrics to enable trend analysis and detection of sustained model degradation. | 2 |
-| **13.3.10** | **Verify that** degradation root cause analysis correlates performance drops with data changes, infrastructure issues, or external factors. | 3 |
-| **13.3.11** | **Verify that** sudden unexplained behavioral shifts are distinguished from gradual expected operational drift, with a security escalation path defined for unexplained sudden drift. | 3 |
+| **13.3.10** | **Verify that** training pipeline instrumentation continuously monitors runtime duration, loss trajectory, and convergence rate against established baselines for equivalent dataset size and model architecture, and that statistically significant deviations (e.g., abnormally prolonged training duration or erratic loss curves) trigger automated alerts and gating of the resulting model artifact pending investigation, as such anomalies may indicate the presence of adversarial poisoning payloads in the training data. | 2 |
+| **13.3.11** | **Verify that** degradation root cause analysis correlates performance drops with data changes, infrastructure issues, or external factors. | 3 |
+| **13.3.12** | **Verify that** sudden unexplained behavioral shifts are distinguished from gradual expected operational drift, with a security escalation path defined for unexplained sudden drift. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -409,6 +409,7 @@ Detect anomalies, alert on threats, and respond to security incidents in AI syst
 | Performance degradation retraining and replacement workflow triggers | 13.3.8 |
 | Hallucination detection monitoring | 13.3.5 |
 | Hallucination rate time-series tracking | 13.3.9 |
+| Training pipeline telemetry monitoring (runtime duration, loss trajectory, convergence rate) with baseline alerting and artifact gating | 13.3.10 |
 | Model extraction alert generation with query metadata logging | 11.5.2 |
 | Emergent multi-agent behavior detection (oscillation, deadlock, broadcast storms) | 9.8.4 |
 | AI-specific incident response plans (model compromise, data poisoning, adversarial attack) | 13.5.1 |


### PR DESCRIPTION
# Summary

Fixes #719 

Adds a new requirement to C13.3 (Model, Data, and Performance Drift Detection) for monitoring training-process behavioral signals — runtime duration, loss trajectory, and convergence rate — as an orthogonal poisoning detection channel.

## Why C13.3

The original issue proposed placement in C01, but C13.3 is a better fit on review. C13.3 already establishes the pattern of baseline-and-alert monitoring for model performance (13.3.1), automated threshold alerting (13.3.3), input distribution drift (13.3.5), and unexplained behavioral shifts with security escalation (13.3.9). The training telemetry requirement extends this same monitoring pattern to the training pipeline, where it detects poisoning-induced anomalies rather than post-deployment drift.

C01 (Training Data Integrity & Traceability) focuses on ensuring data has not been tampered with, poisoned, or corrupted, i.e. covering origin traceability, integrity, and quality of the training data itself. C13.3 focuses on behavioral monitoring with baselines and automated alerting, which is exactly what training telemetry monitoring is.

## Motivation

Existing C01 poisoning detection controls focus on inspecting the **dataset itself** (statistical outlier detection, embedding analysis, label consistency) to ensure data integrity and traceability. This is necessary but insufficient for sophisticated backdoor poisoning, which is specifically designed to evade sample-level inspection. Training-process telemetry provides a complementary detection signal: poisoned data introduces conflicting gradient signals that measurably slow convergence and distort loss curves, even when individual samples appear normal.

This is a low-cost addition, since training pipelines already log duration and loss metrics for operational purposes.

## Changes

- **File:** `1.0/en/0x10-C13-Monitoring-and-Logging.md`
- **Section:** C13.3 Model, Data, and Performance Drift Detection
- **Change:** Add one requirement row after 13.3.11
- **Scope:** Single addition, no existing controls modified

## Requirement added

| # | Description | Level |
|---|---|---|
| 13.3.12 | **Verify that** training pipeline instrumentation continuously monitors runtime duration, loss trajectory, and convergence rate against established baselines for equivalent dataset size and model architecture, and that statistically significant deviations (e.g., abnormally prolonged training duration or erratic loss curves) trigger automated alerts and gating of the resulting model artifact pending investigation, as such anomalies may indicate the presence of adversarial poisoning payloads in the training data. | 2 |

## Why Level 2

- Consistent with the level of other baseline-and-alert controls in C13.3 (13.3.1 is Level 1, 13.3.2/13.3.3 are Level 2).
- Required infrastructure (loss logging, duration tracking, baseline comparison) is standard in production ML pipelines.
- Goes beyond baseline checks but does not require formal verification methods characteristic of Level 3.