### PR TITLE
fix(C13): split compound requirements 13.1.1 and 13.3.1

### DIFF
--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -12,10 +12,11 @@ Generic logging and operational controls (log storage access control, retention,
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **13.1.1** | **Verify that** AI interactions are logged with security-relevant metadata (e.g. timestamp, user ID, session ID, model version, token count, input hash, system prompt version, confidence score, safety filter outcome, and safety filter decisions) without logging prompt or response content by default. | 1 |
-| **13.1.2** | **Verify that** policy decisions and safety filtering actions are logged with sufficient detail to enable audit and debugging of content moderation systems. | 2 |
-| **13.1.3** | **Verify that** log entries for AI inference events capture a structured, interoperable schema that includes at minimum model identifier, token usage (input and output), provider name, and operation type, to enable consistent AI observability across tools and platforms. | 2 |
-| **13.1.4** | **Verify that** full prompt and response content is logged only when a security-relevant event is detected (e.g., safety filter trigger, prompt injection detection, anomaly flag), or when required by explicit user consent and a documented legal basis. | 2 |
+| **13.1.1** | **Verify that** AI interactions are logged with security-relevant metadata (e.g., timestamp, user ID, session ID, model version, token count, input hash, system prompt version, confidence score, safety filter outcome, and safety filter decisions). | 1 |
+| **13.1.2** | **Verify that** AI interaction logs exclude prompt and response content by default, and that content logging is enabled only on explicit opt-in with documented justification. | 1 |
+| **13.1.3** | **Verify that** policy decisions and safety filtering actions are logged with sufficient detail to enable audit and debugging of content moderation systems. | 2 |
+| **13.1.4** | **Verify that** log entries for AI inference events capture a structured, interoperable schema that includes at minimum model identifier, token usage (input and output), provider name, and operation type, to enable consistent AI observability across tools and platforms. | 2 |
+| **13.1.5** | **Verify that** full prompt and response content is logged only when a security-relevant event is detected (e.g., safety filter trigger, prompt injection detection, anomaly flag), or when required by explicit user consent and a documented legal basis. | 2 |
 
 ---
 
@@ -42,7 +43,7 @@ Monitor and detect drift and degradation across model outputs, input distributio
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **13.3.1** | **Verify that** model performance metrics (accuracy, precision, recall, F1 score, confidence scores, latency, and error rates) are continuously monitored across model versions and time periods and compared against documented baselines. | 1 |
+| **13.3.1** | **Verify that** model performance metrics (accuracy, precision, recall, F1 score, confidence scores, latency, and error rates) are continuously monitored across model versions and time periods. | 1 |
 | **13.3.2** | **Verify that** data drift detection monitors input distribution changes that may impact model performance, using statistically validated methods appropriate to the data type. | 1 |
 | **13.3.3** | **Verify that** baseline performance profiles are formally documented and version-controlled, and are reviewed at a defined frequency or after any model or data pipeline change. | 2 |
 | **13.3.4** | **Verify that** automated alerting triggers when performance metrics exceed predefined degradation thresholds or deviate significantly from baselines. | 2 |

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -64,7 +64,7 @@ Protect stored data, models, secrets, logs, and backups through encryption.
 | --- | --- |
 | Training data encryption at rest | 1.2.3 |
 | Labeled data encryption | 1.3.5 |
-| Log encryption at rest | 13.1.3 |
+| Log encryption at rest | 13.1.4 |
 
 **Common pitfalls:** encrypting the database but not model checkpoints or embeddings; not encrypting logs that contain prompt/response data; storing encryption keys alongside the data they protect.
 
@@ -79,7 +79,7 @@ Protect data moving between services, agents, tools, and edge devices.
 | Mutual TLS with certificate validation for inter-service communication | 4.3.4 |
 | Authenticated streamable-HTTP transport with TLS 1.3 for MCP | 10.3.1, 10.3.2 |
 | SSE private channel with TLS enforcement | 10.3.2 |
-| Log encryption in transit | 13.1.3 |
+| Log encryption in transit | 13.1.4 |
 | MCP client minimum protocol version enforcement against downgrade negotiation | 10.3.6 |
 
 **Common pitfalls:** allowing plaintext interconnects in multi-tenant GPU clusters; using SSE over public internet without TLS; not validating certificates on internal service calls.
@@ -378,11 +378,12 @@ Capture security-relevant events with integrity protection for forensic analysis
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Prompt and response logging with metadata (timestamp, user ID, session, model version) | 13.1.1 |
-| Secure, access-controlled log repositories with retention policies | 13.1.2 |
-| Log encryption at rest and in transit | 13.1.3 |
-| PII, credential, and proprietary information redaction in logs | 13.1.4 |
-| Policy decision and safety filtering action logging | 13.1.2 |
+| Security-relevant metadata logging for AI interactions (timestamp, user ID, session ID, model version, token count, input hash, confidence score, safety filter outcome) | 13.1.1 |
+| AI interaction logs exclude prompt and response content by default, with content logging requiring explicit opt-in and documented justification | 13.1.2 |
+| Secure, access-controlled log repositories with retention policies | 13.1.3 |
+| Log encryption at rest and in transit | 13.1.4 |
+| PII, credential, and proprietary information redaction in logs | 13.1.5 |
+| Policy decision and safety filtering action logging | 13.1.3 |
 | Audit log context fields sufficient for forensic reconstruction (actor, delegation, policy, parameters, outcomes) | 9.4.3 |
 | Agent action signing with chain ID binding and timestamps | 9.4.2 |
 | Immutable audit records for model changes (actor, change type, before/after) | 3.2.6 |


### PR DESCRIPTION
Closes part of #693.

**13.1.1** bundled metadata logging with a content-exclusion default. Split into:
- **13.1.1** — log security-relevant metadata (timestamp, user ID, session ID, model version, token count, input hash, confidence score, safety filter outcome)
- **13.1.2** — exclude prompt/response content by default; content logging requires explicit opt-in with documented justification (positive reframe of the former negative clause)

**13.3.1** bundled continuous monitoring with baseline comparison. The second concern is already covered by 13.3.3 (documented baselines) and 13.3.4 (alerting on deviation), so 13.3.1 is narrowed to monitoring only.

Requirements sorted by level (L1 first, then L2, then L3) and renumbered sequentially.
Appendix D AD.16 updated accordingly.