### PR TITLE
fix(C12): sort controls by level within each section and renumber sequentially

### DIFF
--- a/1.0/en/0x10-C12-Privacy.md
+++ b/1.0/en/0x10-C12-Privacy.md
@@ -28,8 +28,8 @@ Ensure data-subject deletion requests propagate across all AI artifacts and that
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.2.1** | **Verify that** data-subject deletion requests propagate to AI-derived artifacts including training and fine-tuning datasets, model checkpoints, evaluation sets, derived caches, and feature stores within a service level agreement of less than 30 days. Embedding and RAG index propagation is governed by C8.3. | 1 |
-| **12.2.2** | **Verify that** machine-unlearning routines, when claimed, either physically retrain the affected model on the retained data or apply a certified unlearning algorithm with documented (ε, δ) guarantees. | 3 |
-| **12.2.3** | **Verify that** shadow-model or membership-inference evaluation demonstrates that forgotten records influence less than a documented policy threshold of model outputs after unlearning. | 2 |
+| **12.2.2** | **Verify that** shadow-model or membership-inference evaluation demonstrates that forgotten records influence less than a documented policy threshold of model outputs after unlearning. | 2 |
+| **12.2.3** | **Verify that** machine-unlearning routines, when claimed, either physically retrain the affected model on the retained data or apply a certified unlearning algorithm with documented (ε, δ) guarantees. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -351,8 +351,8 @@ Protect personal data and enforce data subject rights throughout the AI lifecycl
 | Feature-importance leakage check on trained models | 12.1.3 |
 | Synthetic data with formal re-identification risk bounds | 12.1.4 |
 | Data deletion propagation across AI artifacts (datasets, checkpoints, caches) | 12.2.1 |
-| Machine unlearning with certified algorithms | 12.2.2 |
-| Shadow-model evaluation of unlearning effectiveness | 12.2.3 |
+| Shadow-model evaluation of unlearning effectiveness | 12.2.2 |
+| Machine unlearning with certified algorithms | 12.2.3 |
 | Privacy-loss accounting with epsilon budget tracking and alerts | 12.3.1 |
 | Empirical (black-box) differential privacy audits | 12.3.2 |
 | Formal differential privacy proofs (including post-training and embeddings) | 12.3.3 |


### PR DESCRIPTION
Part of the level-ordering cleanup series (see #705).

## Summary

One section had an L2 control placed after an L3 control.

- **C12.2**: `12.2.3` (L2 - shadow-model unlearning evaluation) was placed after `12.2.2` (L3 - certified unlearning algorithms). Swapped: L2 is now `12.2.2`, L3 is now `12.2.3`.

All other sections (C12.1, C12.3-C12.6) were already in correct L1->L2->L3 order.

Updated two Appendix D cross-references.