### PR TITLE
fix(C14): sort controls by level within each section and renumber sequentially

### DIFF
--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -14,10 +14,10 @@ Provide shutdown or rollback paths when unsafe behavior of the AI system is obse
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **14.1.1** | **Verify that** a manual kill-switch mechanism exists to immediately halt AI model inference and outputs. | 1 |
 | **14.1.2** | **Verify that** override controls are accessible to only to authorized personnel. | 1 |
-| **14.1.3** | **Verify that** rollback procedures can revert to previous model versions or safe-mode operations. | 3 |
-| **14.1.4** | **Verify that** override mechanisms are tested regularly. | 3 |
-| **14.1.5** | **Verify that** the system can be placed into at least two intermediate operational states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined entry triggers and can be exited independently without requiring a full system restart or shutdown. | 2 |
-| **14.1.6** | **Verify that** override and kill-switch commands for autonomous agents are delivered and enforced through a channel that the agent runtime cannot access, intercept, or suppress (e.g., out-of-band infrastructure controls, hypervisor-level signals, network-layer isolation), so that a compromised or manipulated agent cannot prevent its own shutdown. | 2 |
+| **14.1.3** | **Verify that** the system can be placed into at least two intermediate operational states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined entry triggers and can be exited independently without requiring a full system restart or shutdown. | 2 |
+| **14.1.4** | **Verify that** override and kill-switch commands for autonomous agents are delivered and enforced through a channel that the agent runtime cannot access, intercept, or suppress (e.g., out-of-band infrastructure controls, hypervisor-level signals, network-layer isolation), so that a compromised or manipulated agent cannot prevent its own shutdown. | 2 |
+| **14.1.5** | **Verify that** rollback procedures can revert to previous model versions or safe-mode operations. | 3 |
+| **14.1.6** | **Verify that** override mechanisms are tested regularly. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -506,7 +506,7 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 | High-risk model quarantine with human review and sign-off | 6.1.3 |
 | Post-condition outcome checking with containment on mismatch | 9.7.2 |
 | Compensating actions and transactional rollback on failure | 9.2.4 |
-| Intermediate operational degradation states (tool disable, model swap, read-only, source removal) | 14.1.5 |
+| Intermediate operational degradation states (tool disable, model swap, read-only, source removal) | 14.1.3 |
 
 **Common pitfalls:** not binding approval to exact parameters allowing bait-and-switch; confirmation tokens without quick expiration; missing post-condition checks after approved actions execute.
 


### PR DESCRIPTION
Part of the level-ordering cleanup series (see #705).

## Summary

One section had an ordering issue.

- **C14.1**: `14.1.5` (L2 - intermediate operational states) and `14.1.6` (L2 - out-of-band shutdown channel) were placed after two L3 controls (`14.1.3` rollback, `14.1.4` override testing). Moved both L2 controls before the L3 controls; renumbered `14.1.5`→`14.1.3`, `14.1.6`→`14.1.4`, `14.1.3`→`14.1.5`, `14.1.4`→`14.1.6`.

Sections C14.2–C14.7 were already correctly ordered with sequential numbering.

Updated 1 Appendix D cross-reference.