### PR TITLE
fix(#693): split compound requirements and reframe negative requirements

### DIFF
--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -15,7 +15,9 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.1.1** | **Verify that** all external or derived inputs that may steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier before being included in prompts or used to trigger actions. | 1 |
-| **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. This enforcement must be preserved across multi-step interactions and tool-augmented workflows. In such cases, prompt composition or intermediate outputs must not allow user-controlled content to influence or override system or developer instructions. | 1 |
+| **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. | 1 |
+| **2.1.10** | **Verify that** instruction hierarchy enforcement is preserved across multi-step interactions and tool-augmented workflows. | 1 |
+| **2.1.11** | **Verify that** prompt composition and intermediate outputs in multi-step or tool-augmented workflows do not allow user-controlled content to influence or override system or developer instructions. | 1 |
 | **2.1.3** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, and that inputs exceeding token limits are rejected rather than silently truncated, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
 | **2.1.4** | **Verify that** the system implements a character set limitation for user inputs to model prompts, allowing only characters that are explicitly required for business purposes using an allow-list approach. | 1 |
 | **2.1.5** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
@@ -32,7 +34,8 @@ AI models process text through tokenizers and embeddings that can be exploited v
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.2.1** | **Verify that** input normalization (Unicode NFC canonicalization, homoglyph mapping, removal of control and invisible Unicode characters, and bidirectional text neutralization) is applied before tokenization or embedding, and that inputs which still contain suspicious encoding artifacts after normalization are rejected or flagged for review. | 1 |
+| **2.2.1** | **Verify that** input normalization (Unicode NFC canonicalization, homoglyph mapping, removal of control and invisible Unicode characters, and bidirectional text neutralization) is applied before tokenization or embedding. | 1 |
+| **2.2.4** | **Verify that** inputs which still contain suspicious encoding artifacts after normalization are rejected or flagged for review. | 1 |
 | **2.2.2** | **Verify that** inputs identified as adversarial by any detection mechanism are blocked from inclusion in prompts or execution of actions. | 1 |
 | **2.2.3** | **Verify that** encoding and representation smuggling in both inputs and outputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) are detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
 

--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -86,7 +86,8 @@ Fine-tuning pipelines are high-privilege operations that can alter deployed mode
 | **3.6.1** | **Verify that** reward models used in RLHF fine-tuning are versioned, cryptographically signed, and integrity-verified before use in a training run. | 2 |
 | **3.6.2** | **Verify that** initiating a fine-tuning or retraining run requires authorization from a person who did not request the run (separation of duties). | 3 |
 | **3.6.3** | **Verify that** RLHF training stages include automated detection of reward hacking or reward model over-optimization (e.g., held-out human-preference probe sets, divergence thresholds, or KL penalty monitoring), with the run blocked from promotion if detection thresholds are exceeded. | 3 |
-| **3.6.4** | **Verify that** in multi-stage fine-tuning pipelines, each stage's output is integrity-verified before the next stage consumes it, and intermediate checkpoints are registered as distinct artifacts enabling per-stage rollback. | 3 |
+| **3.6.4** | **Verify that** in multi-stage fine-tuning pipelines, each stage's output is integrity-verified before the next stage consumes it. | 3 |
+| **3.6.5** | **Verify that** intermediate fine-tuning checkpoints are registered as distinct artifacts with version or digest identifiers, enabling per-stage rollback. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -40,9 +40,11 @@ Constrain tool execution, loading, and outputs to prevent unauthorized system ac
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.3.1** | **Verify that** each tool/plugin executes in an isolated sandbox (container/VM/WASM/OS sandbox) with least-privilege filesystem, network egress, and syscall permissions appropriate to the tool's function. | 1 |
-| **9.3.2** | **Verify that** per-tool quotas and timeouts (CPU, memory, disk, egress, execution time) are enforced and logged, and that quota or timeout breaches fail closed by terminating the tool execution rather than continuing with degraded or uncontrolled behavior. | 1 |
+| **9.3.2** | **Verify that** per-tool quotas and timeouts (CPU, memory, disk, egress, execution time) are enforced, and that quota or timeout breaches fail closed by terminating the tool execution rather than continuing with degraded or uncontrolled behavior. | 1 |
+| **9.3.6** | **Verify that** quota and timeout breaches are logged with sufficient detail to identify the tool, the exceeded limit, and the time of breach. | 1 |
 | **9.3.3** | **Verify that** tool outputs are validated against strict schemas and security policies before being incorporated into downstream reasoning or follow-on actions. | 1 |
