### PR TITLE
Add certified robustness tracking and post-transformation re-verification to C11.2

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -6,8 +6,6 @@ Ensure that AI systems remain reliable, privacy-preserving, and abuse-resistant 
 
 Generic application security controls (configuration management, secret and key management, signed artifacts, audit logging, change control, transport security, generic anti-automation rate limiting) are covered by ASVS v5 (V11, V13, V14, V15, V16) and are not repeated here. Logging of AI security events, AI incident response planning, and human-oversight escalation are covered by AISVS C13 and C14. Inversion-specific (C11.4) and extraction-specific (C11.5) throttling controls do not substitute for generic API rate limiting (ASVS v5 V2.4) or orchestration runtime budgets (C9.1). C11.8 (agent self-review) covers AI-augmented review of proposed agent actions and protection of that review mechanism from prompt-injection bypass; the deterministic runtime gate that blocks high-impact agent actions is governed by C9.2 and C9.7.
 
-> **Scope note for 11.2.7:** C3.2.7 requires re-evaluation of quantized/pruned/distilled models against the same safety and alignment test suite, and C3.2.4 may imply inclusion of adversarial robustness in that suite. However, 11.2.7 addresses a distinct concern: formal or empirical **robustness certification** (certified radius, verified robust accuracy at defined perturbation bounds) is not equivalent to passing a general safety/alignment test suite. A model can pass behavioral safety tests while losing certified robustness guarantees after transformation. 11.2.7 explicitly requires that the robustness metrics tracked under 11.2.6 are re-verified, not merely that the model passes a functional test suite. Auditors should treat C3.2.7 and 11.2.7 as complementary, since the former covers behavioral safety regression, the latter covers formal robustness guarantee preservation.
-
 ---
 
 ## C11.1 Model Alignment & Safety
@@ -28,14 +26,16 @@ Guard against harmful or policy-breaking outputs through systematic testing and 
 
 Increase resilience to manipulated inputs designed to cause misclassification or policy bypass. Adversarial testing and robustness benchmarking are the current best practices.
 
+> **Scope note for 11.2.7:** C3.2.7 requires re-evaluation of quantized/pruned/distilled models against the same safety and alignment test suite, and C3.2.4 may imply inclusion of adversarial robustness in that suite. However, 11.2.7 addresses a distinct concern: formal or empirical **robustness certification** (certified radius, verified robust accuracy at defined perturbation bounds) is not equivalent to passing a general safety/alignment test suite. A model can pass behavioral safety tests while losing certified robustness guarantees after transformation. 11.2.7 explicitly requires that the robustness metrics tracked under 11.2.6 are re-verified, not merely that the model passes a functional test suite. Auditors should treat C3.2.7 and 11.2.7 as complementary, since the former covers behavioral safety regression, the latter covers formal robustness guarantee preservation.
+
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.2.1** | **Verify that** models serving high-risk functions are evaluated against known adversarial attack techniques relevant to their modality (e.g., perturbation attacks for vision, token-manipulation attacks for text). | 1 |
 | **11.2.2** | **Verify that** adversarial-example detection raises alerts in production pipelines, with blocking or degraded-capability responses for high-risk endpoints or use cases. | 2 |
 | **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied where feasible, with documented configurations and reproducible procedures. | 2 |
