### PR TITLE
fix(C10): sort controls by level within each section and renumber sequentially

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -24,9 +24,9 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | :--: | --- | :---: |
 | **10.2.1** | **Verify that** MCP clients and servers implement the OAuth 2.1 authorization framework: clients present a valid access token for each request, and servers validate the token's issuer, audience, expiration, and scope claims, acting as resource servers that do not store tokens or user credentials. | 1 |
 | **10.2.2** | **Verify that** MCP servers are registered through a controlled technical onboarding mechanism requiring explicit owner, environment, and resource definitions; unregistered or undiscoverable servers must not be callable in production. | 1 |
-| **10.2.3** | **Verify that** MCP `tools/list` and resource discovery responses are filtered based on the end-user's authorized scopes so that agents receive only the tool and resource definitions the user is permitted to invoke. | 2 |
-| **10.2.4** | **Verify that** MCP servers enforce access control on every tool invocation, validating that the user's access token authorizes both the requested tool and the specific argument values supplied. | 2 |
-| **10.2.5** | **Verify that** MCP session identifiers are treated as state, not identity: generated using cryptographically secure random values, bound to the authenticated user, and never relied on for authentication or authorization decisions. | 1 |
+| **10.2.3** | **Verify that** MCP session identifiers are treated as state, not identity: generated using cryptographically secure random values, bound to the authenticated user, and never relied on for authentication or authorization decisions. | 1 |
+| **10.2.4** | **Verify that** MCP `tools/list` and resource discovery responses are filtered based on the end-user's authorized scopes so that agents receive only the tool and resource definitions the user is permitted to invoke. | 2 |
+| **10.2.5** | **Verify that** MCP servers enforce access control on every tool invocation, validating that the user's access token authorizes both the requested tool and the specific argument values supplied. | 2 |
 | **10.2.6** | **Verify that** MCP servers do not pass through access tokens received from clients to downstream APIs and instead obtain a separate token scoped to the server's own identity (e.g., via on-behalf-of or client credentials flow). | 2 |
 | **10.2.7** | **Verify that** MCP clients request only the minimum scopes needed for the current operation and elevate progressively via step-up authorization for higher-privilege operations. | 2 |
 | **10.2.8** | **Verify that** MCP servers enforce deterministic session teardown, destroying cached tokens, in-memory state, temporary storage, and file handles when a session terminates, disconnects, or times out. | 2 |
@@ -39,11 +39,11 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | # | Description | Level |
 | :--: | --- | :---: |
 | **10.3.1** | **Verify that** authenticated, encrypted streamable-HTTP is used as the primary MCP transport in production environments and that alternate transports (e.g., stdio or SSE) are restricted to local or tightly controlled environments with explicit justification. | 1 |
-| **10.3.3** | **Verify that** SSE-based MCP transports are used only within private, authenticated internal channels with TLS, schema validation, payload size limits, and rate limiting enforced, and are not exposed to the public internet. | 2 |
-| **10.3.4** | **Verify that** MCP servers validate the `Origin` and `Host` headers on all HTTP-based transports (including SSE and streamable-HTTP) to prevent DNS rebinding attacks and reject requests from untrusted, mismatched, or missing origins. | 2 |
-| **10.3.5** | **Verify that** intermediaries do not alter or remove the `Mcp-Protocol-Version` header on streamable-HTTP transports unless explicitly required by the protocol specification, preventing protocol downgrade via header stripping. | 2 |
-| **10.3.6** | **Verify that** SSE-based MCP transport endpoints enforce TLS, authentication, schema validation, payload size limits, and rate limiting. | 2 |
-| **10.3.7** | **Verify that** MCP clients enforce a minimum acceptable protocol version and reject `initialize` responses that propose a version below that minimum, preventing a server or intermediary from forcing use of a protocol version with weaker security properties. | 2 |
+| **10.3.2** | **Verify that** SSE-based MCP transports are used only within private, authenticated internal channels with TLS, schema validation, payload size limits, and rate limiting enforced, and are not exposed to the public internet. | 2 |
+| **10.3.3** | **Verify that** MCP servers validate the `Origin` and `Host` headers on all HTTP-based transports (including SSE and streamable-HTTP) to prevent DNS rebinding attacks and reject requests from untrusted, mismatched, or missing origins. | 2 |
+| **10.3.4** | **Verify that** intermediaries do not alter or remove the `Mcp-Protocol-Version` header on streamable-HTTP transports unless explicitly required by the protocol specification, preventing protocol downgrade via header stripping. | 2 |
+| **10.3.5** | **Verify that** SSE-based MCP transport endpoints enforce TLS, authentication, schema validation, payload size limits, and rate limiting. | 2 |
+| **10.3.6** | **Verify that** MCP clients enforce a minimum acceptable protocol version and reject `initialize` responses that propose a version below that minimum, preventing a server or intermediary from forcing use of a protocol version with weaker security properties. | 2 |
 
 ---
 
