### PR TITLE
fix(C07): move inline scope note into Control Objective

### DIFF
--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -4,15 +4,13 @@
 
 This control category ensures that model outputs are technically constrained, validated, and monitored so that unsafe, malformed, or high-risk responses cannot reach users or downstream systems. The chapter focuses on AI-specific output handling concerns and intentionally avoids duplicating controls that already exist in OWASP ASVS v5 or in other AISVS chapters.
 
-General application output controls such as output encoding and escaping, parameterized queries, safe deserialization, anti-automation, security event logging, and error handling are addressed by ASVS v5 chapters V1, V2, V14, and V16.
+General application output controls such as output encoding and escaping, parameterized queries, safe deserialization, anti-automation, security event logging, and error handling are addressed by ASVS v5 chapters V1, V2, V14, and V16. Schema output validation (7.1.1) applies only to applications that expect structured output (e.g., JSON, XML, typed function-call responses); free-form text outputs are out of scope for schema validation.
 
 ---
 
 ## C7.1 Output Format Enforcement
 
 Ensure the model outputs data in a way that helps prevent injection.
-
-> **Scope note:** 7.1.1 applies only to applications that expect structured output (e.g., JSON, XML, typed function-call responses). Free-form text outputs are out of scope for schema validation.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |


### PR DESCRIPTION
Closes #693.

The scope note for C7.1 (schema validation applies only to structured-output applications) was placed as a standalone blockquote between the section heading and the requirement table. Moved it into the Control Objective paragraph, consistent with how scope delimitation is handled in other AISVS chapters.