-| **11.2.4** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 |
-| **11.2.5** | **Verify that** formal robustness verification methods (e.g., certified bounds, interval-bound propagation) are applied to safety-critical model components where the model architecture supports them. | 3 |
-| **11.2.6** | **Verify that** certified robustness metrics (e.g., certified radius, verified robust accuracy at defined perturbation bounds) are tracked and recorded per model version, and that degradation beyond defined thresholds triggers re-evaluation before deployment. | 2 |
+| **11.2.4** | **Verify that** certified robustness metrics (e.g., certified radius, verified robust accuracy at defined perturbation bounds) are tracked and recorded per model version, and that degradation beyond defined thresholds triggers re-evaluation before deployment. | 2 |
+| **11.2.5** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 |
+| **11.2.6** | **Verify that** formal robustness verification methods (e.g., certified bounds, interval-bound propagation) are applied to safety-critical model components where the model architecture supports them. | 3 |
 | **11.2.7** | **Verify that** robustness certification or empirical robustness audits are repeated after all post-training transformations (fine-tuning, distillation, quantization, adapter merging) that consume the same base model. | 3 |
 
 ---

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -26,8 +26,6 @@ Guard against harmful or policy-breaking outputs through systematic testing and 
 
 Increase resilience to manipulated inputs designed to cause misclassification or policy bypass. Adversarial testing and robustness benchmarking are the current best practices.
 
-> **Scope note for 11.2.7:** C3.2.7 requires re-evaluation of quantized/pruned/distilled models against the same safety and alignment test suite, and C3.2.4 may imply inclusion of adversarial robustness in that suite. However, 11.2.7 addresses a distinct concern: formal or empirical **robustness certification** (certified radius, verified robust accuracy at defined perturbation bounds) is not equivalent to passing a general safety/alignment test suite. A model can pass behavioral safety tests while losing certified robustness guarantees after transformation. 11.2.7 explicitly requires that the robustness metrics tracked under 11.2.6 are re-verified, not merely that the model passes a functional test suite. Auditors should treat C3.2.7 and 11.2.7 as complementary, since the former covers behavioral safety regression, the latter covers formal robustness guarantee preservation.
-
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.2.1** | **Verify that** models serving high-risk functions are evaluated against known adversarial attack techniques relevant to their modality (e.g., perturbation attacks for vision, token-manipulation attacks for text). | 1 |

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -6,6 +6,8 @@ Ensure that AI systems remain reliable, privacy-preserving, and abuse-resistant 
 
 Generic application security controls (configuration management, secret and key management, signed artifacts, audit logging, change control, transport security, generic anti-automation rate limiting) are covered by ASVS v5 (V11, V13, V14, V15, V16) and are not repeated here. Logging of AI security events, AI incident response planning, and human-oversight escalation are covered by AISVS C13 and C14. Inversion-specific (C11.4) and extraction-specific (C11.5) throttling controls do not substitute for generic API rate limiting (ASVS v5 V2.4) or orchestration runtime budgets (C9.1). C11.8 (agent self-review) covers AI-augmented review of proposed agent actions and protection of that review mechanism from prompt-injection bypass; the deterministic runtime gate that blocks high-impact agent actions is governed by C9.2 and C9.7.
 
+> **Scope note for 11.2.7:** C3.2.7 requires re-evaluation of quantized/pruned/distilled models against the same safety and alignment test suite, and C3.2.4 may imply inclusion of adversarial robustness in that suite. However, 11.2.7 addresses a distinct concern: formal or empirical **robustness certification** (certified radius, verified robust accuracy at defined perturbation bounds) is not equivalent to passing a general safety/alignment test suite. A model can pass behavioral safety tests while losing certified robustness guarantees after transformation. 11.2.7 explicitly requires that the robustness metrics tracked under 11.2.6 are re-verified, not merely that the model passes a functional test suite. Auditors should treat C3.2.7 and 11.2.7 as complementary, since the former covers behavioral safety regression, the latter covers formal robustness guarantee preservation.
+
 ---
 
 ## C11.1 Model Alignment & Safety
@@ -33,6 +35,8 @@ Increase resilience to manipulated inputs designed to cause misclassification or
 | **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied where feasible, with documented configurations and reproducible procedures. | 2 |
 | **11.2.4** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 |
 | **11.2.5** | **Verify that** formal robustness verification methods (e.g., certified bounds, interval-bound propagation) are applied to safety-critical model components where the model architecture supports them. | 3 |
