### PR TITLE
fix(C3): sort controls by level within each section and renumber sequentially

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -33,8 +33,8 @@ Models must pass defined security and safety validations before deployment.
 | **3.2.3** | **Verify that** models undergo safety evaluations with defined pass/fail thresholds before deployment. | 1 |
 | **3.2.4** | **Verify that** security testing covers agent workflows, tool and MCP integrations, RAG and memory interactions, multimodal inputs, and guardrails (safety models or detection services) using a versioned evaluation harness. | 2 |
 | **3.2.5** | **Verify that** all model changes (deployment, configuration, retirement) generate immutable audit records including a timestamp, an authenticated actor identity, a change type, and before/after states, with trace metadata (environment and consuming services/agents) and a model identifier (version/digest/signature). | 2 |
-| **3.2.6** | **Verify that** validation failures automatically block model deployment unless an explicit override approval from pre-designated authorized personnel with documented business justifications. | 3 |
-| **3.2.7** | **Verify that** models subjected to post-training quantization, pruning, or distillation are re-evaluated against the same safety and alignment test suite on the compressed artifact before deployment, and that evaluation results are retained as distinct records linked to the compressed artifact's version or digest. | 2 |
+| **3.2.6** | **Verify that** models subjected to post-training quantization, pruning, or distillation are re-evaluated against the same safety and alignment test suite on the compressed artifact before deployment, and that evaluation results are retained as distinct records linked to the compressed artifact's version or digest. | 2 |
+| **3.2.7** | **Verify that** validation failures automatically block model deployment unless an explicit override approval from pre-designated authorized personnel with documented business justifications. | 3 |
 
 ---
 
@@ -46,9 +46,9 @@ Model deployments must be controlled, monitored, and reversible.
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **3.3.1** | **Verify that** production deployments implement gradual rollout mechanisms (e.g., canary or blue-green deployments) with automated rollback triggers based on pre-agreed error rates, latency thresholds, guardrail alerts, or tool/MCP failure rates. | 2 |
 | **3.3.2** | **Verify that** rollback capabilities restore the complete model state (weights, configurations, dependencies including adapters and safety/policy models) atomically. | 2 |
-| **3.3.3** | **Verify that** emergency model shutdown capabilities can disable model endpoints within a pre-defined response time. | 3 |
-| **3.3.4** | **Verify that** emergency shutdown cascades to all parts of the system including e.g. deactivating agent tool and MCP access, RAG connectors, database and API credentials, and memory-store bindings. | 3 |
-| **3.3.5** | **Verify that** model versions running in parallel (e.g., A/B tests, canary, shadow deployments) use isolated runtime state so that AI-specific shared resources (e.g., KV caches, prompt caches, session state, retrieval indices) are not shared across deployment cohorts. | 2 |
+| **3.3.3** | **Verify that** model versions running in parallel (e.g., A/B tests, canary, shadow deployments) use isolated runtime state so that AI-specific shared resources (e.g., KV caches, prompt caches, session state, retrieval indices) are not shared across deployment cohorts. | 2 |
+| **3.3.4** | **Verify that** emergency model shutdown capabilities can disable model endpoints within a pre-defined response time. | 3 |
+| **3.3.5** | **Verify that** emergency shutdown cascades to all parts of the system including e.g. deactivating agent tool and MCP access, RAG connectors, database and API credentials, and memory-store bindings. | 3 |
 
 ---
 
@@ -83,8 +83,8 @@ Fine-tuning pipelines are high-privilege operations that can alter deployed mode
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **3.6.1** | **Verify that** initiating a fine-tuning or retraining run requires authorization from a person who did not request the run (separation of duties). | 3 |
-| **3.6.2** | **Verify that** reward models used in RLHF fine-tuning are versioned, cryptographically signed, and integrity-verified before use in a training run. | 2 |
+| **3.6.1** | **Verify that** reward models used in RLHF fine-tuning are versioned, cryptographically signed, and integrity-verified before use in a training run. | 2 |
+| **3.6.2** | **Verify that** initiating a fine-tuning or retraining run requires authorization from a person who did not request the run (separation of duties). | 3 |
 | **3.6.3** | **Verify that** RLHF training stages include automated detection of reward hacking or reward model over-optimization (e.g., held-out human-preference probe sets, divergence thresholds, or KL penalty monitoring), with the run blocked from promotion if detection thresholds are exceeded. | 3 |
 | **3.6.4** | **Verify that** in multi-stage fine-tuning pipelines, each stage's output is integrity-verified before the next stage consumes it, and intermediate checkpoints are registered as distinct artifacts enabling per-stage rollback. | 3 |
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -321,12 +321,12 @@ Manage model deployment, rollback, retirement, and emergency response.
 | Safety evaluations with pass/fail thresholds before deployment | 3.2.3 |
 | Agent workflow, tool, MCP, and RAG integration testing | 3.2.4 |
 | Immutable audit records for model changes | 3.2.5 |
-| Deployment validation with failure blocking and override approval | 3.2.6 |
+| Deployment validation with failure blocking and override approval | 3.2.7 |
 | Canary / blue-green deployments with automated rollback triggers | 3.3.1 |
-| Parallel deployment cohort isolation (A/B, canary, shadow) | 3.3.5 |
+| Parallel deployment cohort isolation (A/B, canary, shadow) | 3.3.3 |
 | Atomic state restoration on rollback (weights, config, adapters, safety models) | 3.3.2 |
-| Emergency model shutdown capability with pre-defined response time | 3.3.3 |
-| Shutdown cascade to tools, MCP, RAG, credentials, memory stores | 3.3.4 |
+| Emergency model shutdown capability with pre-defined response time | 3.3.4 |
+| Shutdown cascade to tools, MCP, RAG, credentials, memory stores | 3.3.5 |
 | Development / test / production environment separation | 3.4.1 |
 | No shared infrastructure across environment boundaries | 3.4.2 |
 | Version control for all development artifacts (hyperparams, scripts, prompts, policies) | 3.4.3 |


### PR DESCRIPTION
Part of the level-ordering cleanup series (see #705).

## Summary

Three sections had L2 controls placed after L3 controls.

- **C3.2**: `3.2.7` (L2 - quantization/pruning re-evaluation) was placed after `3.2.6` (L3 - validation failure blocking). Swapped and renumbered: L2 is now `3.2.6`, L3 is now `3.2.7`.
- **C3.3**: `3.3.5` (L2 - parallel deployment isolation) was placed after `3.3.3` and `3.3.4` (both L3). Moved to position 3; L3 controls became `3.3.4` and `3.3.5`.
- **C3.6**: `3.6.2` (L2 - reward model signing) was placed after `3.6.1` (L3 - separation of duties). Swapped to `3.6.1` (L2) and `3.6.2` (L3).

Sections C3.1, C3.4, and C3.5 were already in correct L1->L2->L3 order and required no changes.

Updated Appendix D cross-references for all four affected IDs (`3.2.6`, `3.3.3`, `3.3.4`, `3.3.5`).