### PR TITLE
docs(Appendix-B): add Agent Threat Rules reference

### DIFF
--- a/1.0/en/0x91-Appendix-B_References.md
+++ b/1.0/en/0x91-Appendix-B_References.md
@@ -11,6 +11,7 @@ The following standards, frameworks, and publications are referenced throughout 
 * [OWASP Top 10 for Large Language Model Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 * [OWASP Secure Coding Practices: Quick Reference Guide](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/)
 * [MITRE ATLAS: Adversarial Threat Landscape for AI Systems](https://atlas.mitre.org/)
+* [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) — Open detection standard providing executable Sigma/YARA-style YAML rules for AI agent threats, with cross-walks to OWASP Agentic Top 10, MITRE ATLAS, NIST AI RMF, and SAFE-MCP.
 
 ## Specifications and Protocols
 


### PR DESCRIPTION
Adding Agent Threat Rules (ATR) to Appendix B References. The Contributing guide invites improvements to references so each chapter can point at the best available standards, frameworks, and research.

ATR is an open detection standard for AI agent threats: 330 Sigma/YARA-style YAML rules covering prompt injection, tool poisoning, MCP attacks, and skill compromise. The corpus is fully cross-walked to several frameworks AISVS already references — MITRE ATLAS (100/113 mapped), NIST AI RMF (100% function coverage), OWASP Agentic Top 10 (10/10), and SAFE-MCP (78/85). That makes it a useful pointer for readers who want executable rules to test the requirements in C02 (Input Validation), C09 (Orchestration and Agentic Action), C10 (MCP Security), and C13 (Monitoring and Logging).

ATR is shipped in production at Cisco AI Defense (skill-scanner) and Microsoft agent-governance-toolkit (PolicyEvaluator examples), so the rule format and corpus are stable.

Repo: https://github.com/Agent-Threat-Rule/agent-threat-rules
License: Apache-2.0

Diff is one line in Appendix B, formatted to match neighboring entries. No requirements are added or modified, so this stays inside the post-freeze editorial-fix scope. Happy to move this to an issue first if maintainers prefer the issue-then-PR flow.