### PR TITLE
fix(C5): sort controls by level within each section and renumber sequentially

### DIFF
--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -25,8 +25,8 @@ Agent-specific authorization policies and delegation are covered in C9.6; single
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.2.1** | **Verify that** every AI resource (datasets, models, endpoints, vector collections, embedding indices, compute instances) enforces access controls (e.g., RBAC, ABAC) with explicit allow-lists and default-deny policies. | 1 |
 | **5.2.2** | **Verify that** privileged access to model weights, training pipelines, and production AI configuration is provisioned on a just-in-time basis with a defined maximum session duration and automatic expiry, and permanent standing privileged access to these resources is not permitted. | 2 |
-| **5.2.3** | **Verify that** data classification labels (PII, PHI, proprietary, etc.) automatically propagate to derived resources (embeddings, prompt caches, model outputs). | 3 |
-| **5.2.4** | **Verify that** a documented data classification taxonomy covering AI-specific data types (embeddings, model weights, prompt templates, RAG context assemblies, fine-tuning datasets, agent tool schemas) is defined, and that AI assets are labeled in accordance with this taxonomy. | 2 |
+| **5.2.3** | **Verify that** a documented data classification taxonomy covering AI-specific data types (embeddings, model weights, prompt templates, RAG context assemblies, fine-tuning datasets, agent tool schemas) is defined, and that AI assets are labeled in accordance with this taxonomy. | 2 |
+| **5.2.4** | **Verify that** data classification labels (PII, PHI, proprietary, etc.) automatically propagate to derived resources (embeddings, prompt caches, model outputs). | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -37,8 +37,8 @@ Enforce access decisions across users, agents, tools, data, and MCP resources us
 | --- | --- |
 | Access controls on AI resources (datasets, models, endpoints, vector collections, compute) | 5.2.1 |
 | Just-in-time privileged access for AI resources (model weights, training pipelines) | 5.2.2 |
-| Classification label propagation to derived AI resources (embeddings, caches, outputs) | 5.2.3 |
-| AI-specific data classification taxonomy | 5.2.4 |
+| AI-specific data classification taxonomy | 5.2.3 |
+| Classification label propagation to derived AI resources (embeddings, caches, outputs) | 5.2.4 |
 | Caller authorization context enforcement through AI query pipelines | 5.3.1 |
 | Fine-grained agent action authorization (tool, parameters, resources, data scope) | 9.6.1 |
 | Delegation context propagation with integrity protection (user, tenant, scopes) | 9.6.2 |


### PR DESCRIPTION
Part of the level-ordering cleanup series (see #705).

## Summary

One section had an L2 control placed after an L3 control.

- **C5.2**: `5.2.4` (L2 - data classification taxonomy) was placed after `5.2.3` (L3 - label propagation to derived resources). Swapped: the L2 control is now `5.2.3`, the L3 control is now `5.2.4`.

All other sections (C5.1, C5.3, C5.4, C5.5, C5.6) were already in correct L1->L2->L3 order.

Updated Appendix D cross-references for both affected IDs.