### PR TITLE
fix(C14): reframe 14.1.4 positively and split compound 14.2.2

### DIFF
--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -17,7 +17,7 @@ Provide shutdown or rollback paths when unsafe behavior of the AI system is obse
 | **14.1.1** | **Verify that** a manual kill-switch mechanism exists to immediately halt AI model inference and outputs. | 1 |
 | **14.1.2** | **Verify that** kill-switch and intermediate-state mechanisms are exercised at a defined frequency, and that each test confirms the system reaches the target state within the documented response time and that all dependent components (e.g., agent runtimes, tool/MCP servers, retrieval connectors) transition as specified. | 2 |
 | **14.1.3** | **Verify that** the system can be placed into at least two intermediate operational states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined entry triggers and can be exited independently without requiring a full system restart or shutdown. | 2 |
-| **14.1.4** | **Verify that** override and kill-switch commands for autonomous agents are delivered and enforced through a channel that the agent runtime cannot access, intercept, or suppress (e.g., out-of-band infrastructure controls, hypervisor-level signals, network-layer isolation), so that a compromised or manipulated agent cannot prevent its own shutdown. | 2 |
+| **14.1.4** | **Verify that** override and kill-switch commands for autonomous agents are delivered through an out-of-band channel (e.g., infrastructure controls, hypervisor-level signals, network-layer isolation) that is architecturally isolated from the agent runtime, ensuring commands remain enforceable even if the agent runtime is compromised or manipulated. | 2 |
 
 ---
 
@@ -28,7 +28,8 @@ Define which AI decisions and agent actions require human approval so that runti
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **14.2.1** | **Verify that** a documented human oversight policy defines which AI decisions and agent actions are classified as high-risk, the criteria used to make that determination, and the approval authority required before execution. | 1 |
-| **14.2.2** | **Verify that** when a human-approval gate (per C14.2.1 and C9.2) is not satisfied within the defined approval time-to-live, the system applies a documented default action, that the default action is fail-closed (blocking the action) unless an alternative is explicitly authorized in the high-risk action policy, and that any non-fail-closed default is itself classified and approved as a high-risk policy decision. | 2 |
+| **14.2.2** | **Verify that** when a human-approval gate (per C14.2.1 and C9.2) is not satisfied within the defined approval time-to-live, the system applies a documented default action that is fail-closed (blocking the pending action). | 2 |
+| **14.2.3** | **Verify that** any deviation from the fail-closed default for an approval TTL expiry is explicitly authorized in the human oversight policy (C14.2.1) and is itself classified as a high-risk policy decision requiring approval authority sign-off. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -452,7 +452,8 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 | High-impact action approval gates (deploy, delete, financial, notify) | 9.2.1 |
 | Approval parameter binding (prevent approve-one-execute-another) | 9.2.2 |
 | High-impact intent confirmation with exact parameter binding and quick expiration | 9.2.3 |
-| Documented fail-closed default when human approval is not received within TTL | 14.2.2 |
+| Fail-closed default action (block pending action) when human approval is not received within TTL | 14.2.2 |
+| Any non-fail-closed TTL-expiry default explicitly authorized and classified as a high-risk policy decision requiring approval authority sign-off | 14.2.3 |
 | Human review on anomaly detection | 11.6.3 |
 | High-risk model quarantine with human review and sign-off | 6.1.3 |
 | Post-condition outcome checking with containment on mismatch | 9.7.2 |


### PR DESCRIPTION
Closes part of #693.

**14.1.4** had an implicit negative framing ("cannot access, intercept, or suppress"). Reframed to state the positive architectural property: the channel must be architecturally isolated from the agent runtime.

**14.2.2** bundled three concerns into one requirement. Split into:
- **14.2.2** — when the approval TTL expires, the system applies a documented default action that is fail-closed (blocks the pending action)
- **14.2.3** — any deviation from the fail-closed default is explicitly authorized in the high-risk action policy and is itself classified as a high-risk policy decision

Appendix D AD.19 updated accordingly.