### PR TITLE
fix(C13): sort controls by level within each section and renumber sequentially

### DIFF
--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -13,9 +13,9 @@ Generic logging and operational controls (log storage access control, retention,
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **13.1.1** | **Verify that** AI interactions are logged with security-relevant metadata (e.g. timestamp, user ID, session ID, model version, token count, input hash, system prompt version, confidence score, safety filter outcome, and safety filter decisions) without logging prompt or response content by default. | 1 |
-| **13.1.5** | **Verify that** policy decisions and safety filtering actions are logged with sufficient detail to enable audit and debugging of content moderation systems. | 2 |
-| **13.1.7** | **Verify that** log entries for AI inference events capture a structured, interoperable schema that includes at minimum model identifier, token usage (input and output), provider name, and operation type, to enable consistent AI observability across tools and platforms. | 2 |
-| **13.1.8** | **Verify that** full prompt and response content is logged only when a security-relevant event is detected (e.g., safety filter trigger, prompt injection detection, anomaly flag), or when required by explicit user consent and a documented legal basis. | 2 |
+| **13.1.2** | **Verify that** policy decisions and safety filtering actions are logged with sufficient detail to enable audit and debugging of content moderation systems. | 2 |
+| **13.1.3** | **Verify that** log entries for AI inference events capture a structured, interoperable schema that includes at minimum model identifier, token usage (input and output), provider name, and operation type, to enable consistent AI observability across tools and platforms. | 2 |
+| **13.1.4** | **Verify that** full prompt and response content is logged only when a security-relevant event is detected (e.g., safety filter trigger, prompt injection detection, anomaly flag), or when required by explicit user consent and a documented legal basis. | 2 |
 
 ---
 
@@ -26,13 +26,13 @@ Detect AI-specific attack patterns (jailbreak, prompt injection, model extractio
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **13.2.1** | **Verify that** the system detects and alerts on known jailbreak patterns, prompt injection attempts, and adversarial inputs using signature-based detection. | 1 |
-| **13.2.3** | **Verify that** enriched security events include AI-specific context such as model identifiers, confidence scores, and safety filter decisions. | 2 |
-| **13.2.4** | **Verify that** behavioral anomaly detection identifies unusual conversation patterns, excessive retry attempts, or systematic probing behaviors. | 2 |
-| **13.2.6** | **Verify that** custom rules are included to detect AI-specific threat patterns including coordinated jailbreak attempts, prompt injection campaigns, and model extraction attacks. | 2 |
-| **13.2.7** | **Verify that** automated incident response workflows can isolate compromised models and block malicious users. | 3 |
-| **13.2.8** | **Verify that** session-level conversation trajectory analysis detects multi-turn jailbreak patterns where no individual turn is overtly malicious in isolation but the aggregate conversation exhibits attack indicators. | 3 |
-| **13.2.9** | **Verify that** per-user and per-session token consumption triggers an alert when consumption exceeds defined thresholds. | 2 |
-| **13.2.10** | **Verify that** LLM API traffic is monitored for covert channel indicators, including Base64-encoded payloads, structured non-human query patterns, and communication signatures consistent with malware command-and-control activity using LLM endpoints. | 3 |
+| **13.2.2** | **Verify that** enriched security events include AI-specific context such as model identifiers, confidence scores, and safety filter decisions. | 2 |
+| **13.2.3** | **Verify that** behavioral anomaly detection identifies unusual conversation patterns, excessive retry attempts, or systematic probing behaviors. | 2 |
+| **13.2.4** | **Verify that** custom rules are included to detect AI-specific threat patterns including coordinated jailbreak attempts, prompt injection campaigns, and model extraction attacks. | 2 |
+| **13.2.5** | **Verify that** per-user and per-session token consumption triggers an alert when consumption exceeds defined thresholds. | 2 |
+| **13.2.6** | **Verify that** automated incident response workflows can isolate compromised models and block malicious users. | 3 |
+| **13.2.7** | **Verify that** session-level conversation trajectory analysis detects multi-turn jailbreak patterns where no individual turn is overtly malicious in isolation but the aggregate conversation exhibits attack indicators. | 3 |
+| **13.2.8** | **Verify that** LLM API traffic is monitored for covert channel indicators, including Base64-encoded payloads, structured non-human query patterns, and communication signatures consistent with malware command-and-control activity using LLM endpoints. | 3 |
 
 ---
 
@@ -43,16 +43,16 @@ Monitor and detect drift and degradation across model outputs, input distributio
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **13.3.1** | **Verify that** model performance metrics (accuracy, precision, recall, F1 score, confidence scores, latency, and error rates) are continuously monitored across model versions and time periods and compared against documented baselines. | 1 |
-| **13.3.2** | **Verify that** baseline performance profiles are formally documented and version-controlled, and are reviewed at a defined frequency or after any model or data pipeline change. | 2 |
-| **13.3.3** | **Verify that** automated alerting triggers when performance metrics exceed predefined degradation thresholds or deviate significantly from baselines. | 2 |
-| **13.3.4** | **Verify that** hallucination detection monitors identify and flag instances when model outputs contain factually incorrect, inconsistent, or fabricated information. | 2 |
-| **13.3.5** | **Verify that** data drift detection monitors input distribution changes that may impact model performance, using statistically validated methods appropriate to the data type. | 1 |
+| **13.3.2** | **Verify that** data drift detection monitors input distribution changes that may impact model performance, using statistically validated methods appropriate to the data type. | 1 |
+| **13.3.3** | **Verify that** baseline performance profiles are formally documented and version-controlled, and are reviewed at a defined frequency or after any model or data pipeline change. | 2 |
+| **13.3.4** | **Verify that** automated alerting triggers when performance metrics exceed predefined degradation thresholds or deviate significantly from baselines. | 2 |
+| **13.3.5** | **Verify that** hallucination detection monitors identify and flag instances when model outputs contain factually incorrect, inconsistent, or fabricated information. | 2 |
 | **13.3.6** | **Verify that** schema drift in incoming data (unexpected field additions, removals, type changes, or format variations) is detected and triggers alerting. | 2 |
 | **13.3.7** | **Verify that** concept drift detection identifies changes in the relationship between inputs and expected outputs. | 2 |
-| **13.3.8** | **Verify that** degradation root cause analysis correlates performance drops with data changes, infrastructure issues, or external factors. | 3 |
-| **13.3.9** | **Verify that** sudden unexplained behavioral shifts are distinguished from gradual expected operational drift, with a security escalation path defined for unexplained sudden drift. | 3 |
-| **13.3.10** | **Verify that** performance degradation alerts trigger a defined remediation workflow (e.g., manual review, retraining, or replacement). | 2 |
-| **13.3.11** | **Verify that** hallucination rates are tracked as continuous time-series metrics to enable trend analysis and detection of sustained model degradation. | 2 |
+| **13.3.8** | **Verify that** performance degradation alerts trigger a defined remediation workflow (e.g., manual review, retraining, or replacement). | 2 |
+| **13.3.9** | **Verify that** hallucination rates are tracked as continuous time-series metrics to enable trend analysis and detection of sustained model degradation. | 2 |
+| **13.3.10** | **Verify that** degradation root cause analysis correlates performance drops with data changes, infrastructure issues, or external factors. | 3 |
+| **13.3.11** | **Verify that** sudden unexplained behavioral shifts are distinguished from gradual expected operational drift, with a security escalation path defined for unexplained sudden drift. | 3 |
 
 ---
 
@@ -60,8 +60,8 @@ Monitor and detect drift and degradation across model outputs, input distributio
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **13.4.4** | **Verify that** token usage is tracked at granular attribution levels including per user, per session, per feature endpoint, and per team or workspace. | 2 |
-| **13.4.5** | **Verify that** output-to-input token ratio anomalies are detected and alerted. | 2 |
+| **13.4.1** | **Verify that** token usage is tracked at granular attribution levels including per user, per session, per feature endpoint, and per team or workspace. | 2 |
+| **13.4.2** | **Verify that** output-to-input token ratio anomalies are detected and alerted. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -226,7 +226,7 @@ Enforce consumption bounds to prevent abuse, runaway execution, and denial-of-se
 | Sub-task delegation chain depth limit per execution | 7.4.4 |
 | Query-rate limiting for model extraction and inversion defense, sized to the threat model (e.g., the number of queries required to approximate the model or to reconstruct training records) rather than as a generic API throttle | 11.4.2, 11.5.1 |
 | MCP outbound execution limits, timeouts, recursion limits, and circuit breakers | 10.5.2 |
-| Anomalous usage pattern detection and blocking | 13.2.4, ASVS v5 V2.4 |
+| Anomalous usage pattern detection and blocking | 13.2.3, ASVS v5 V2.4 |
 | Resource quotas (CPU, memory, GPU) for infrastructure | 4.6.1 |
 | Threshold-based protection triggers on resource exhaustion | 4.6.2 |
 
@@ -418,7 +418,7 @@ Capture security-relevant events with integrity protection for forensic analysis
 | Secure, access-controlled log repositories with retention policies | 13.1.2 |
 | Log encryption at rest and in transit | 13.1.3 |
 | PII, credential, and proprietary information redaction in logs | 13.1.4 |
-| Policy decision and safety filtering action logging | 13.1.5 |
+| Policy decision and safety filtering action logging | 13.1.2 |
 | Cryptographic log signatures with write-only storage | 13.1.6 |
 | Audit log context fields sufficient for forensic reconstruction (actor, delegation, policy, parameters, outcomes) | 9.4.3 |
 | Agent action signing with chain ID binding and timestamps | 9.4.2 |
@@ -442,14 +442,14 @@ Detect anomalies, alert on threats, and respond to security incidents in AI syst
 | --- | --- |
 | Jailbreak and prompt injection attempt detection (signature-based) | 13.2.1 |
 | SIEM integration with standard log formats | 13.2.2 |
-| AI-specific event enrichment (model ID, confidence, filter decisions) | 13.2.3 |
-| Behavioral anomaly detection (unusual patterns, excessive retries, systematic probing) | 13.2.4, 13.2.5 |
-| Real-time alerting on policy violations and coordinated attack campaigns | 13.2.6 |
-| Automated incident response (isolation and blocking of compromised models and malicious users) | 13.2.7 |
-| Performance metric monitoring (accuracy, latency, error rate) with alerting | 13.3.1, 13.3.2, 13.3.3 |
-| Performance degradation retraining and replacement workflow triggers | 13.3.10 |
-| Hallucination detection monitoring | 13.3.4 |
-| Hallucination rate time-series tracking | 13.3.11 |
+| AI-specific event enrichment (model ID, confidence, filter decisions) | 13.2.2 |
+| Behavioral anomaly detection (unusual patterns, excessive retries, systematic probing) | 13.2.3, 13.2.5 |
+| Real-time alerting on policy violations and coordinated attack campaigns | 13.2.4 |
+| Automated incident response (isolation and blocking of compromised models and malicious users) | 13.2.6 |
+| Performance metric monitoring (accuracy, latency, error rate) with alerting | 13.3.1, 13.3.3, 13.3.4 |
+| Performance degradation retraining and replacement workflow triggers | 13.3.8 |
+| Hallucination detection monitoring | 13.3.5 |
+| Hallucination rate time-series tracking | 13.3.9 |
 | Data drift and concept drift detection | 13.6.2, 13.6.3 |
 | Model extraction alert generation with query metadata logging | 11.5.2 |
 | Emergent multi-agent behavior detection (oscillation, deadlock, broadcast storms) | 9.8.4 |


### PR DESCRIPTION
Part of the level-ordering cleanup series (see #705).

## Summary

Four sections had ordering or numbering issues.

- **C13.1**: Gaps at `13.1.2`-`13.1.4` and `13.1.6` from prior reductions. Levels already correct (1, 2, 2, 2); renumbered `13.1.5`→`13.1.2`, `13.1.7`→`13.1.3`, `13.1.8`→`13.1.4`.
- **C13.2**: `13.2.9` (L2 - token consumption alerts) was placed after two L3 controls. Moved to position 5 and closed remaining gaps; new sequence `13.2.1`-`13.2.8`.
- **C13.3**: `13.3.5` (L1 - data drift) was placed after three L2 controls. `13.3.10` and `13.3.11` (both L2) were placed after two L3 controls. Reordered to L1, L1, L2×7, L3, L3; new sequence `13.3.1`-`13.3.11`.
- **C13.4**: Gaps at `13.4.1`-`13.4.3` from prior reductions. Levels already correct (2, 2); renumbered `13.4.4`→`13.4.1`, `13.4.5`→`13.4.2`.

Sections C13.5 and C13.7 were already correctly ordered with sequential numbering.

Updated 10 Appendix D cross-references.