### PR TITLE
fix(#693): split compound requirements in C02

### DIFF
--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -15,14 +15,15 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.1.1** | **Verify that** all external or derived inputs that may steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier before being included in prompts or used to trigger actions. | 1 |
-| **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. This enforcement must be preserved across multi-step interactions and tool-augmented workflows. In such cases, prompt composition or intermediate outputs must not allow user-controlled content to influence or override system or developer instructions. | 1 |
+| **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. | 1 |
 | **2.1.3** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, and that inputs exceeding token limits are rejected rather than silently truncated, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
 | **2.1.4** | **Verify that** the system implements a character set limitation for user inputs to model prompts, allowing only characters that are explicitly required for business purposes using an allow-list approach. | 1 |
-| **2.1.5** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
-| **2.1.6** | **Verify that** the system enforces per-request limits on the number of user-supplied demonstrations included in a single context window. | 2 |
-| **2.1.7** | **Verify that** the system detects patterns indicative of systematic in-context behavioral override attempts consistent with many-shot jailbreaking. | 2 |
-| **2.1.8** | **Verify that** detected in-context behavioral override attempts are classified and handled as prompt injection events. | 2 |
-| **2.1.9** | **Verify that** prompt injection screening respects user-specific policies (age and regional legal constraints) via attribute-based rules resolved at request time, including the role or permission level of the calling agent. | 2 |
+| **2.1.5** | **Verify that** the instruction hierarchy is preserved across multi-step interactions and tool-augmented workflows, including prompt composition and intermediate outputs, such that user-controlled content cannot override system or developer instructions. | 1 |
+| **2.1.6** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
+| **2.1.7** | **Verify that** the system enforces per-request limits on the number of user-supplied demonstrations included in a single context window. | 2 |
+| **2.1.8** | **Verify that** the system detects patterns indicative of systematic in-context behavioral override attempts consistent with many-shot jailbreaking. | 2 |
+| **2.1.9** | **Verify that** detected in-context behavioral override attempts are classified and handled as prompt injection events. | 2 |
+| **2.1.10** | **Verify that** prompt injection screening respects user-specific policies (age and regional legal constraints) via attribute-based rules resolved at request time, including the role or permission level of the calling agent. | 2 |
 
 ---
 
@@ -32,9 +33,10 @@ AI models process text through tokenizers and embeddings that can be exploited v
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.2.1** | **Verify that** input normalization (Unicode NFC canonicalization, homoglyph mapping, removal of control and invisible Unicode characters, and bidirectional text neutralization) is applied before tokenization or embedding, and that inputs which still contain suspicious encoding artifacts after normalization are rejected or flagged for review. | 1 |
+| **2.2.1** | **Verify that** input normalization (Unicode NFC canonicalization, homoglyph mapping, removal of control and invisible Unicode characters, and bidirectional text neutralization) is applied before tokenization or embedding. | 1 |
 | **2.2.2** | **Verify that** inputs identified as adversarial by any detection mechanism are blocked from inclusion in prompts or execution of actions. | 1 |
-| **2.2.3** | **Verify that** encoding and representation smuggling in both inputs and outputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) are detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
+| **2.2.3** | **Verify that** inputs which still contain suspicious encoding artifacts after normalization are rejected or flagged for review. | 2 |
+| **2.2.4** | **Verify that** encoding and representation smuggling in both inputs and outputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) are detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -131,19 +131,21 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | --- | --- |
 | Prompt injection detection ruleset / service | 2.1.1 |
 | Instruction hierarchy enforcement (system > developer > user) | 2.1.2 |
-| Per-request demonstration count limits in context window | 2.1.6 |
-| Many-shot jailbreaking pattern detection (systematic in-context behavioral override) | 2.1.7 |
-| In-context behavioral override attempts classified as prompt injection events | 2.1.8 |
+| Instruction hierarchy preservation across multi-step and tool-augmented workflows, including prompt composition | 2.1.5 |
+| Per-request demonstration count limits in context window | 2.1.7 |
+| Many-shot jailbreaking pattern detection (systematic in-context behavioral override) | 2.1.8 |
+| In-context behavioral override attempts classified as prompt injection events | 2.1.9 |
 | Context window proportion limits and token limit enforcement (reject, not truncate) | 2.1.3 |
-| Third-party content sanitization | 2.1.5 |
+| Third-party content sanitization | 2.1.6 |
 | Character set allow-listing for model prompt inputs | 2.1.4 |
 | Pre-tokenization input normalization (Unicode NFC, homoglyph mapping, control/invisible character removal, bidirectional text neutralization) | 2.2.1 |
+| Post-normalization suspicious artifact rejection or flagging | 2.2.3 |
 | Adversarial input quarantine and logging | 2.2.2 |
-| Encoding and representation smuggling detection and mitigation | 2.2.3 |
+| Encoding and representation smuggling detection and mitigation | 2.2.4 |
 | Content classifiers for inbound prompts (hate, violence, sexual, illegal) with threshold-based rejection or sanitization | 2.3.1 |
 | Multilingual classifier gap evaluation with compensating controls (language detection, conservative thresholds, human review routing) | 2.3.2 |
 | Policy-violating input rejection before model propagation | 2.3.3 |
-| User-specific and agent-aware policy screening | 2.1.9 |
+| User-specific and agent-aware policy screening | 2.1.10 |
 | Extracted and hidden content from non-text inputs treated as untrusted | 2.4.1 |
 | Adversarial perturbation detection on image/audio inputs | 2.4.2 |
 | Cross-modal attack detection | 2.4.3 |


### PR DESCRIPTION
Splits two compound requirements in C2 Input Validation per #693.

**2.1.2** (hierarchy + multi-step + composition) → **2.1.2**, **2.1.5**
- 2.1.5 and 2.1.6 were initially split into two separate items; merged back into one per reviewer feedback (they verify the same underlying property end-to-end)
- "influence or override" narrowed to "cannot override" for auditability

**2.2.1** (normalization + artifact rejection) → **2.2.1**, **2.2.3**
- 2.2.3 placed at L2 per reviewer feedback (requires second-pass heuristic above L1 normalization)

Requirements sorted by level (L1 first, then L2, then L3) and renumbered sequentially.
Appendix D cross-references updated.