### PR TITLE
fix(#693): split compound requirements in C09

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -40,10 +40,12 @@ Constrain tool and plugin execution, loading, and outputs to prevent unauthorize
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.3.1** | **Verify that** each tool/plugin executes in an isolated sandbox (container/VM/WASM/OS sandbox) with least-privilege filesystem, network egress, and syscall permissions appropriate to the tool's function. | 1 |
-| **9.3.2** | **Verify that** per-tool quotas and timeouts (CPU, memory, disk, egress, execution time) are enforced and logged, and that quota or timeout breaches fail closed by terminating the tool execution rather than continuing with degraded or uncontrolled behavior. | 1 |
+| **9.3.2** | **Verify that** per-tool quotas and timeouts (CPU, memory, disk, egress, execution time) are enforced, and that quota or timeout breaches fail closed by terminating the tool execution rather than continuing with degraded or uncontrolled behavior. | 1 |
 | **9.3.3** | **Verify that** tool outputs are validated against strict schemas and security policies before being incorporated into downstream reasoning or follow-on actions. | 1 |
-| **9.3.4** | **Verify that** tool manifests declare required privileges, side-effect level, resource limits, and output validation requirements, and that the runtime enforces these declarations. | 2 |
-| **9.3.5** | **Verify that** sandbox escape indicators or policy violations trigger automated containment (tool disabled/quarantined). | 3 |
+| **9.3.4** | **Verify that** quota and timeout breaches are logged with sufficient detail to identify the tool, the exceeded limit, and the time of breach. | 1 |
+| **9.3.5** | **Verify that** tool manifests declare required privileges, side-effect level, resource limits, and output validation requirements. | 2 |
+| **9.3.6** | **Verify that** the orchestration runtime enforces the declarations specified in tool manifests for required privileges, side-effect level, resource limits, and output validation. | 2 |
+| **9.3.7** | **Verify that** sandbox escape indicators or policy violations trigger automated containment (tool disabled/quarantined). | 3 |
 
 ---
 
@@ -54,10 +56,11 @@ Make every action attributable and every mutation detectable.
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.4.1** | **Verify that** each agent instance (and orchestrator/runtime) has a unique cryptographic identity and authenticates as a first-class principal to downstream systems (no reuse of end-user credentials). | 1 |
-| **9.4.2** | **Verify that** agent-initiated actions are cryptographically bound to the execution chain (chain ID) and are signed and timestamped for non-repudiation and traceability. | 2 |
+| **9.4.2** | **Verify that** agent-initiated actions are cryptographically bound to the execution chain (chain ID). | 2 |
 | **9.4.3** | **Verify that** audit log records include sufficient context to reconstruct who/what acted, the initiating user identifier, delegation scope, authorization decision (policy/version), tool parameters, approvals (where applicable), and outcomes. | 2 |
-| **9.4.4** | **Verify that** agent identity credentials (keys/certs/tokens) rotate on a defined schedule and on compromise indicators, with rapid revocation and quarantine on suspected compromise or spoofing attempts. | 3 |
-| **9.4.5** | **Verify that** agent state persisted between invocations (including memory, task context, goals, and partial results) is integrity-protected (e.g., via cryptographic MACs or signatures), and that the runtime rejects or quarantines state that fails integrity verification before resuming execution. | 3 |
+| **9.4.4** | **Verify that** agent-initiated actions are signed and timestamped for non-repudiation and traceability. | 2 |
+| **9.4.5** | **Verify that** agent identity credentials (keys/certs/tokens) rotate on a defined schedule and on compromise indicators, with rapid revocation and quarantine on suspected compromise or spoofing attempts. | 3 |
+| **9.4.6** | **Verify that** agent state persisted between invocations (including memory, task context, goals, and partial results) is integrity-protected (e.g., via cryptographic MACs or signatures), and that the runtime rejects or quarantines state that fails integrity verification before resuming execution. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -16,7 +16,7 @@ Verify the identity of users, agents, services, MCP clients/servers, and edge de
 | Short-lived signed tokens for federated AI agent authentication | 5.1.2 |
 | Unique cryptographic agent and orchestrator identity | 9.4.1 |
 | First-class principal authentication (no end-user credential reuse) | 9.4.1 |
-| Agent identity credential rotation and rapid revocation | 9.4.4 |
+| Agent identity credential rotation and rapid revocation | 9.4.5 |
 | OAuth 2.1 for MCP client authentication | 10.2.1 |
 | MCP server OAuth token validation (issuer, audience, expiration, scope) | 10.2.2 |
 | MCP server registration with explicit ownership | 10.2.4 |
@@ -92,7 +92,7 @@ Manage cryptographic keys, secrets, and credentials throughout their lifecycle.
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Agent identity credential rotation with rapid revocation | 9.4.4 |
+| Agent identity credential rotation with rapid revocation | 9.4.5 |
 | MCP runtime credential injection (no plaintext secrets) | 10.1.2 |
 
 **Common pitfalls:** hardcoded secrets in config or container images; neglecting rotation schedules; storing MCP OAuth tokens in server state rather than validating externally.
@@ -113,11 +113,12 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 | Third-party model origin and integrity verification (signed records) | 6.1.1 |
 | Cryptographic signature validation for model publishers | 6.2.1, 6.2.2 |
 | Model watermarking and fingerprinting | 11.5.4 |
-| Execution chain cryptographic signing with non-repudiation timestamps | 9.4.2 |
+| Execution chain cryptographic binding (chain ID) for agent actions | 9.4.2 |
+| Agent action signing and timestamps for non-repudiation and traceability | 9.4.4 |
 | MCP component signature and checksum verification | 10.1.1 |
 | MCP schema integrity signing and tool definition hash tracking | 10.4.6, 10.4.5 |
 | Publisher key pinning per source registry with rotation re-approval | 6.2.2 |
-| Agent persisted state integrity protection (MAC/signature, rejection on failure) | 9.4.5 |
+| Agent persisted state integrity protection (MAC/signature, rejection on failure) | 9.4.6 |
 
 **Common pitfalls:** using mutable `:latest` tags instead of immutable digests; not re-verifying tool definition hashes between MCP invocations; missing replay protection on agent messages.
 
@@ -195,6 +196,7 @@ Enforce consumption bounds to prevent abuse, runaway execution, and denial-of-se
 | Wall-clock time and monetary spend caps | 9.1.1 |
 | Cumulative resource counters with hard-stop thresholds and circuit breaker enforcement | 9.1.2 |
 | Per-tool CPU, memory, disk, egress, and execution time limits with fail-closed termination on breach | 9.3.2 |
+| Quota and timeout breach logging (tool, exceeded limit, timestamp) | 9.3.4 |
 | Query-rate limiting for model extraction and inversion defense, sized to the threat model (e.g., the number of queries required to approximate the model or to reconstruct training records) rather than as a generic API throttle | 11.4.2, 11.5.1 |
 | Anomalous usage pattern detection and blocking | 13.2.3, ASVS v5 V2.4 |
 
@@ -214,7 +216,7 @@ Isolate workloads, tools, models, and agents to contain failures and prevent lat
 | Runtime privilege escalation and container escape detection | 4.1.4 |
 | TEE / confidential computing with remote attestation | 4.1.5 |
 | Tool and plugin sandboxing (container, VM, WASM, OS sandbox) | 9.3.1 |
-| Sandbox escape detection with automated tool quarantine | 9.3.5 |
+| Sandbox escape detection with automated tool quarantine | 9.3.7 |
 | Agent isolation across tenants, security domains, and environments | 9.8.1 |
 | MCP stdio local-only enforcement with terminal injection prevention | 10.6.1 |
 
@@ -384,7 +386,8 @@ Capture security-relevant events with integrity protection for forensic analysis
 | PII, credential, and proprietary information redaction in logs | 13.1.4 |
 | Policy decision and safety filtering action logging | 13.1.2 |
 | Audit log context fields sufficient for forensic reconstruction (actor, delegation, policy, parameters, outcomes) | 9.4.3 |
-| Agent action signing with chain ID binding and timestamps | 9.4.2 |
+| Agent action cryptographic chain ID binding | 9.4.2 |
+| Agent action signing and timestamps for non-repudiation | 9.4.4 |
 | Immutable audit records for model changes (actor, change type, before/after) | 3.2.6 |
 | Generic audit log immutability and tamper-evidence | ASVS v5 V16.4.2 |
 | CI/CD audit log streaming to SIEM | ASVS v5 V16.4.3 |


### PR DESCRIPTION
Splits three compound requirements in C9 Orchestration and Agentic Action per #693.

**9.3.2** (enforce + log breaches) → **9.3.2**, **9.3.4**
**9.3.4** (manifest declaration + runtime enforcement) → **9.3.5**, **9.3.6**
**9.4.2** (chain binding + signing + timestamping) → **9.4.2**, **9.4.4**

Requirements sorted by level (L1 first, then L2, then L3) and renumbered sequentially.
Appendix D cross-references updated. "timestamping" corrected to "timestamps".