### PR TITLE
fix stale links flagged in #742 audit

### DIFF
--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -75,6 +75,6 @@ Prevent cross-tenant information leakage through AI-specific shared infrastructu
 
 ## References
 
-* [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final)
+* [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)
 * [NIST SP 800-63-3: Digital Identity Guidelines](https://csrc.nist.gov/pubs/sp/800/63/3/final)
 * [I Know What You Asked: Prompt Leakage via KV-Cache Sharing in Multi-Tenant LLM Serving (NDSS 2025)](https://www.ndss-symposium.org/ndss-paper/i-know-what-you-asked-prompt-leakage-via-kv-cache-sharing-in-multi-tenant-llm-serving/)

--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -120,6 +120,6 @@ Reduce cross-domain interference and emergent unsafe collective behavior.
 * [OWASP LLM06:2025 Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/)
 * [OWASP LLM10:2025 Unbounded Consumption](https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/)
 * [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
-* [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final)
+* [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)
 * [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026)
 * [OpenAPI x-agent-trust Extension (OAI Extensions Registry)](https://spec.openapis.org/registry/extension/x-agent-trust.html)

--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -87,4 +87,4 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 
 * [Model Context Protocol (MCP) Specification](https://modelcontextprotocol.io/)
 * [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html)
-* [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/detail/sp/800-207/final)
+* [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)

--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -93,5 +93,5 @@ Detect and prevent security threats arising from proactive (agent-initiated) beh
 
 * [OWASP Top 10 for LLM Applications 2025](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 * [MITRE ATLAS - Adversarial Threat Landscape for AI Systems](https://atlas.mitre.org/)
-* [NIST AI Risk Management Framework (AI RMF 1.0)](https://www.nist.gov/system/files/documents/2023/01/26/AI%20RMF%201.0.pdf)
+* [NIST AI Risk Management Framework (AI RMF 1.0)](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-1.pdf)
 * [NIST AI 100-1 - Artificial Intelligence Risk Management Framework](https://doi.org/10.6028/NIST.AI.100-1)

--- a/1.0/en/0x91-Appendix-B_References.md
+++ b/1.0/en/0x91-Appendix-B_References.md
@@ -6,7 +6,7 @@ The following standards, frameworks, and publications are referenced throughout 
 
 * [NIST AI Risk Management Framework 1.0](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf)
 * [NIST SP 800-218A: Secure Software Development Practices for Generative AI](https://csrc.nist.gov/pubs/sp/800/218/a/final)
-* [ISO/IEC 42001:2023: AI Management Systems Requirements](https://www.iso.org/standard/81230.html)
+* [ISO/IEC 42001:2023: AI Management Systems Requirements](https://www.iso.org/standard/42001)
 * [OWASP Application Security Verification Standard (ASVS)](https://owasp.org/www-project-application-security-verification-standard/)
 * [OWASP Top 10 for Large Language Model Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 * [OWASP Secure Coding Practices: Quick Reference Guide](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/)

--- a/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
+++ b/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
@@ -131,5 +131,5 @@ In practice, policy-based enforcement depends on the availability and quality of
 ## References
 
 * [NIST AI Risk Management Framework 1.0](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf)
-* [ISO/IEC 42001:2023: AI Management Systems Requirements](https://www.iso.org/standard/81230.html)
+* [ISO/IEC 42001:2023: AI Management Systems Requirements](https://www.iso.org/standard/42001)
 * [OWASP Secure Coding Practices: Quick Reference Guide](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/)

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -466,7 +466,7 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 ## References
 
 * [NIST AI Risk Management Framework 1.0](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf)
-* [ISO/IEC 42001:2023: AI Management Systems Requirements](https://www.iso.org/standard/81230.html)
+* [ISO/IEC 42001:2023: AI Management Systems Requirements](https://www.iso.org/standard/42001)
 * [OWASP Top 10 for Large Language Model Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 * [OWASP Application Security Verification Standard (ASVS)](https://owasp.org/www-project-application-security-verification-standard/)
 * [NIST SP 800-218A: Secure Software Development Practices for Generative AI](https://csrc.nist.gov/pubs/sp/800/218/a/final)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This work is licensed under a
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 
-[cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/
+[cc-by-sa]: https://creativecommons.org/licenses/by-sa/4.0/
 [cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
 [cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-blue.svg
 
@@ -33,7 +33,7 @@ This project was founded by [Jim Manico](https://github.com/jmanico). Current pr
 
 ### What AISVS is NOT
 
-* **Not a governance framework.** Governance is well-covered by [NIST AI RMF](https://www.nist.gov/artificial-intelligence/risk-management-framework), [ISO/IEC 42001](https://www.iso.org/standard/81230.html), and EU AI Act compliance guides.
+* **Not a governance framework.** Governance is well-covered by [NIST AI RMF](https://www.nist.gov/itl/ai-risk-management-framework), [ISO/IEC 42001](https://www.iso.org/standard/42001), and EU AI Act compliance guides.
 * **Not a risk management framework.** AISVS provides the technical controls that risk frameworks point to, but does not define risk assessment methodology.
 * **Not a tool recommendation list.** AISVS is vendor-neutral and does not endorse specific products or frameworks.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,4 +14,4 @@ Email jim@owasp.org with the following information:
 4. Current public knowledge of this vulnerability (e.g. related CVE, security advisory, etc.)
 
 ## Our security acknowledgments page
-Acknowledgments: https://github.com/OWASP/AISVS/blob/main/hall_of_fame.md
+Acknowledgments: https://github.com/OWASP/AISVS/blob/main/HALL_OF_FAME.md


### PR DESCRIPTION
Fixes the stale links surfaced in #742.

Closes #742.

## What's in here

Four real 404s:
- `csrc.nist.gov/pubs/detail/sp/800-207/final` -> `csrc.nist.gov/pubs/sp/800/207/final` (NIST SP 800-207 path scheme changed). Touches C05, C09, C10.
- `www.nist.gov/system/files/.../AI%20RMF%201.0.pdf` -> `nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-1.pdf` in C13. The www.nist.gov direct PDF copy is gone; NVL Pubs has the canonical file.
- `www.nist.gov/artificial-intelligence/risk-management-framework` -> `www.nist.gov/itl/ai-risk-management-framework` in README. Same URL pattern we already use in C01, C04, C12.
- `github.com/OWASP/AISVS/blob/main/hall_of_fame.md` -> `HALL_OF_FAME.md` in SECURITY.md (case mismatch with the actual filename on disk).

A couple of cosmetic redirect cleanups while I was in there:
- `iso.org/standard/81230.html` -> `iso.org/standard/42001` in README, Appendix B, C, D. The text already says "ISO/IEC 42001:2023" so this just brings the URL slug in line.
- README `cc-by-sa` license link from `http://` to `https://`.

## What's NOT in here

The 10 MITRE ATLAS deep URLs that return HTTP 404 from a static check are intentionally untouched. The atlas.mitre.org SPA serves the shell and renders the page client-side; the IDs all still exist in upstream `mitre-atlas/atlas-data`. Discussion in the issue thread.

The 7 redirect-but-still-resolving links (modelcontextprotocol.io, docs.anthropic.com -> platform.claude.com, etc.) are also untouched here. They work as cited; happy to do them as a follow-up if anyone wants.

## Verification

Each new URL was checked with `curl -sIL` and returned 200 against the live host.
