### PR TITLE
fix(C14): close control ID gaps in C14.1 and C14.2

### DIFF
--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -15,9 +15,9 @@ Provide shutdown or rollback paths when unsafe behavior of the AI system is obse
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **14.1.1** | **Verify that** a manual kill-switch mechanism exists to immediately halt AI model inference and outputs. | 1 |
-| **14.1.4** | **Verify that** kill-switch and intermediate-state mechanisms are exercised at a defined frequency, and that each test confirms the system reaches the target state within the documented response time and that all dependent components (e.g., agent runtimes, tool/MCP servers, retrieval connectors) transition as specified. | 2 |
-| **14.1.5** | **Verify that** the system can be placed into at least two intermediate operational states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined entry triggers and can be exited independently without requiring a full system restart or shutdown. | 2 |
-| **14.1.6** | **Verify that** override and kill-switch commands for autonomous agents are delivered and enforced through a channel that the agent runtime cannot access, intercept, or suppress (e.g., out-of-band infrastructure controls, hypervisor-level signals, network-layer isolation), so that a compromised or manipulated agent cannot prevent its own shutdown. | 2 |
+| **14.1.2** | **Verify that** kill-switch and intermediate-state mechanisms are exercised at a defined frequency, and that each test confirms the system reaches the target state within the documented response time and that all dependent components (e.g., agent runtimes, tool/MCP servers, retrieval connectors) transition as specified. | 2 |
+| **14.1.3** | **Verify that** the system can be placed into at least two intermediate operational states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined entry triggers and can be exited independently without requiring a full system restart or shutdown. | 2 |
+| **14.1.4** | **Verify that** override and kill-switch commands for autonomous agents are delivered and enforced through a channel that the agent runtime cannot access, intercept, or suppress (e.g., out-of-band infrastructure controls, hypervisor-level signals, network-layer isolation), so that a compromised or manipulated agent cannot prevent its own shutdown. | 2 |
 
 ---
 
@@ -28,7 +28,7 @@ Define which AI decisions and agent actions require human approval so that runti
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **14.2.1** | **Verify that** a documented human oversight policy defines which AI decisions and agent actions are classified as high-risk, the criteria used to make that determination, and the approval authority required before execution. | 1 |
-| **14.2.3** | **Verify that** when a human-approval gate (per C14.2.1 and C9.2) is not satisfied within the defined approval time-to-live, the system applies a documented default action, that the default action is fail-closed (blocking the action) unless an alternative is explicitly authorized in the high-risk action policy, and that any non-fail-closed default is itself classified and approved as a high-risk policy decision. | 2 |
+| **14.2.2** | **Verify that** when a human-approval gate (per C14.2.1 and C9.2) is not satisfied within the defined approval time-to-live, the system applies a documented default action, that the default action is fail-closed (blocking the action) unless an alternative is explicitly authorized in the high-risk action policy, and that any non-fail-closed default is itself classified and approved as a high-risk policy decision. | 2 |
 
 ---
 
@@ -38,7 +38,7 @@ Capture human-initiated oversight events so that override and mode-change action
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **14.3.1** | **Verify that** kill-switch activations, intermediate operational state transitions, and override commands are logged with the operator identity, the channel used (including whether the out-of-band channel per C14.1.6 was invoked), the originating trigger or justification, the prior and resulting system state, and the timestamp. | 1 |
+| **14.3.1** | **Verify that** kill-switch activations, intermediate operational state transitions, and override commands are logged with the operator identity, the channel used (including whether the out-of-band channel per C14.1.4 was invoked), the originating trigger or justification, the prior and resulting system state, and the timestamp. | 1 |
 
 ## References
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -449,15 +449,15 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 | High-impact action approval gates (deploy, delete, financial, notify) | 9.2.1 |
 | Approval parameter binding (prevent approve-one-execute-another) | 9.2.2 |
 | High-impact intent confirmation with exact parameter binding and quick expiration | 9.2.3 |
-| Documented fail-closed default when human approval is not received within TTL | 14.2.3 |
+| Documented fail-closed default when human approval is not received within TTL | 14.2.2 |
 | Human review on anomaly detection | 11.6.3 |
 | High-risk model quarantine with human review and sign-off | 6.1.3 |
 | Post-condition outcome checking with containment on mismatch | 9.7.2 |
 | Compensating actions and transactional rollback on failure | 9.2.4 |
 | Manual kill-switch to halt model inference and outputs | 14.1.1 |
-| Intermediate operational degradation states (tool disable, model swap, read-only, source removal) | 14.1.5 |
-| Recurring exercise of kill-switch and intermediate-state mechanisms with response-time verification | 14.1.4 |
-| Out-of-band override and kill-switch channel for autonomous agents | 14.1.6 |
+| Intermediate operational degradation states (tool disable, model swap, read-only, source removal) | 14.1.3 |
+| Recurring exercise of kill-switch and intermediate-state mechanisms with response-time verification | 14.1.2 |
+| Out-of-band override and kill-switch channel for autonomous agents | 14.1.4 |
 
 **Common pitfalls:** documenting a high-risk action policy that is never wired to a runtime gate; binding approval to a hash of parameters without binding to identity or context (replay across sessions); confirmation tokens without quick expiration; defaulting to fail-open when the approver does not respond, silently bypassing the gate; assuming an in-band kill-switch will work against a compromised agent; kill-switch implemented but never exercised, atrophying until the moment it is needed.
 


### PR DESCRIPTION
## Summary

Closes two control ID gaps in C14 that were introduced when the C14 rewrite removed controls mid-section without renumbering the ones that remained.

### Gaps fixed

| Section | Was | Now |
|---|---|---|
| C14.1 | jumps 14.1.1 → 14.1.4 | sequential 14.1.1 → 14.1.4 |
| C14.2 | jumps 14.2.1 → 14.2.3 | sequential 14.2.1 → 14.2.2 |

### Renumbering

- `14.1.4` → `14.1.2` (kill-switch exercise and response-time verification)
- `14.1.5` → `14.1.3` (intermediate operational states)
- `14.1.6` → `14.1.4` (out-of-band override channel for autonomous agents)
- `14.2.3` → `14.2.2` (fail-closed default on approval timeout)

### Cross-references updated

- Inline reference `C14.1.6` in control `14.3.1` updated to `C14.1.4`
- Four Appendix D rows updated to match new IDs

No control text, levels, or sections were changed.