+| **11.2.6** | **Verify that** certified robustness metrics (e.g., certified radius, verified robust accuracy at defined perturbation bounds) are tracked and recorded per model version, and that degradation beyond defined thresholds triggers re-evaluation before deployment. | 2 |
+| **11.2.7** | **Verify that** robustness certification or empirical robustness audits are repeated after all post-training transformations (fine-tuning, distillation, quantization, adapter merging) that consume the same base model. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -383,7 +383,9 @@ Test for and defend against evasion, extraction, inversion, poisoning, and align
 | RLHF / Constitutional AI alignment training | 11.1.4 |
 | Adversarial training and defensive distillation | 11.2.3 |
 | Adversarially robust distillation — distill teacher into student using adversarial training so the student inherits robustness as well as accuracy (implementation example for 11.2.3) | 11.2.3 |
-| Formal robustness verification (certified bounds, interval-bound propagation) | 11.2.5 |
+| Certified robustness metrics tracking per model version with degradation alerting | 11.2.4 |
+| Formal robustness verification (certified bounds, interval-bound propagation) | 11.2.6 |
+| Post-transformation robustness re-certification (fine-tuning, distillation, quantization, adapter merging) | 11.2.7 |
 | Adversarial-example detection with production alerting | 11.2.2 |
 | Model ensemble as evasion containment — route queries through independently trained models and flag disagreement beyond a threshold (implementation example for 11.2.2) | 11.2.2 |
 | Output calibration and perturbation for privacy | 11.3.1 |


### PR DESCRIPTION
## Summary

Fixes #720 

Adds two requirements to C11.2 (Adversarial-Example Hardening) that bring it into structural alignment with C12.3 (Differential-Privacy Safeguards). C12.3 requires per-version metric tracking (12.3.1), empirical audits with confidence bounds (12.3.2), and post-transformation coverage (12.3.3). C11.2 currently has none of these despite certified robustness metrics being equally mature and auditable.

Includes a scope note distinguishing 11.2.7 from C3.2.7 to prevent auditor confusion.

## Motivation

C12.3 gives auditors clear, measurable criteria: ε/δ consumption logs, empirical ε̂ estimates with Clopper-Pearson bounds, and formal proof coverage across post-training steps. C11.2 stays abstract,  "evaluate against known techniques," "apply adversarial training", i.e. without specifying what to measure or how to ensure measurements survive the model lifecycle.

The certified robustness field has equivalent tooling and metrics: certified radius, verified robust accuracy at defined perturbation budgets (ℓ∞ ε-balls), and standardized benchmarks (AutoAttack). These are direct analogues to the DP metrics in C12.3.

## Changes

- **File:** `1.0/en/0x10-C11-Adversarial-Robustness.md`
- **Section:** C11.2 Adversarial-Example Hardening
- **Change:** Add two requirement rows after 11.2.5, plus a scope note for 11.2.7
- **Scope:** Two additions, no existing controls modified

## Requirements added

| # | Description | Level |
|---|---|---|
| 11.2.6 | **Verify that** certified robustness metrics (e.g., certified radius, verified robust accuracy at defined perturbation bounds) are tracked and recorded per model version, and that degradation beyond defined thresholds triggers re-evaluation before deployment. | 2 |
| 11.2.7 | **Verify that** robustness certification or empirical robustness audits are repeated after all post-training transformations (fine-tuning, distillation, quantization, adapter merging) that consume the same base model. | 3 |

## Scope note (included in file change)

11.2.7 is complementary to C3.2.7, not redundant. C3.2.7 requires re-running the safety/alignment test suite after transformation, i.e. a behavioral regression check. 11.2.7 requires re-verifying formal robustness certification, a guarantee preservation check. A model can pass one and fail the other.

## Parallel structure with C12.3

| Aspect | C12.3 (Privacy) existing | C11.2 (Robustness) proposed |
|---|---|---|
| Per-version metric tracking | 12.3.1: Track ε and δ per training round | 11.2.6: Track certified radius / robust accuracy per model version |
| Post-training coverage | 12.3.3: Formal proofs cover post-training steps | 11.2.7: Robustness certification repeated after transformations |