### PR TITLE
fix(#693): split compound requirements in C11

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -30,12 +30,13 @@ Increase resilience to manipulated inputs designed to cause misclassification or
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.2.1** | **Verify that** models serving high-risk functions are evaluated against known adversarial attack techniques relevant to their modality (e.g., perturbation attacks for vision, token-manipulation attacks for text, trigger-based or instruction-injection backdoors where applicable). | 1 |
 | **11.2.2** | **Verify that** adversarial-example detection raises alerts in production pipelines, with blocking or degraded-capability responses for high-risk endpoints or use cases. | 2 |
-| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied where feasible, with documented configurations and reproducible procedures. | 2 |
+| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied where feasible. | 2 |
 | **11.2.4** | **Verify that** certified robustness metrics (e.g., certified radius, verified robust accuracy at defined perturbation bounds) are tracked and recorded per model version, and that degradation beyond defined thresholds triggers re-evaluation before deployment. | 2 |
-| **11.2.5** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 |
-| **11.2.6** | **Verify that** formal robustness verification methods (e.g., certified bounds, interval-bound propagation) are applied to safety-critical model components where the model architecture supports them. | 3 |
-| **11.2.7** | **Verify that** robustness certification or empirical robustness audits are repeated after all post-training transformations (fine-tuning, distillation, quantization, adapter merging) that consume the same base model. | 3 |
-| **11.2.8** | **Verify that** post-training model integrity verification techniques (e.g., activation clustering, spectral signature analysis, neural cleanse) are applied to detect potential backdoors or poisoning-induced behavioral anomalies, where such techniques exist for the model architecture. | 3 |
+| **11.2.5** | **Verify that** adversarial hardening configurations and procedures are documented and reproducible. | 2 |
+| **11.2.6** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 |
+| **11.2.7** | **Verify that** formal robustness verification methods (e.g., certified bounds, interval-bound propagation) are applied to safety-critical model components where the model architecture supports them. | 3 |
+| **11.2.8** | **Verify that** robustness certification or empirical robustness audits are repeated after all post-training transformations (fine-tuning, distillation, quantization, adapter merging) that consume the same base model. | 3 |
+| **11.2.9** | **Verify that** post-training model integrity verification techniques (e.g., activation clustering, spectral signature analysis, neural cleanse) are applied to detect potential backdoors or poisoning-induced behavioral anomalies, where such techniques exist for the model architecture. | 3 |
 
 ---
 
@@ -84,10 +85,11 @@ Identify and neutralize manipulated, backdoored, or adversarial data entering th
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.6.1** | **Verify that** inputs from external or untrusted sources pass through anomaly detection (e.g., statistical outlier detection, consistency scoring) before model inference. | 2 |
-| **11.6.2** | **Verify that** anomaly-detection thresholds are tuned on representative clean and adversarial validation sets and that the false-positive rate is measured and documented. | 2 |
+| **11.6.2** | **Verify that** anomaly-detection thresholds are tuned on representative clean and adversarial validation sets. | 2 |
 | **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review) appropriate to the risk level. | 2 |
-| **11.6.4** | **Verify that** detection methods are periodically stress-tested with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
-| **11.6.5** | **Verify that** detection efficacy metrics are logged and periodically re-evaluated against updated threat intelligence. | 3 |
+| **11.6.4** | **Verify that** the false-positive rate of anomaly detection is measured on representative data and documented per model version. | 2 |
+| **11.6.5** | **Verify that** detection methods are periodically stress-tested with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
+| **11.6.6** | **Verify that** detection efficacy metrics are logged and periodically re-evaluated against updated threat intelligence. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -343,11 +343,12 @@ Test for and defend against evasion, extraction, inversion, poisoning, and align
 | Red-team and jailbreak test suites (version-controlled) | 11.1.2 |
 | Automated harmful-content rate evaluation with regression detection | 11.1.3 |
 | RLHF / Constitutional AI alignment training | 11.1.4 |
-| Adversarial training and defensive distillation | 11.2.3 |
+| Adversarial training and equivalent hardening techniques applied where feasible | 11.2.3 |
+| Adversarial hardening configurations and procedures documented and reproducible | 11.2.5 |
 | Adversarially robust distillation — distill teacher into student using adversarial training so the student inherits robustness as well as accuracy (implementation example for 11.2.3) | 11.2.3 |
 | Certified robustness metrics tracking per model version with degradation alerting | 11.2.4 |
-| Formal robustness verification (certified bounds, interval-bound propagation) | 11.2.6 |
-| Post-transformation robustness re-certification (fine-tuning, distillation, quantization, adapter merging) | 11.2.7 |
+| Formal robustness verification (certified bounds, interval-bound propagation) | 11.2.7 |
+| Post-transformation robustness re-certification (fine-tuning, distillation, quantization, adapter merging) | 11.2.8 |
 | Adversarial-example detection with production alerting | 11.2.2 |
 | Model ensemble as evasion containment — route queries through independently trained models and flag disagreement beyond a threshold (implementation example for 11.2.2) | 11.2.2 |
 | Output calibration and perturbation for privacy | 11.3.1 |
@@ -357,7 +358,7 @@ Test for and defend against evasion, extraction, inversion, poisoning, and align
 | Membership inference attack simulation (shadow-model, likelihood-ratio) | 11.3.3 |
 | Model extraction detection (query-pattern analysis, diversity measurement) | 11.5.3 |
 | Statistical outlier and consistency scoring on external inputs | 11.6.1 |
-| Adaptive attack evasion testing | 11.6.4 |
+| Adaptive attack evasion testing | 11.6.5 |
 | AI-augmented review of high-risk agent actions (secondary model, structured self-review, ensemble-of-judges) supplementing the deterministic policy gate (C9.7.1) | 11.8.1 |
 | AI-augmented review mechanism protected against prompt-injection bypass | 11.8.2 |
 | Self-modification restriction with scope bounds and rate limits | 11.9.1, 11.9.5 |


### PR DESCRIPTION
Splits two compound requirements in C11 Adversarial Robustness per #693.

**11.2.3** (training applied + documented + reproducible) → **11.2.3**, **11.2.5**
**11.6.2** (threshold tuning + FPR measured) → **11.6.2**, **11.6.4**

Requirements sorted by level (L1 first, then L2, then L3) and renumbered sequentially.
Appendix D cross-references updated.