-| **9.3.4** | **Verify that** tool manifests declare required privileges, side-effect level, resource limits, and output validation requirements, and that the runtime enforces these declarations. | 2 |
+| **9.3.4** | **Verify that** tool manifests declare required privileges, side-effect level, resource limits, and output validation requirements. | 2 |
+| **9.3.7** | **Verify that** the orchestration runtime enforces the declarations specified in tool manifests for required privileges, side-effect level, resource limits, and output validation. | 2 |
 | **9.3.5** | **Verify that** sandbox escape indicators or policy violations trigger automated containment (tool disabled/quarantined). | 3 |
 
 ---
@@ -54,7 +56,8 @@ Make every action attributable and every mutation detectable.
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.4.1** | **Verify that** each agent instance (and orchestrator/runtime) has a unique cryptographic identity and authenticates as a first-class principal to downstream systems (no reuse of end-user credentials). | 1 |
-| **9.4.2** | **Verify that** agent-initiated actions are cryptographically bound to the execution chain (chain ID) and are signed and timestamped for non-repudiation and traceability. | 2 |
+| **9.4.2** | **Verify that** agent-initiated actions are cryptographically bound to the execution chain (chain ID). | 2 |
+| **9.4.6** | **Verify that** agent-initiated actions are signed and timestamped for non-repudiation and traceability. | 2 |
 | **9.4.3** | **Verify that** audit log records include sufficient context to reconstruct who/what acted, the initiating user identifier, delegation scope, authorization decision (policy/version), tool parameters, approvals (where applicable), and outcomes. | 2 |
 | **9.4.4** | **Verify that** agent identity credentials (keys/certs/tokens) rotate on a defined schedule and on compromise indicators, with rapid revocation and quarantine on suspected compromise or spoofing attempts. | 3 |
 | **9.4.5** | **Verify that** agent state persisted between invocations (including memory, task context, goals, and partial results) is integrity-protected (e.g., via cryptographic MACs or signatures), and that the runtime rejects or quarantines state that fails integrity verification before resuming execution. | 3 |

--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -22,7 +22,9 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **10.2.1** | **Verify that** MCP clients and servers implement the OAuth 2.1 authorization framework: clients present a valid access token for each request, and servers validate the token's issuer, audience, expiration, and scope claims, acting as resource servers that do not store tokens or user credentials. | 1 |
+| **10.2.1** | **Verify that** MCP clients present a valid access token for each request to MCP servers. | 1 |
+| **10.2.10** | **Verify that** MCP servers validate the presented access token's issuer, audience, expiration, and scope claims in accordance with OAuth 2.1. | 1 |
+| **10.2.11** | **Verify that** MCP servers acting as OAuth 2.1 resource servers do not store or persist access tokens or user credentials. | 1 |
 | **10.2.2** | **Verify that** MCP servers are registered through a controlled technical onboarding mechanism requiring explicit owner, environment, and resource definitions; unregistered or undiscoverable servers must not be callable in production. | 1 |
 | **10.2.3** | **Verify that** MCP session identifiers are treated as state, not identity: generated using cryptographically secure random values, bound to the authenticated user, and never relied on for authentication or authorization decisions. | 1 |
 | **10.2.4** | **Verify that** MCP `tools/list` and resource discovery responses are filtered based on the end-user's authorized scopes so that agents receive only the tool and resource definitions the user is permitted to invoke. | 2 |
