### PR TITLE
fix(C2,C11): add multilingual classifier coverage control and jailbreak probes

### DIFF
--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -46,7 +46,8 @@ Syntactically valid prompts may request disallowed content such as policy-violat
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.3.1** | **Verify that** a content classifier scores every inbound prompt for violence, self-harm, hate, sexual content and illegal requests, with configurable thresholds, before the prompt is included in model context. | 1 |
 | **2.3.2** | **Verify that** inputs which violate policies are rejected so they do not propagate to downstream model or tool/MCP calls. | 1 |
-| **2.3.3** | **Verify that** screening logs include classifier confidence scores and policy category tags with applied stage (pre-prompt or post-response) and trace metadata (source, tool or MCP server, agent ID, session) for SOC correlation and future red-team replay. | 3 |
+| **2.3.3** | **Verify that** content screening classifiers are evaluated for effectiveness across the languages the system is configured or marketed to support, with coverage gaps documented and compensating controls (e.g., character-set restrictions, conservative threshold adjustments, or human review routing) applied where classifiers lack sufficient coverage. | 2 |
+| **2.3.4** | **Verify that** screening logs include classifier confidence scores and policy category tags with applied stage (pre-prompt or post-response) and trace metadata (source, tool or MCP server, agent ID, session) for SOC correlation and future red-team replay. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -15,7 +15,7 @@ Guard against harmful or policy-breaking outputs through systematic testing and 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.1.1** | **Verify that** refusal and safe-completion guardrails are enforced to prevent the model from generating disallowed content categories. | 1 |
-| **11.1.2** | **Verify that** an alignment test suite (red-team prompts, jailbreak probes, disallowed-content checks) is version-controlled and run on every model update or release. | 1 |
+| **11.1.2** | **Verify that** an alignment test suite (red-team prompts, jailbreak probes, disallowed-content checks, and multilingual and language-switching jailbreak probes) is version-controlled and run on every model update or release. | 1 |
 | **11.1.3** | **Verify that** an automated evaluator measures harmful-content rate and flags regressions beyond a defined threshold. | 2 |
 | **11.1.4** | **Verify that** alignment and safety training procedures (e.g., RLHF, constitutional AI, or equivalent) are documented and reproducible. | 2 |
 | **11.1.5** | **Verify that** alignment evaluation includes assessments for evaluation awareness, where the model may behave differently when it detects it is being tested versus deployed. | 3 |

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -142,6 +142,7 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | Encoding and representation smuggling detection and mitigation | 2.2.3 |
 | Content classifiers for inbound prompts (hate, violence, sexual, illegal) | 2.3.1 |
 | Policy-violating input rejection before model propagation | 2.3.2 |
+| Cross-lingual classifier coverage evaluation and gap remediation | 2.3.3 |
 | User-specific and agent-aware policy screening | 2.1.9 |
 | Extracted and hidden content from non-text inputs treated as untrusted | 2.4.1 |
 | Adversarial perturbation detection on image/audio inputs | 2.4.2 |


### PR DESCRIPTION
Closes #750. Supersedes #751 (fixes the duplicate control ID and compound requirement issues flagged in review).

## Changes

### C2.3.3 — new control (L2)
Adds a dedicated control for cross-lingual classifier coverage evaluation, separated from the runtime scoring requirement in C2.3.1. Former C2.3.3 (screening logs) renumbered to C2.3.4.

> **Verify that** content screening classifiers are evaluated for effectiveness across the languages the system is configured or marketed to support, with coverage gaps documented and compensating controls (e.g., character-set restrictions, conservative threshold adjustments, or human review routing) applied where classifiers lack sufficient coverage.

Scoped to "languages the system is configured or marketed to support" rather than "all languages the model may process" (which would be infeasible for frontier models covering hundreds of languages).

### C11.1.2 — amendment
Extends the existing red-team test suite requirement to explicitly include multilingual and language-switching jailbreak probes.

### Appendix D
Adds the new 2.3.3 row.

## What this does not do
Does not add a runtime "translation demand detection" control — that framing from the original issue is too broad and would produce significant false positives. The translation-as-wrapper attack is a prompt injection variant already covered by C2.1.1; this change closes the underlying classifier coverage gap that makes it effective.