### PR TITLE
fix(692): consolidate scope notes at top of C10 (MCP Security)

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -4,6 +4,8 @@
 
 Ensure secure discovery, authentication, authorization, transport, and use of MCP-based tool and resource integrations to prevent context confusion, unauthorized tool invocation, or cross-tenant data exposure.
 
+> **Scope:** This chapter focuses on MCP-protocol-specific controls. General agent authorization principles (model output must not override access control, delegation context, continuous authorization) are covered in C9.6; OAuth details in ASVS v5 V10. Execution budgets, circuit breakers, and human approval gates for agent-initiated actions are covered in C9.1 and C9.2. General agent sandbox isolation is covered in C9.3; multi-agent tenant and environment isolation in C9.8.
+
 ---
 
 ## C10.1 Component Integrity & Supply Chain Hygiene
@@ -17,8 +19,6 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ---
 
 ## C10.2 Authentication & Authorization
-
-> **Scope note:** General agent authorization principles (model output must not override access control, delegation context, continuous authorization) are covered in C9.6. Controls in this section address MCP-protocol-specific authentication and authorization mechanisms. Refer to ASVSv5 V10 for OAuth specific details.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -64,8 +64,6 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 
 ## C10.5 Outbound Access & Agent Execution Safety
 
-> **Scope note:** Execution budgets, circuit breakers, and human approval gates for agent-initiated actions (including MCP tool invocations) are covered in C9.1 and C9.2. Controls in this section address MCP-specific outbound network constraints.
-
 | # | Description | Level |
 | :--: | --- | :---: |
 | **10.5.1** | **Verify that** MCP servers may only initiate outbound requests to approved internal or external destinations following least-privilege egress policies and cannot access arbitrary network targets or internal cloud metadata services. | 2 |
@@ -73,8 +71,6 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ---
 
 ## C10.6 Transport Restrictions & High-Risk Boundary Controls
-
-> **Scope note:** General agent sandbox isolation is covered in C9.3. Tenant and environment isolation for multi-agent systems is covered in C9.8. Controls in this section address MCP-specific transport and dispatch restrictions.
 
 | # | Description | Level |
 | :--: | --- | :---: |

--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -2,9 +2,7 @@
 
 ## Control Objective
 
-Ensure secure discovery, authentication, authorization, transport, and use of MCP-based tool and resource integrations to prevent context confusion, unauthorized tool invocation, or cross-tenant data exposure.
-
-> **Scope:** This chapter focuses on MCP-protocol-specific controls. General agent authorization principles (model output must not override access control, delegation context, continuous authorization) are covered in C9.6; OAuth details in ASVS v5 V10. Execution budgets, circuit breakers, and human approval gates for agent-initiated actions are covered in C9.1 and C9.2. General agent sandbox isolation is covered in C9.3; multi-agent tenant and environment isolation in C9.8.
+Ensure secure discovery, authentication, authorization, transport, and use of MCP-based tool and resource integrations to prevent context confusion, unauthorized tool invocation, or cross-tenant data exposure. This chapter covers MCP-protocol-specific controls; general agent authorization is in C9.6, OAuth details in ASVS v5 V10, execution budgets and human approval gates in C9.1–C9.2, sandbox isolation in C9.3, and multi-agent tenant and environment isolation in C9.8.
 
 ---
 


### PR DESCRIPTION
Closes part of #692.

Three mid-chapter scope notes (in C10.2, C10.5, and C10.6) are removed from their section descriptions and replaced with a single `> **Scope:**` note at the top of the chapter.

**Before:** Three separate `> **Scope note:**` blockquotes inside individual sections.
**After:** One consolidated `> **Scope:**` note immediately after the control objective.