@@ -52,13 +52,13 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | # | Description | Level |
 | :--: | --- | :---: |
 | **10.4.1** | **Verify that** MCP tool responses are validated before being injected into the model context to prevent prompt injection, malicious tool output, or context manipulation. | 1 |
-| **10.4.2** | **Verify that** MCP tool and resource schemas (e.g., JSON schemas or capability descriptors) along with schema manifests are validated for authenticity and integrity using signatures to prevent schema tampering or malicious parameter modification. | 3 |
+| **10.4.2** | **Verify that** MCP server error responses do not expose internal details (stack traces, file paths, tokens, tool implementation) to the client or model context, preventing information leakage that could be exploited via the model. | 1 |
 | **10.4.3** | **Verify that** all MCP transports enforce message-framing integrity, strict schema validation, maximum payload sizes, and rejection of malformed, truncated, or interleaved frames to prevent desynchronization or injection attacks. | 2 |
 | **10.4.4** | **Verify that** MCP servers perform strict input validation for all function calls, including type checking, boundary validation, enumeration enforcement, and rejection of unrecognized or oversized parameters. | 2 |
 | **10.4.5** | **Verify that** MCP clients maintain a hash or versioned snapshot of tool definitions and that any change to a tool definition (via `notifications/tools/list_changed` or between sessions) triggers re-approval before the modified tool can be invoked. | 2 |
-| **10.4.6** | **Verify that** MCP server error responses do not expose internal details (stack traces, file paths, tokens, tool implementation) to the client or model context, preventing information leakage that could be exploited via the model. | 1 |
-| **10.4.8** | **Verify that** intermediaries evaluating message content either forward the canonicalized representation they evaluated or reject messages where multiple byte representations could produce different parsed structures. | 3 |
-| **10.4.11** | **Verify that** MCP servers sign tool responses with a unique nonce and timestamp within a bounded time window so that the calling agent can verify origin, integrity, and freshness, preventing spoofing, tampering, and replay of tool responses by intermediaries. | 3 |
+| **10.4.6** | **Verify that** MCP tool and resource schemas (e.g., JSON schemas or capability descriptors) along with schema manifests are validated for authenticity and integrity using signatures to prevent schema tampering or malicious parameter modification. | 3 |
+| **10.4.7** | **Verify that** intermediaries evaluating message content either forward the canonicalized representation they evaluated or reject messages where multiple byte representations could produce different parsed structures. | 3 |
+| **10.4.8** | **Verify that** MCP servers sign tool responses with a unique nonce and timestamp within a bounded time window so that the calling agent can verify origin, integrity, and freshness, preventing spoofing, tampering, and replay of tool responses by intermediaries. | 3 |
 
 ---
 
@@ -78,8 +78,8 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 
 | # | Description | Level |
 | :--: | --- | :---: |
+| **10.6.1** | **Verify that** MCP security controls enforce fail-closed semantics: if tool schema validation, MCP-Protocol-Version negotiation fails, authentication check, or policy evaluation fails or cannot be completed, the default action is to deny the request rather than permit it. | 2 |
 | **10.6.2** | **Verify that** MCP servers expose only allow-listed functions and resources and prohibit dynamic dispatch, reflective invocation, or execution of function names influenced by user or model-provided input. | 3 |
-| **10.6.4** | **Verify that** MCP security controls enforce fail-closed semantics: if tool schema validation, MCP-Protocol-Version negotiation fails, authentication check, or policy evaluation fails or cannot be completed, the default action is to deny the request rather than permit it. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -19,7 +19,7 @@ Verify the identity of users, agents, services, MCP clients/servers, and edge de
 | Agent identity credential rotation and rapid revocation | 9.4.4 |
 | OAuth 2.1 for MCP client authentication | 10.2.1 |
 | MCP server OAuth token validation (issuer, audience, expiration, scope) | 10.2.2 |
-| MCP server registration with explicit ownership | 10.2.3 |
+| MCP server registration with explicit ownership | 10.2.4 |
 | Cryptographically secure MCP session IDs (not used for auth) | 10.2.8 |
 | Edge device mutual authentication with certificate validation | 4.8.1 |
 | Workload attestation for confidential compute | 4.5.3 |
@@ -48,7 +48,7 @@ Enforce access decisions across users, agents, tools, data, and MCP resources us
 | Per-tool MCP invocation access control (argument, token scope) | 10.2.7 |
 | Minimum scope requests with step-up authorization | 10.2.11 |
 | Wildcard and overly broad scope rejection | 10.2.14 |
-| MCP policy enforcement that model output cannot bypass | 10.2.4 |
+| MCP policy enforcement that model output cannot bypass | 10.2.5 |
 | Authorization-aware post-inference filtering (per-caller entitlement enforcement) | 5.4.1 |
 | Citation and attribution validation against caller entitlements | 5.4.2 |
 | Agent PDP runtime isolation from agent execution environment | 5.5.1 |
@@ -91,12 +91,12 @@ Protect data moving between services, agents, tools, and edge devices.
 | --- | --- |
 | Mutual TLS with certificate validation for inter-service communication | 4.3.4 |
 | Authenticated streamable-HTTP transport with TLS 1.3 for MCP | 10.3.1, 10.3.2 |