@@ -53,8 +55,10 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | :--: | --- | :---: |
 | **10.4.1** | **Verify that** MCP tool responses are validated before being injected into the model context to prevent prompt injection, malicious tool output, or context manipulation. | 1 |
 | **10.4.2** | **Verify that** MCP server error responses do not expose internal details (stack traces, file paths, tokens, tool implementation) to the client or model context, preventing information leakage that could be exploited via the model. | 1 |
-| **10.4.3** | **Verify that** all MCP transports enforce message-framing integrity, strict schema validation, maximum payload sizes, and rejection of malformed, truncated, or interleaved frames to prevent desynchronization or injection attacks. | 2 |
-| **10.4.4** | **Verify that** MCP servers perform strict input validation for all function calls, including type checking, boundary validation, enumeration enforcement, and rejection of unrecognized or oversized parameters. | 2 |
+| **10.4.3** | **Verify that** all MCP transports enforce message-framing integrity and strict schema validation to prevent desynchronization or injection attacks. | 2 |
+| **10.4.4** | **Verify that** MCP servers perform strict input validation for all function calls, including type checking, boundary validation, and enumeration enforcement. | 2 |
+| **10.4.9** | **Verify that** all MCP transports enforce maximum payload size limits and reject malformed, truncated, or interleaved frames. | 2 |
+| **10.4.10** | **Verify that** MCP servers reject unrecognized or oversized parameters in function calls. | 2 |
 | **10.4.5** | **Verify that** MCP clients maintain a hash or versioned snapshot of tool definitions and that any change to a tool definition (via `notifications/tools/list_changed` or between sessions) triggers re-approval before the modified tool can be invoked. | 2 |
 | **10.4.6** | **Verify that** MCP tool and resource schemas (e.g., JSON schemas or capability descriptors) along with schema manifests are validated for authenticity and integrity using signatures to prevent schema tampering or malicious parameter modification. | 3 |
 | **10.4.7** | **Verify that** intermediaries evaluating message content either forward the canonicalized representation they evaluated or reject messages where multiple byte representations could produce different parsed structures. | 3 |
@@ -68,7 +72,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **10.5.1** | **Verify that** MCP servers may only initiate outbound requests to approved internal or external destinations following least-privilege egress policies and cannot access arbitrary network targets or internal cloud metadata services. | 2 |
+| **10.5.1** | **Verify that** MCP servers restrict outbound requests to approved internal or external destinations per least-privilege egress policies, with egress to all other targets blocked by default. | 2 |
 
 ---
 
@@ -79,7 +83,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | # | Description | Level |
 | :--: | --- | :---: |
 | **10.6.1** | **Verify that** MCP security controls enforce fail-closed semantics: if tool schema validation, MCP-Protocol-Version negotiation fails, authentication check, or policy evaluation fails or cannot be completed, the default action is to deny the request rather than permit it. | 2 |
-| **10.6.2** | **Verify that** MCP servers expose only allow-listed functions and resources and prohibit dynamic dispatch, reflective invocation, or execution of function names influenced by user or model-provided input. | 3 |
+| **10.6.2** | **Verify that** MCP servers expose only allow-listed functions and resources, and restrict function invocation to statically defined, pre-approved names that cannot be influenced by user or model-provided input. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -30,7 +30,8 @@ Increase resilience to manipulated inputs designed to cause misclassification or
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.2.1** | **Verify that** models serving high-risk functions are evaluated against known adversarial attack techniques relevant to their modality (e.g., perturbation attacks for vision, token-manipulation attacks for text). | 1 |
 | **11.2.2** | **Verify that** adversarial-example detection raises alerts in production pipelines, with blocking or degraded-capability responses for high-risk endpoints or use cases. | 2 |
-| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied where feasible, with documented configurations and reproducible procedures. | 2 |
+| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied where feasible. | 2 |
+| **11.2.9** | **Verify that** adversarial hardening configurations and procedures are documented and reproducible. | 2 |
 | **11.2.4** | **Verify that** certified robustness metrics (e.g., certified radius, verified robust accuracy at defined perturbation bounds) are tracked and recorded per model version, and that degradation beyond defined thresholds triggers re-evaluation before deployment. | 2 |
 | **11.2.5** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 |
 | **11.2.6** | **Verify that** formal robustness verification methods (e.g., certified bounds, interval-bound propagation) are applied to safety-critical model components where the model architecture supports them. | 3 |
@@ -81,7 +82,8 @@ Identify and neutralize manipulated, backdoored, or adversarial data entering th
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.6.1** | **Verify that** inputs from external or untrusted sources pass through anomaly detection (e.g., statistical outlier detection, consistency scoring) before model inference. | 2 |
-| **11.6.2** | **Verify that** anomaly-detection thresholds are tuned on representative clean and adversarial validation sets and that the false-positive rate is measured and documented. | 2 |
+| **11.6.2** | **Verify that** anomaly-detection thresholds are tuned on representative clean and adversarial validation sets. | 2 |
+| **11.6.6** | **Verify that** the false-positive rate of anomaly detection is measured on representative data and documented per model version. | 2 |
 | **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review) appropriate to the risk level. | 2 |
 | **11.6.4** | **Verify that** detection methods are periodically stress-tested with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
 | **11.6.5** | **Verify that** detection efficacy metrics are logged and periodically re-evaluated against updated threat intelligence. | 3 |

