### PR TITLE
fix(c7,c13): extend system prompt leakage coverage (fixes #721)

### DIFF
--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -41,7 +41,7 @@ Technical controls to detect and scrub bad content before it is shown to the use
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **7.3.1** | **Verify that** automated classifiers scan every response and block content that matches hate, harassment, or sexual violence categories. | 1 |
-| **7.3.2** | **Verify that** output filters detect and block responses that reproduce verbatim segments of system prompt content. | 2 |
+| **7.3.2** | **Verify that** output filters detect and block responses that disclose system prompt content, including verbatim reproduction and semantically equivalent paraphrases of instructions, role definitions, or policy directives. | 2 |
 | **7.3.3** | **Verify that** LLM client applications prevent model-generated output from triggering automatic outbound requests (e.g., auto-rendered images, iframes, or link prefetching) to attacker-controlled endpoints, for example by disabling automatic external resource loading or restricting it to explicitly allowlisted origins as appropriate. | 2 |
 | **7.3.4** | **Verify that** generated outputs are analyzed for statistical steganographic covert channels (e.g., biased token-choice patterns or output distribution anomalies) that could encode hidden data across the model's valid output space, and that detections are flagged for review. | 3 |
 

--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -28,7 +28,7 @@ Detect AI-specific attack patterns (jailbreak, prompt injection, model extractio
 | **13.2.1** | **Verify that** the system detects and alerts on known jailbreak patterns, prompt injection attempts, and adversarial inputs using signature-based detection. | 1 |
 | **13.2.2** | **Verify that** enriched security events include AI-specific context such as model identifiers, confidence scores, and safety filter decisions. | 2 |
 | **13.2.3** | **Verify that** behavioral anomaly detection identifies unusual conversation patterns, excessive retry attempts, or systematic probing behaviors. | 2 |
-| **13.2.4** | **Verify that** custom rules are included to detect AI-specific threat patterns including coordinated jailbreak attempts, prompt injection campaigns, and model extraction attacks. | 2 |
+| **13.2.4** | **Verify that** custom rules are included to detect AI-specific threat patterns including coordinated jailbreak attempts, prompt injection campaigns, system prompt extraction attempts, and model extraction attacks. | 2 |
 | **13.2.5** | **Verify that** per-user and per-session token consumption triggers an alert when consumption exceeds defined thresholds. | 2 |
 | **13.2.6** | **Verify that** automated incident response workflows can isolate compromised models and block malicious users. | 3 |
 | **13.2.7** | **Verify that** session-level conversation trajectory analysis detects multi-turn jailbreak patterns where no individual turn is overtly malicious in isolation but the aggregate conversation exhibits attack indicators. | 3 |

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -169,7 +169,8 @@ Constrain, filter, and validate model outputs before they reach users or downstr
 | Confidence scoring and uncertainty estimation | 7.2.1 |
 | Confidence threshold gating with fallback messages | 7.2.2 |
 | Output safety classifiers (hate, harassment, violence) | 7.3.1 |
-| PII detection and redaction (post-inference filtering) | 7.3.2, 7.3.3 |
+| System prompt leakage detection in outputs (verbatim and paraphrased) | 7.3.2 |
+| Prevention of auto-triggered outbound requests from model-generated output | 7.3.3 |
 | System prompt and backend data removal from explanations | 7.5.1 |
 | Authorization-aware post-inference filtering (per-caller entitlement enforcement) | 5.4.1 |
 | Citation and attribution validation against caller entitlements | 5.4.2 |
@@ -403,7 +404,7 @@ Detect anomalies, alert on threats, and respond to security incidents in AI syst
 | SIEM integration with standard log formats | 13.2.2 |
 | AI-specific event enrichment (model ID, confidence, filter decisions) | 13.2.2 |
 | Behavioral anomaly detection (unusual patterns, excessive retries, systematic probing) | 13.2.3, 13.2.5 |
-| Real-time alerting on policy violations and coordinated attack campaigns | 13.2.4 |
+| Detection rules for AI-specific attack patterns (jailbreak campaigns, prompt injection, system prompt extraction, model extraction) | 13.2.4 |
 | Automated incident response (isolation and blocking of compromised models and malicious users) | 13.2.6 |
 | Performance metric monitoring (accuracy, latency, error rate) with alerting | 13.3.1, 13.3.3, 13.3.4 |
 | Performance degradation retraining and replacement workflow triggers | 13.3.8 |


### PR DESCRIPTION
Closes #721. Implements the two follow-up actions identified by @jmanico.

## Changes

**`7.3.2` — extend verbatim-only filter to include paraphrased leakage**

Before:
> Verify that output filters detect and block responses that reproduce **verbatim segments** of system prompt content.

After:
> Verify that output filters detect and block responses that disclose system prompt content, including **verbatim reproduction and semantically equivalent paraphrases** of instructions, role definitions, or policy directives.

Real-world system prompt extraction rarely reproduces content verbatim — partial and paraphrased leakage is the common case. The previous wording left that attack surface uncovered.

**`13.2.4` — explicitly scope system prompt extraction as a detected threat pattern**

Before:
> ...coordinated jailbreak attempts, prompt injection campaigns, and **model extraction attacks**.

After:
> ...coordinated jailbreak attempts, prompt injection campaigns, **system prompt extraction attempts**, and model extraction attacks.

C11.5 defines model extraction as weight cloning through API abuse. Without an explicit callout, auditors may exclude system prompt extraction from detection rules. The addition closes the definitional gap Jim identified.

**Appendix D** — fix stale `7.3.2`/`7.3.3` description (labelled "PII detection and redaction" from an older chapter structure; neither control covers PII in the current file) and update `13.2.4` description to reflect extended scope.