### PR TITLE
fix(C11.6): rename section to Runtime Context Contamination Detection

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -72,9 +72,9 @@ Detect and deter unauthorized model cloning through API abuse. Rate limiting, qu
 
 ---
 
-## C11.6 Inference-Time Poisoned-Data Detection
+## C11.6 Runtime Context Contamination Detection
 
-Identify and neutralize backdoored or poisoned inputs at inference time, particularly in systems that consume external data (e.g., RAG pipelines, tool outputs).
+Identify and neutralize manipulated, backdoored, or adversarial data entering the model context at inference time via external sources (e.g., RAG retrieval, tool outputs, MCP server responses, grounding pipelines).
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |


### PR DESCRIPTION
## Summary

Renames C11.6 from **"Inference-Time Poisoned-Data Detection"** to **"Runtime Context Contamination Detection"** and updates the section description accordingly.

### What changed

- **Section heading** (`## C11.6`): reflects the broader threat surface beyond training-data poisoning
- **Section description**: explicitly enumerates the external sources that can introduce adversarial data at inference time (RAG retrieval, tool outputs, MCP server responses, grounding pipelines)
- No controls added, removed, or renumbered; no level ordering affected

### Why

The old title implied the section was limited to detecting poisoned training data surfacing at inference time. The actual controls cover any runtime contamination of the model context from external sources, including prompt-injection via RAG, malicious tool outputs, and MCP server responses. The new title and description make that scope immediately clear.

Closes #723