--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -12,7 +12,8 @@ Generic logging and operational controls (log storage access control, retention,
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **13.1.1** | **Verify that** AI interactions are logged with security-relevant metadata (e.g. timestamp, user ID, session ID, model version, token count, input hash, system prompt version, confidence score, safety filter outcome, and safety filter decisions) without logging prompt or response content by default. | 1 |
+| **13.1.1** | **Verify that** AI interactions are logged with security-relevant metadata (e.g., timestamp, user ID, session ID, model version, token count, input hash, system prompt version, confidence score, safety filter outcome, and safety filter decisions). | 1 |
+| **13.1.5** | **Verify that** prompt and response content is not included in AI interaction logs by default. | 1 |
 | **13.1.2** | **Verify that** policy decisions and safety filtering actions are logged with sufficient detail to enable audit and debugging of content moderation systems. | 2 |
 | **13.1.3** | **Verify that** log entries for AI inference events capture a structured, interoperable schema that includes at minimum model identifier, token usage (input and output), provider name, and operation type, to enable consistent AI observability across tools and platforms. | 2 |
 | **13.1.4** | **Verify that** full prompt and response content is logged only when a security-relevant event is detected (e.g., safety filter trigger, prompt injection detection, anomaly flag), or when required by explicit user consent and a documented legal basis. | 2 |
@@ -42,7 +43,8 @@ Monitor and detect drift and degradation across model outputs, input distributio
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **13.3.1** | **Verify that** model performance metrics (accuracy, precision, recall, F1 score, confidence scores, latency, and error rates) are continuously monitored across model versions and time periods and compared against documented baselines. | 1 |
+| **13.3.1** | **Verify that** model performance metrics (accuracy, precision, recall, F1 score, confidence scores, latency, and error rates) are continuously monitored across model versions and time periods. | 1 |
+| **13.3.13** | **Verify that** monitored model performance metrics are compared against documented baselines and that deviations beyond defined thresholds are flagged for investigation. | 1 |
 | **13.3.2** | **Verify that** data drift detection monitors input distribution changes that may impact model performance, using statistically validated methods appropriate to the data type. | 1 |
 | **13.3.3** | **Verify that** baseline performance profiles are formally documented and version-controlled, and are reviewed at a defined frequency or after any model or data pipeline change. | 2 |
 | **13.3.4** | **Verify that** automated alerting triggers when performance metrics exceed predefined degradation thresholds or deviate significantly from baselines. | 2 |

--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -17,7 +17,7 @@ Provide shutdown or rollback paths when unsafe behavior of the AI system is obse
 | **14.1.1** | **Verify that** a manual kill-switch mechanism exists to immediately halt AI model inference and outputs. | 1 |
 | **14.1.4** | **Verify that** kill-switch and intermediate-state mechanisms are exercised at a defined frequency, and that each test confirms the system reaches the target state within the documented response time and that all dependent components (e.g., agent runtimes, tool/MCP servers, retrieval connectors) transition as specified. | 2 |
 | **14.1.5** | **Verify that** the system can be placed into at least two intermediate operational states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined entry triggers and can be exited independently without requiring a full system restart or shutdown. | 2 |
-| **14.1.6** | **Verify that** override and kill-switch commands for autonomous agents are delivered and enforced through a channel that the agent runtime cannot access, intercept, or suppress (e.g., out-of-band infrastructure controls, hypervisor-level signals, network-layer isolation), so that a compromised or manipulated agent cannot prevent its own shutdown. | 2 |
+| **14.1.6** | **Verify that** override and kill-switch commands for autonomous agents are delivered exclusively through out-of-band channels (e.g., infrastructure controls, hypervisor-level signals, network-layer isolation) that are architecturally isolated from the agent runtime, ensuring shutdown is possible even when the agent is compromised or manipulated. | 2 |
 
 ---
 
@@ -28,7 +28,8 @@ Define which AI decisions and agent actions require human approval so that runti
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **14.2.1** | **Verify that** a documented human oversight policy defines which AI decisions and agent actions are classified as high-risk, the criteria used to make that determination, and the approval authority required before execution. | 1 |
-| **14.2.3** | **Verify that** when a human-approval gate (per C14.2.1 and C9.2) is not satisfied within the defined approval time-to-live, the system applies a documented default action, that the default action is fail-closed (blocking the action) unless an alternative is explicitly authorized in the high-risk action policy, and that any non-fail-closed default is itself classified and approved as a high-risk policy decision. | 2 |
+| **14.2.3** | **Verify that** when a human-approval gate (per C14.2.1 and C9.2) is not satisfied within the defined approval time-to-live, the system applies a documented fail-closed default action (blocking the proposed action), unless an explicitly authorized alternative default is defined in the high-risk action policy. | 2 |
+| **14.2.4** | **Verify that** any non-fail-closed default action for expired human-approval gates is itself classified as a high-risk policy decision and requires explicit authorization before adoption. | 2 |
 
 ---
 

--- a/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
+++ b/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
@@ -36,7 +36,7 @@ Prevent leakage of secrets, proprietary code, and personal data when constructin
 
 | # | Description | Level |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
-| **AC.3.1** | **Verify that** written guidance prohibits sending secrets, credentials, or classified data in prompts. | 1 |
+| **AC.3.1** | **Verify that** written guidance specifies which data classifications are permitted in AI tool inputs and requires prompt sanitization to exclude secrets, credentials, and classified data. | 1 |
 | **AC.3.2** | **Verify that** technical controls (client-side redaction, approved context filters) automatically strip sensitive artifacts. | 2 |
 | **AC.3.3** | **Verify that** prompts and responses are tokenized, encrypted in transit and at rest, and retention periods comply with data-classification policy. | 3 |
 
@@ -49,7 +49,8 @@ Detect and remediate vulnerabilities introduced by AI output before the code is 
 | # | Description | Level |
 |:--------:|---------------------------------------------------------------------------------------------------------------------|:---:|
 | **AC.4.1** | **Verify that** AI-generated code is always subjected to human code review. | 1 |
-| **AC.4.2** | **Verify that** automated scanners (SAST/IAST/DAST) run on every pull request containing AI-generated code and block merges on critical findings. | 2 |
+| **AC.4.2** | **Verify that** automated scanners (SAST/IAST/DAST) run on every pull request containing AI-generated code. | 2 |
+| **AC.4.4** | **Verify that** pull requests containing AI-generated code with critical security findings are blocked from merging until findings are resolved. | 2 |
 | **AC.4.3** | **Verify that** differential fuzz testing or property-based tests prove security-critical behaviors (e.g., input validation, authorization logic). | 3 |
 
 ---

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -17,8 +17,10 @@ Verify the identity of users, agents, services, MCP clients/servers, and edge de
 | Unique cryptographic agent and orchestrator identity | 9.4.1 |
 | First-class principal authentication (no end-user credential reuse) | 9.4.1 |
 | Agent identity credential rotation and rapid revocation | 9.4.4 |
-| OAuth 2.1 for MCP client authentication | 10.2.1 |
-| MCP server OAuth token validation (issuer, audience, expiration, scope) | 10.2.2 |
+| MCP client OAuth 2.1 token presentation per request | 10.2.1 |
+| MCP server OAuth 2.1 token validation (issuer, audience, expiration, scope) | 10.2.10 |
+| MCP server stateless constraint (no token or credential persistence) | 10.2.11 |
+| MCP server registration with explicit ownership | 10.2.2 |
 | MCP server registration with explicit ownership | 10.2.4 |
 | Cryptographically secure MCP session IDs (not used for auth) | 10.2.8 |
 
@@ -113,7 +115,8 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 | Third-party model origin and integrity verification (signed records) | 6.1.1 |
 | Cryptographic signature validation for model publishers | 6.2.1, 6.2.2 |
 | Model watermarking and fingerprinting | 11.5.4 |
-| Execution chain cryptographic signing with non-repudiation timestamps | 9.4.2 |
+| Execution chain cryptographic binding (chain ID) for agent actions | 9.4.2 |
+| Agent action signing and timestamping for non-repudiation and traceability | 9.4.6 |
 | MCP component signature and checksum verification | 10.1.1 |
 | MCP schema integrity signing and tool definition hash tracking | 10.4.6, 10.4.5 |
 | Publisher key pinning per source registry with rotation re-approval | 6.2.2 |
@@ -131,6 +134,8 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | --- | --- |
 | Prompt injection detection ruleset / service | 2.1.1 |
 | Instruction hierarchy enforcement (system > developer > user) | 2.1.2 |
+| Instruction hierarchy preservation across multi-step and tool-augmented workflows | 2.1.10 |
+| Prompt composition constraint (user-controlled content cannot override system instructions) | 2.1.11 |
 | Per-request demonstration count limits in context window | 2.1.6 |
 | Many-shot jailbreaking pattern detection (systematic in-context behavioral override) | 2.1.7 |
 | In-context behavioral override attempts classified as prompt injection events | 2.1.8 |
@@ -138,6 +143,7 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | Third-party content sanitization | 2.1.5 |
 | Character set allow-listing for model prompt inputs | 2.1.4 |
 | Pre-tokenization input normalization (Unicode NFC, homoglyph mapping, control/invisible character removal, bidirectional text neutralization) | 2.2.1 |
+| Post-normalization suspicious artifact rejection or flagging | 2.2.4 |
 | Adversarial input quarantine and logging | 2.2.2 |
 | Encoding and representation smuggling detection and mitigation | 2.2.3 |
 | Content classifiers for inbound prompts (hate, violence, sexual, illegal) | 2.3.1 |
@@ -147,7 +153,9 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | Adversarial perturbation detection on image/audio inputs | 2.4.2 |
 | Cross-modal attack detection | 2.4.3 |
 | MCP input type checking, boundary validation, and enumeration enforcement | 10.4.4 |
-| MCP message-framing integrity and payload size limits | 10.4.3 |
+| MCP rejection of unrecognized or oversized function call parameters | 10.4.10 |
+| MCP message-framing integrity and strict schema validation | 10.4.3 |
+| MCP maximum payload size limits and malformed frame rejection | 10.4.9 |
 | MCP schema validation for tool and resource integrity | 10.4.6 |
 | Tool output schema and security policy validation before re-entry to agent | 9.3.3 |
 | MCP tool response validation (prompt injection, context manipulation) | 10.4.1 |
@@ -193,6 +201,7 @@ Enforce consumption bounds to prevent abuse, runaway execution, and denial-of-se
 | Wall-clock time and monetary spend caps | 9.1.1 |
 | Cumulative resource counters with hard-stop thresholds and circuit breaker enforcement | 9.1.2 |
 | Per-tool CPU, memory, disk, egress, and execution time limits with fail-closed termination on breach | 9.3.2 |
+| Quota and timeout breach logging (tool, exceeded limit, timestamp) | 9.3.6 |
 | Query-rate limiting for model extraction and inversion defense, sized to the threat model (e.g., the number of queries required to approximate the model or to reconstruct training records) rather than as a generic API throttle | 11.4.2, 11.5.1 |
 | Anomalous usage pattern detection and blocking | 13.2.3, ASVS v5 V2.4 |
 
@@ -340,7 +349,8 @@ Test for and defend against evasion, extraction, inversion, poisoning, and align
 | Red-team and jailbreak test suites (version-controlled) | 11.1.2 |
 | Automated harmful-content rate evaluation with regression detection | 11.1.3 |
 | RLHF / Constitutional AI alignment training | 11.1.4 |
-| Adversarial training and defensive distillation | 11.2.3 |
+| Adversarial training and equivalent hardening techniques applied where feasible | 11.2.3 |
+| Adversarial hardening configurations and procedures documented and reproducible | 11.2.9 |
 | Adversarially robust distillation — distill teacher into student using adversarial training so the student inherits robustness as well as accuracy (implementation example for 11.2.3) | 11.2.3 |
 | Certified robustness metrics tracking per model version with degradation alerting | 11.2.4 |
 | Formal robustness verification (certified bounds, interval-bound propagation) | 11.2.6 |
@@ -375,13 +385,15 @@ Capture security-relevant events with integrity protection for forensic analysis
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Prompt and response logging with metadata (timestamp, user ID, session, model version) | 13.1.1 |
+| AI interaction logging with security-relevant metadata (timestamp, user ID, session, model version, safety filter outcomes) | 13.1.1 |
+| Prompt and response content excluded from AI interaction logs by default | 13.1.5 |
 | Secure, access-controlled log repositories with retention policies | 13.1.2 |
 | Log encryption at rest and in transit | 13.1.3 |
 | PII, credential, and proprietary information redaction in logs | 13.1.4 |
 | Policy decision and safety filtering action logging | 13.1.2 |
 | Audit log context fields sufficient for forensic reconstruction (actor, delegation, policy, parameters, outcomes) | 9.4.3 |
-| Agent action signing with chain ID binding and timestamps | 9.4.2 |
+| Agent action cryptographic chain ID binding | 9.4.2 |
+| Agent action signing and timestamping for non-repudiation | 9.4.6 |
 | Immutable audit records for model changes (actor, change type, before/after) | 3.2.5 |
 | Generic audit log immutability and tamper-evidence | ASVS v5 V16.4.2 |
 | CI/CD audit log streaming to SIEM | ASVS v5 V16.4.3 |
@@ -406,7 +418,10 @@ Detect anomalies, alert on threats, and respond to security incidents in AI syst
 | Behavioral anomaly detection (unusual patterns, excessive retries, systematic probing) | 13.2.3, 13.2.5 |
 | Detection rules for AI-specific attack patterns (jailbreak campaigns, prompt injection, system prompt extraction, model extraction) | 13.2.4 |
 | Automated incident response (isolation and blocking of compromised models and malicious users) | 13.2.6 |
-| Performance metric monitoring (accuracy, latency, error rate) with alerting | 13.3.1, 13.3.3, 13.3.4 |
+| Continuous performance metric monitoring across model versions (accuracy, latency, error rate) | 13.3.1 |
+| Monitored metric comparison against documented baselines with deviation flagging | 13.3.13 |
+| Baseline documentation, version control, and periodic review | 13.3.3 |
+| Automated alerting on metric degradation beyond defined thresholds | 13.3.4 |
 | Performance degradation retraining and replacement workflow triggers | 13.3.8 |
 | Hallucination detection monitoring | 13.3.5 |
 | Hallucination rate time-series tracking | 13.3.9 |
@@ -450,6 +465,7 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 | Approval parameter binding (prevent approve-one-execute-another) | 9.2.2 |
 | High-impact intent confirmation with exact parameter binding and quick expiration | 9.2.3 |
 | Documented fail-closed default when human approval is not received within TTL | 14.2.3 |
+| Non-fail-closed default classification as high-risk policy decision requiring explicit authorization | 14.2.4 |
 | Human review on anomaly detection | 11.6.3 |
 | High-risk model quarantine with human review and sign-off | 6.1.3 |
 | Post-condition outcome checking with containment on mismatch | 9.7.2 |


### PR DESCRIPTION
Closes #693

## Summary

Resolves all 14 remaining compound requirements and 4 negative-framing requirements identified in #693. Each original requirement ID is preserved for one part; split-off parts receive the next sequential ID in their subsection. Appendix D cross-references updated for all new IDs.

### Compound splits (14 → 28 requirements)

| Chapter | Original | Split into |
|---|---|---|
| C02 | 2.1.2 (hierarchy + multi-step + composition) | 2.1.2, **2.1.10**, **2.1.11** |
| C02 | 2.2.1 (normalization + artifact rejection) | 2.2.1, **2.2.4** |
| C03 | 3.6.4 (integrity-verify + checkpoint registration) | 3.6.4, **3.6.5** |
| C09 | 9.3.2 (enforce + log breaches) | 9.3.2, **9.3.6** |
| C09 | 9.3.4 (manifest declaration + runtime enforcement) | 9.3.4, **9.3.7** |
| C09 | 9.4.2 (chain binding + signing + timestamping) | 9.4.2, **9.4.6** |
| C10 | 10.2.1 (client present + server validate + stateless) | 10.2.1, **10.2.10**, **10.2.11** |
| C10 | 10.4.3 (framing+schema + payload+malformed) | 10.4.3, **10.4.9** |
| C10 | 10.4.4 (type/boundary/enum + unrecognized/oversized) | 10.4.4, **10.4.10** |
| C11 | 11.2.3 (training applied + documented + reproducible) | 11.2.3, **11.2.9** |
| C11 | 11.6.2 (threshold tuning + FPR measured) | 11.6.2, **11.6.6** |
| C13 | 13.1.1 (log metadata + no content by default) | 13.1.1, **13.1.5** |
| C13 | 13.3.1 (metric collection + baseline comparison) | 13.3.1, **13.3.13** |
| C14 | 14.2.3 (fail-closed default + non-fail-closed classification) | 14.2.3, **14.2.4** |
| Appendix C | AC.4.2 (scanner execution + merge gating) | AC.4.2, **AC.4.4** |

### Negative reframes (4 requirements)

| Req | Change |
|---|---|
| 10.5.1 | "cannot access arbitrary targets" → "egress blocked to all non-approved targets by default" |
| 10.6.2 | "prohibit dynamic dispatch" → "restrict to statically defined pre-approved names" |
| 14.1.6 | "cannot access/intercept/suppress" → "delivered exclusively through out-of-band channels architecturally isolated from agent runtime" |
| AC.3.1 | "prohibits sending secrets" → "specifies allowed data classifications and requires sanitization" |

## Test plan

- [ ] Verify each split requirement is independently auditable (no overlap)
- [ ] Verify original IDs still appear at the start of each split pair/triple
- [ ] Verify new IDs are sequential and do not collide with existing requirements
- [ ] Verify Appendix D rows updated/added for all new IDs
- [ ] Verify negative reframes preserve the original security intent with positive framing