### PR TITLE
fix(#174): non-requirement text cleanup pass

### DIFF
--- a/1.0/en/0x01-Frontispiece.md
+++ b/1.0/en/0x01-Frontispiece.md
@@ -8,7 +8,7 @@ Every requirement in AISVS has been developed from the ground up to reflect the 
 
 ## Copyright and License
 
-Version 1.0 (Working Draft), 2025
+Version 1.0 (Working Draft), 2026
 
 [![CC BY-SA 4.0](https://licensebuttons.net/l/by-sa/4.0/88x31.png)](https://creativecommons.org/licenses/by-sa/4.0/)
 
@@ -25,25 +25,6 @@ For any reuse or distribution, you must clearly communicate the license terms of
 
 ## Contributors and Reviewers
 
-The following individuals have contributed to the AISVS through requirements authoring, review, or technical feedback:
+We have included a list of contributors and reviewers in [Appendix E](0x94-Appendix-E_Contributors.md).
 
-* [Josh Beck](https://github.com/Josh-Beck)
-* [Blake Gatto](https://github.com/BlakeGatto)
-* [Khalid Walid Alamri](https://github.com/khalidwalidalamri)
-* [Tetsuo Seto](https://github.com/tetsuoseto)
-* [Jim Schwoebel](https://github.com/jim-schwoebel)
-* [Vineeth Sai](https://github.com/vineethsai)
-* [Almog](https://github.com/almogbhl)
-* [Deepak Pandey](https://github.com/deepakrpandey12)
-* [Tametomo](https://github.com/Tametomo)
-* [Hari Mukundhan](https://github.com/harimukundhan)
-* [Jerry Hoff](https://github.com/jerryhoff)
-* [RogueValley](https://github.com/RogueValley)
-* [Mamicidal](https://github.com/mamicidal)
-* [Stu Small](https://github.com/stusmall)
-* [Wiljav](https://github.com/wiljav)
-* [Hackwither](https://github.com/hackwither)
-* [Kattn](https://github.com/kattn)
-* [mbhatt1](https://github.com/mbhatt1)
-* [cciprofm](https://github.com/cciprofm)
-* [thornshadow99](https://github.com/thornshadow99)
+If a credit is missing, please open an issue or pull request on GitHub to be recognized in future updates.

--- a/1.0/en/0x02-Preface.md
+++ b/1.0/en/0x02-Preface.md
@@ -32,19 +32,20 @@ Each of the 14 requirement chapters follows the same format:
 * **Requirement Tables.** Individual requirements are presented in tables with the following columns:
 
 | Column | Meaning |
-|---|---|
+| --- | --- |
 | **#** | Unique requirement identifier (e.g., 1.1.1, 9.3.2). |
 | **Description** | The requirement text, always beginning with "Verify that" to emphasize testability. |
 | **Level** | The verification level (1, 2, or 3) indicating the depth of assurance required. |
 
 ### Appendices
 
-Four appendices support the core requirements:
+Five appendices support the core requirements:
 
 * **Appendix A (Glossary)** defines key terms and acronyms used throughout the standard.
 * **Appendix B (References)** lists external standards, research, and frameworks referenced by AISVS requirements.
 * **Appendix C (AI-Assisted Secure Coding)** provides controls for the safe use of AI coding tools during software development.
 * **Appendix D (AI Security Controls Inventory)** is a cross-reference of every defense technique in AISVS, organized by security control category (authentication, authorization, encryption, input validation, and so on) with mappings back to specific requirement identifiers.
+* **Appendix E (Contributors)** lists the project leads, contributors, and reviewers who have shaped this standard.
 
 ## Scope Boundaries
 

--- a/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
+++ b/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
@@ -11,7 +11,7 @@ This chapter defines baseline organizational controls for the safe and effective
 Integrate AI tooling into the organization's secure-software-development lifecycle (SSDLC) without weakening existing security gates.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **AC.1.1** | **Verify that** a documented workflow describes when and how AI tools may generate, refactor, or review code. | 1 |
 | **AC.1.2** | **Verify that** the workflow maps to each SSDLC phase (design, implementation, code review, testing, deployment). | 2 |
 | **AC.1.3** | **Verify that** metrics (e.g., vulnerability density, mean-time-to-detect) are collected on AI-produced code and compared to human-only baselines. | 3 |
@@ -23,7 +23,7 @@ Integrate AI tooling into the organization's secure-software-development lifecyc
 Ensure AI coding tools are evaluated for security capabilities, risk, and supply-chain impact before adoption.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **AC.2.1** | **Verify that** a threat model for each AI tool identifies misuse, model-inversion, data leakage, and dependency-chain risks. | 1 |
 | **AC.2.2** | **Verify that** tool evaluations include static/dynamic analysis of any local components and assessment of SaaS endpoints (TLS, authentication/authorization, logging). | 2 |
 | **AC.2.3** | **Verify that** evaluations follow a recognized framework and are re-performed after major version changes. | 3 |
@@ -35,7 +35,7 @@ Ensure AI coding tools are evaluated for security capabilities, risk, and supply
 Prevent leakage of secrets, proprietary code, and personal data when constructing prompts or contexts for AI models.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **AC.3.1** | **Verify that** written guidance prohibits sending secrets, credentials, or classified data in prompts. | 1 |
 | **AC.3.2** | **Verify that** technical controls (client-side redaction, approved context filters) automatically strip sensitive artifacts. | 2 |
 | **AC.3.3** | **Verify that** prompts and responses are tokenized, encrypted in transit and at rest, and retention periods comply with data-classification policy. | 3 |
@@ -47,7 +47,7 @@ Prevent leakage of secrets, proprietary code, and personal data when constructin
 Detect and remediate vulnerabilities introduced by AI output before the code is merged or deployed.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **AC.4.1** | **Verify that** AI-generated code is always subjected to human code review. | 1 |
 | **AC.4.2** | **Verify that** automated scanners (SAST/IAST/DAST) run on every pull request containing AI-generated code and block merges on critical findings. | 2 |
 | **AC.4.3** | **Verify that** differential fuzz testing or property-based tests prove security-critical behaviors (e.g., input validation, authorization logic). | 3 |
@@ -59,10 +59,10 @@ Detect and remediate vulnerabilities introduced by AI output before the code is 
 Provide auditors and developers with insight into why a suggestion was made and how it evolved.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **AC.5.1** | **Verify that** prompt/response pairs are logged with commit IDs. | 1 |
 | **AC.5.2** | **Verify that** developers can surface model citations (training snippets, documentation) supporting a suggestion. | 2 |
-| **AC.5.3** | **Verify that** explainability reports are stored with design artifacts and referenced in security reviews, satisfying ISO/IEC 42001 traceability principles. | 3 |
+| **AC.5.3** | **Verify that** explainability reports are stored with design artifacts and referenced in security reviews, satisfying ISO/IEC 42001 traceability principles. | 3 |
 
 ---
 
@@ -71,7 +71,7 @@ Provide auditors and developers with insight into why a suggestion was made and 
 Improve model security performance over time while preventing negative drift.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **AC.6.1** | **Verify that** developers can flag insecure or non-compliant suggestions, and that flags are tracked. | 1 |
 | **AC.6.2** | **Verify that** aggregated feedback informs periodic fine-tuning or retrieval-augmented generation with vetted secure-coding corpora (e.g., OWASP Cheat Sheets). | 2 |
 | **AC.6.3** | **Verify that** a closed-loop evaluation harness runs regression tests after every fine-tune; security metrics must meet or exceed prior baselines before deployment. | 3 |
@@ -83,7 +83,7 @@ Improve model security performance over time while preventing negative drift.
 Ensure that AI-generated infrastructure-as-code (IaC), CI/CD workflows, deployment configurations, and security policy artifacts are subject to appropriate validation and governance controls.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **AC.7.1** | **Verify that** AI-generated infrastructure-as-code, CI/CD workflows, and security policy artifacts are clearly identified and tracked. | 1 |
 | **AC.7.2** | **Verify that** AI-generated infrastructure and pipeline configurations require appropriate review and approval prior to execution. | 2 |
 | **AC.7.3** | **Verify that** AI-generated infrastructure and workflow changes are subject to security validation, configuration checks, and policy enforcement equivalent to or stricter than application code. | 3 |
@@ -95,7 +95,7 @@ Ensure that AI-generated infrastructure-as-code (IaC), CI/CD workflows, deployme
 Ensure that autonomous AI agents involved in code or configuration generation are subject to appropriate separation of duties and cannot independently approve or promote their own changes.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **AC.8.1** | **Verify that** autonomous agents cannot approve, merge, sign, or deploy artifacts that they have generated. | 1 |
 | **AC.8.2** | **Verify that** AI systems operate with scoped identities and permissions that prevent self-promotion of generated artifacts across environments. | 2 |
 | **AC.8.3** | **Verify that** separation of duties is enforced between artifact generation, review, approval, and deployment stages for AI-generated changes. | 3 |
@@ -107,7 +107,7 @@ Ensure that autonomous AI agents involved in code or configuration generation ar
 Ensure that deployment and promotion pipelines validate the origin and generation history of AI-generated artifacts before they are promoted.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **AC.9.1** | **Verify that** AI-generated artifacts include origin and generation metadata identifying the AI system that produced them, the generation context, and associated audit records. | 1 |
 | **AC.9.2** | **Verify that** deployment pipelines validate the presence and integrity of origin and generation metadata for AI-generated artifacts prior to promotion. | 2 |
 | **AC.9.3** | **Verify that** artifacts lacking required origin and generation information, or produced by untrusted AI systems or environments, are rejected during deployment. | 3 |
@@ -121,7 +121,7 @@ Ensure that AI-generated artifacts include complete and consistent origin and ge
 In practice, policy-based enforcement depends on the availability and quality of origin and generation records. Incomplete or inconsistent records can lead to missed detections or enforcement gaps. These controls ensure that origin tracking is treated as a first-class requirement and validated prior to artifact acceptance.
 
 | # | Description | Level |
-|:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
+| :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **AC.10.1** | **Verify that** AI-generated artifacts include required origin and generation fields (e.g., model identity, generation context, human involvement, and session identifiers). | 1 |
 | **AC.10.2** | **Verify that** origin and generation metadata is validated for completeness and consistency (e.g., no missing or ambiguous fields, normalized representations). | 2 |
 | **AC.10.3** | **Verify that** artifacts with incomplete, inconsistent, or unverifiable origin and generation metadata are rejected prior to merge or deployment. | 3 |

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -361,7 +361,7 @@ Test for and defend against evasion, extraction, inversion, poisoning, and align
 | Self-modification reversibility and integrity verification enabling rollback to known-good state | 11.9.4 |
 | Safety-violation feedback pipeline integrity, poisoning detection, and human review gates | 11.9.6 |
 | Data augmentation with perturbed inputs for training robustness | 1.4.6 |
-| RONI (Reject On Negative Influence) filtering -- influence-score each training sample and reject those that degrade held-out performance beyond a threshold (implementation example for 1.4.2) | 1.4.2 |
+| RONI (Reject On Negative Influence) filtering — influence-score each training sample and reject those that degrade held-out performance beyond a threshold (implementation example for 1.4.2) | 1.4.2 |
 | Gradient fingerprinting / per-sample gradient analysis — detect abnormal gradient norms or directions indicating poisoned samples during training (implementation example for 1.4.2) | 1.4.2 |
 | Activation clustering — cluster intermediate activations to detect backdoor-associated subpopulations (implementation example for 1.4.2) | 1.4.2 |
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Organizations should select a target level based on the risk profile of their AI
 * [Appendix B: References](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x91-Appendix-B_References.md)
 * [Appendix C: AI-Assisted Secure Coding](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md)
 * [Appendix D: AI Security Controls Inventory](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md)
+* [Appendix E: Contributors](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x94-Appendix-E_Contributors.md)
 
 ---
 


### PR DESCRIPTION
Closes #174

## Changes

**Frontispiece (`0x01-Frontispiece.md`)**
- Version year corrected: `2025` → `2026`
- Inline contributor list replaced with a reference to Appendix E, following the same pattern as the ASVS 5.0 Frontispiece

**Preface (`0x02-Preface.md`)**
- `Four appendices` → `Five appendices`
- Appendix E added to the appendix list
- Pre-existing MD060 table separator row fixed

**README**
- Appendix E link added to the Appendices section

**Appendix C (`0x92-Appendix-C_AI_for_Code_Generation.md`)**
- Non-breaking space (U+00A0) before `ISO/IEC 42001` in AC.5.3 replaced with a regular space
- Pre-existing MD060 table separator rows fixed throughout (all tables now use spaced pipes)

**Appendix D (`0x93-Appendix-D_AI_Security_Controls_Inventory.md`)**
- Mixed dash style resolved: the lone `--` in the RONI row replaced with `—` to match the five surrounding rows