### PR TITLE
fix(C2): sort controls by level within each section and renumber sequentially

### DIFF
--- a/1.0/en/0x10-C02-User-Input-Validation.md
+++ b/1.0/en/0x10-C02-User-Input-Validation.md
@@ -17,12 +17,12 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | **2.1.1** | **Verify that** all external or derived inputs that may steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier before being included in prompts or used to trigger actions. | 1 |
 | **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. This enforcement must be preserved across multi-step interactions and tool-augmented workflows. In such cases, prompt composition or intermediate outputs must not allow user-controlled content to influence or override system or developer instructions. | 1 |
 | **2.1.3** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, and that inputs exceeding token limits are rejected rather than silently truncated, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
-| **2.1.4** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
-| **2.1.5** | **Verify that** the system enforces per-request limits on the number of user-supplied demonstrations included in a single context window. | 2 |
-| **2.1.6** | **Verify that** the system detects patterns indicative of systematic in-context behavioral override attempts consistent with many-shot jailbreaking. | 2 |
-| **2.1.7** | **Verify that** detected in-context behavioral override attempts are classified and handled as prompt injection events. | 2 |
-| **2.1.8** | **Verify that** prompt injection screening respects user-specific policies (age and regional legal constraints) via attribute-based rules resolved at request time, including the role or permission level of the calling agent. | 2 |
-| **2.1.9** | **Verify that** the system implements a character set limitation for user inputs to model prompts, allowing only characters that are explicitly required for business purposes using an allow-list approach. | 1 |
+| **2.1.4** | **Verify that** the system implements a character set limitation for user inputs to model prompts, allowing only characters that are explicitly required for business purposes using an allow-list approach. | 1 |
+| **2.1.5** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
+| **2.1.6** | **Verify that** the system enforces per-request limits on the number of user-supplied demonstrations included in a single context window. | 2 |
+| **2.1.7** | **Verify that** the system detects patterns indicative of systematic in-context behavioral override attempts consistent with many-shot jailbreaking. | 2 |
+| **2.1.8** | **Verify that** detected in-context behavioral override attempts are classified and handled as prompt injection events. | 2 |
+| **2.1.9** | **Verify that** prompt injection screening respects user-specific policies (age and regional legal constraints) via attribute-based rules resolved at request time, including the role or permission level of the calling agent. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -156,18 +156,18 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | --- | --- |
 | Prompt injection detection ruleset / service | 2.1.1 |
 | Instruction hierarchy enforcement (system > developer > user) | 2.1.2 |
-| Per-request demonstration count limits in context window | 2.1.5 |
-| Many-shot jailbreaking pattern detection (systematic in-context behavioral override) | 2.1.6 |
-| In-context behavioral override attempts classified as prompt injection events | 2.1.7 |
+| Per-request demonstration count limits in context window | 2.1.6 |
+| Many-shot jailbreaking pattern detection (systematic in-context behavioral override) | 2.1.7 |
+| In-context behavioral override attempts classified as prompt injection events | 2.1.8 |
 | Context window proportion limits and token limit enforcement (reject, not truncate) | 2.1.3 |
-| Third-party content sanitization | 2.1.4 |
-| Character set allow-listing for model prompt inputs | 2.1.9 |
+| Third-party content sanitization | 2.1.5 |
+| Character set allow-listing for model prompt inputs | 2.1.4 |
 | Pre-tokenization input normalization (Unicode NFC, homoglyph mapping, control/invisible character removal, bidirectional text neutralization) | 2.2.1 |
 | Adversarial input quarantine and logging | 2.2.2 |
 | Encoding and representation smuggling detection and mitigation | 2.2.3 |
 | Content classifiers for inbound prompts (hate, violence, sexual, illegal) | 2.3.1 |
 | Policy-violating input rejection before model propagation | 2.3.2 |
-| User-specific and agent-aware policy screening | 2.1.8 |
+| User-specific and agent-aware policy screening | 2.1.9 |
 | Extracted and hidden content from non-text inputs treated as untrusted | 2.4.1 |
 | Adversarial perturbation detection on image/audio inputs | 2.4.2 |
 | Cross-modal attack detection | 2.4.3 |


### PR DESCRIPTION
Part of the level-ordering cleanup series (see #705).

## Summary

One section had an L1 control placed after L2 controls.

- **C2.1**: `2.1.9` (L1 - character set allow-listing) was placed at the end after five L2 controls (`2.1.4`-`2.1.8`). Moved to position 4 and renumbered so all L1 controls come first:
  - `2.1.4` = character set allow-listing (was `2.1.9`, L1)
  - `2.1.5` = third-party content sanitization (was `2.1.4`, L2)
  - `2.1.6` = per-request demonstration count limits (was `2.1.5`, L2)
  - `2.1.7` = many-shot jailbreaking detection (was `2.1.6`, L2)
  - `2.1.8` = in-context override classified as injection (was `2.1.7`, L2)
  - `2.1.9` = user-specific policy screening (was `2.1.8`, L2)

Sections C2.2, C2.3, and C2.4 were already in correct L1->L2->L3 order.

Updated all six affected Appendix D cross-references.