-| SSE private channel with TLS enforcement | 10.3.3 |
+| SSE private channel with TLS enforcement | 10.3.2 |
 | Encrypted TEE communication channels | 4.5.9 |
 | Authenticated accelerator interconnects (NVLink, PCIe, InfiniBand) | 4.7.7 |
 | Encrypted edge-to-cloud communication with bandwidth throttling | 4.8.6 |
 | Log encryption in transit | 13.1.3 |
-| MCP client minimum protocol version enforcement against downgrade negotiation | 10.3.7 |
+| MCP client minimum protocol version enforcement against downgrade negotiation | 10.3.6 |
 
 **Common pitfalls:** allowing plaintext interconnects in multi-tenant GPU clusters; using SSE over public internet without TLS; not validating certificates on internal service calls.
 
@@ -138,7 +138,7 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 | Execution chain cryptographic signing with non-repudiation timestamps | 9.4.2 |
 | Cryptographic log signatures (write-only / append-only) | 13.1.6 |
 | MCP component signature and checksum verification | 10.1.1 |
-| MCP schema integrity signing and tool definition hash tracking | 10.4.2, 10.4.5 |
+| MCP schema integrity signing and tool definition hash tracking | 10.4.6, 10.4.5 |
 | DAG cryptographic signatures and tamper-evident storage | 13.7.3 |
 | Publisher key pinning per source registry with rotation re-approval | 6.2.2 |
 | Document metadata tag immutability after initial ingestion write | 8.1.7 |
@@ -173,7 +173,7 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | Cross-modal attack detection | 2.4.3 |
 | MCP input type checking, boundary validation, and enumeration enforcement | 10.4.4 |
 | MCP message-framing integrity and payload size limits | 10.4.3 |
-| MCP schema validation for tool and resource integrity | 10.4.2 |
+| MCP schema validation for tool and resource integrity | 10.4.6 |
 | Tool output schema and security policy validation before re-entry to agent | 9.3.3 |
 | MCP tool response validation (prompt injection, context manipulation) | 10.4.1 |
 
@@ -201,7 +201,7 @@ Constrain, filter, and validate model outputs before they reach users or downstr
 | Explicit / non-consensual content filters | 7.7.1 |
 | Authorization-aware post-inference filtering (per-caller entitlement enforcement) | 5.4.1 |
 | Citation and attribution validation against caller entitlements | 5.4.2 |
-| MCP error response sanitization (no stack traces, tokens, internal paths) | 10.4.6 |
+| MCP error response sanitization (no stack traces, tokens, internal paths) | 10.4.2 |
 | Statistical steganographic covert channel detection in generated outputs | 7.3.9 |
 | RAG attribution derived from retrieval metadata, not model-generated | 7.8.3 |
 | Generalization or one-way transformation of model-inferred sensitive attributes (ranges, buckets) to limit reconstruction of training records | 11.4.1 |
@@ -273,8 +273,8 @@ Control network boundaries, traffic flow, and outbound access for AI workloads.
 | MCP egress allow-list with cloud metadata service blocking | 10.5.1 |
 | MCP dynamic dispatch and reflective invocation prevention | 10.6.2 |
 | Default-deny cross-domain agent discovery and calls | 9.8.1 |
-| Origin and Host header validation for DNS rebinding defense | 10.3.4 |
-| SSE public internet blocking | 10.3.3 |
+| Origin and Host header validation for DNS rebinding defense | 10.3.3 |
+| SSE public internet blocking | 10.3.2 |
 
 **Common pitfalls:** allowing AI workloads to reach cloud metadata services; not logging egress traffic for forensic analysis; missing Origin header validation enabling DNS rebinding attacks.
 


### PR DESCRIPTION
Part of the level-ordering cleanup series (see #705).

## Summary

Four sections had ordering or numbering issues:

- **C10.2**: `10.2.5` (L1 - session ID as state not identity) was placed after two L2 controls. Moved to position 3; old `10.2.3`→`10.2.4` and `10.2.4`→`10.2.5`.
- **C10.3**: Gap at `10.3.2` left by a prior reduction pass. Levels were already correct (1, 2, 2, 2, 2, 2); renumbered `10.3.3`-`10.3.7` → `10.3.2`-`10.3.6` to close the gap.
- **C10.4**: `10.4.2` (L3 - schema signing) was placed immediately after the single L1 control before five L2 controls, and `10.4.6` (L1 - error response sanitization) was placed after all of them. Reordered to L1, L1, L2, L2, L2, L3, L3, L3 and closed gaps at `10.4.7`/`10.4.9`/`10.4.10` (new sequence: `10.4.1`-`10.4.8`).
- **C10.6**: `10.6.4` (L2 - fail-closed semantics) was placed after `10.6.2` (L3 - dynamic dispatch prevention). Swapped and renumbered to `10.6.1` (L2) and `10.6.2` (L3), closing the gap at `10.6.1`.

Updated all nine affected Appendix D cross-references.