### PR TITLE
fix: tighten vague qualifiers across C01, C05, C07, C09, C11, C13 per #795

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -28,7 +28,7 @@ Restrict access to training data, encrypt it at rest and in transit, and validat
 | **1.2.1** | **Verify that** access controls protect training data storage and pipelines. | 1 |
 | **1.2.2** | **Verify that** all access to training data is logged, including user, time, and action. | 1 |
 | **1.2.3** | **Verify that** training datasets are encrypted in transit and at rest, using current recommended cryptographic algorithms and key management practices. | 1 |
-| **1.2.4** | **Verify that** training data is securely purged or anonymized when it is no longer required for the model's stated purpose or when its defined retention period expires. | 1 |
+| **1.2.4** | **Verify that** training data is securely purged or anonymized when it is no longer required for the model's stated purpose. | 1 |
 | **1.2.5** | **Verify that** cryptographic hashes or digital signatures are used to ensure data integrity during training data storage and transfer. | 2 |
 | **1.2.6** | **Verify that** automated integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
 | **1.2.7** | **Verify that** all training dataset versions are uniquely identified, stored immutably, and auditable to support rollback and forensic analysis. | 3 |

--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -13,9 +13,9 @@ Maintain a verifiable inventory of all datasets, accept only trusted sources, an
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **1.1.1** | **Verify that** an up-to-date inventory of every training-data source (origin, responsible party, license, collection method, intended use constraints, and processing history) is maintained. | 1 |
-| **1.1.2** | **Verify that** training data processes include only features, attributes, and fields specified in a documented data-minimization policy or feature inventory, excluding all others (e.g., unused metadata, sensitive PII, leaked test data). | 1 |
+| **1.1.2** | **Verify that** training data processes include only features, attributes, and fields required for the model's stated purpose, excluding all others (e.g., unused metadata, sensitive PII, leaked test data). | 1 |
 | **1.1.3** | **Verify that** all dataset changes are subject to a logged approval workflow. | 1 |
-| **1.1.4** | **Verify that** datasets or subsets are watermarked or fingerprinted to enable downstream attribution, with documented justification recorded for any datasets where this is omitted. | 3 |
+| **1.1.4** | **Verify that** datasets or subsets are watermarked or fingerprinted to enable downstream attribution and detection of unauthorized use. | 3 |
 
 ---
 
@@ -28,7 +28,7 @@ Restrict access to training data, encrypt it at rest and in transit, and validat
 | **1.2.1** | **Verify that** access controls protect training data storage and pipelines. | 1 |
 | **1.2.2** | **Verify that** all access to training data is logged, including user, time, and action. | 1 |
 | **1.2.3** | **Verify that** training datasets are encrypted in transit and at rest, using current recommended cryptographic algorithms and key management practices. | 1 |
-| **1.2.4** | **Verify that** training data is securely purged or anonymized when its retention period under a documented retention schedule expires. | 1 |
+| **1.2.4** | **Verify that** training data is securely purged or anonymized when it is no longer required for the model's stated purpose or when its defined retention period expires. | 1 |
 | **1.2.5** | **Verify that** cryptographic hashes or digital signatures are used to ensure data integrity during training data storage and transfer. | 2 |
 | **1.2.6** | **Verify that** automated integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
 | **1.2.7** | **Verify that** all training dataset versions are uniquely identified, stored immutably, and auditable to support rollback and forensic analysis. | 3 |
@@ -45,7 +45,7 @@ Ensure labeling and annotation processes are access-controlled and auditable.
 | **1.3.2** | **Verify that** all labeling activities are recorded in audit logs, including the annotator identity, timestamp, and action performed. | 1 |
 | **1.3.3** | **Verify that** annotator identity metadata is exported and retained alongside the dataset so that every annotation or preference pair can be attributed to a specific, verified human annotator throughout the training pipeline. | 1 |
 | **1.3.4** | **Verify that** cryptographic hashes or digital signatures are applied to labeling artifacts, annotation data, and fine-tuning feedback records (including RLHF preference pairs) to ensure their integrity and authenticity. | 2 |
-| **1.3.5** | **Verify that** sensitive information in labels is redacted, anonymized, or encrypted at rest and in transit, with the granularity of redaction or encryption applied per a documented data-classification policy. | 2 |
+| **1.3.5** | **Verify that** sensitive information in labels is redacted, anonymized, or encrypted both at rest and in transit before being used in any labeling artifact. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -13,9 +13,9 @@ Maintain a verifiable inventory of all datasets, accept only trusted sources, an
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **1.1.1** | **Verify that** an up-to-date inventory of every training-data source (origin, responsible party, license, collection method, intended use constraints, and processing history) is maintained. | 1 |
-| **1.1.2** | **Verify that** training data processes exclude unnecessary features, attributes, or fields (e.g., unused metadata, sensitive PII, leaked test data). | 1 |
+| **1.1.2** | **Verify that** training data processes include only features, attributes, and fields specified in a documented data-minimization policy or feature inventory, excluding all others (e.g., unused metadata, sensitive PII, leaked test data). | 1 |
 | **1.1.3** | **Verify that** all dataset changes are subject to a logged approval workflow. | 1 |
-| **1.1.4** | **Verify that** datasets or subsets are watermarked or fingerprinted where feasible. | 3 |
+| **1.1.4** | **Verify that** datasets or subsets are watermarked or fingerprinted to enable downstream attribution, with documented justification recorded for any datasets where this is omitted. | 3 |
 
 ---
 
@@ -28,7 +28,7 @@ Restrict access to training data, encrypt it at rest and in transit, and validat
 | **1.2.1** | **Verify that** access controls protect training data storage and pipelines. | 1 |
 | **1.2.2** | **Verify that** all access to training data is logged, including user, time, and action. | 1 |
 | **1.2.3** | **Verify that** training datasets are encrypted in transit and at rest, using current recommended cryptographic algorithms and key management practices. | 1 |
-| **1.2.4** | **Verify that** obsolete training data is securely purged or anonymized. | 1 |
+| **1.2.4** | **Verify that** training data is securely purged or anonymized when its retention period under a documented retention schedule expires. | 1 |
 | **1.2.5** | **Verify that** cryptographic hashes or digital signatures are used to ensure data integrity during training data storage and transfer. | 2 |
 | **1.2.6** | **Verify that** automated integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
 | **1.2.7** | **Verify that** all training dataset versions are uniquely identified, stored immutably, and auditable to support rollback and forensic analysis. | 3 |
@@ -45,7 +45,7 @@ Ensure labeling and annotation processes are access-controlled and auditable.
 | **1.3.2** | **Verify that** all labeling activities are recorded in audit logs, including the annotator identity, timestamp, and action performed. | 1 |
 | **1.3.3** | **Verify that** annotator identity metadata is exported and retained alongside the dataset so that every annotation or preference pair can be attributed to a specific, verified human annotator throughout the training pipeline. | 1 |
 | **1.3.4** | **Verify that** cryptographic hashes or digital signatures are applied to labeling artifacts, annotation data, and fine-tuning feedback records (including RLHF preference pairs) to ensure their integrity and authenticity. | 2 |
-| **1.3.5** | **Verify that** sensitive information in labels is redacted, anonymized, or encrypted using appropriate granularity at rest and in transit. | 2 |
+| **1.3.5** | **Verify that** sensitive information in labels is redacted, anonymized, or encrypted at rest and in transit, with the granularity of redaction or encryption applied per a documented data-classification policy. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -15,7 +15,7 @@ Agent-specific authorization policies and delegation are covered in C9.6; single
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.1.1** | **Verify that** high-risk AI operations (model deployment, weight export, training data access, production configuration changes) require step-up authentication with session re-validation. | 2 |
-| **5.1.2** | **Verify that** AI agents in federated or multi-system deployments authenticate using short-lived, cryptographically signed tokens (e.g., signed JWT assertions) that bind the token to its issuer. | 3 |
+| **5.1.2** | **Verify that** AI agents in federated or multi-system deployments authenticate using short-lived, cryptographically signed tokens (e.g., signed JWT assertions) where the signature key is bound to the issuing system's identity (e.g., via JWKS, x5c, or sender-constrained tokens such as DPoP or mTLS). | 3 |
 
 ---
 

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -15,7 +15,7 @@ Agent-specific authorization policies and delegation are covered in C9.6; single
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.1.1** | **Verify that** high-risk AI operations (model deployment, weight export, training data access, production configuration changes) require step-up authentication with session re-validation. | 2 |
-| **5.1.2** | **Verify that** AI agents in federated or multi-system deployments authenticate via short-lived, cryptographically signed authentication tokens (e.g., signed JWT assertions) with a maximum lifetime appropriate to the risk level and including cryptographic proof of origin. | 3 |
+| **5.1.2** | **Verify that** AI agents in federated or multi-system deployments authenticate via short-lived, cryptographically signed authentication tokens (e.g., signed JWT assertions) with a maximum lifetime set per a documented token policy that tiers lifetime by operation sensitivity, and including cryptographic proof of origin. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -15,7 +15,7 @@ Agent-specific authorization policies and delegation are covered in C9.6; single
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.1.1** | **Verify that** high-risk AI operations (model deployment, weight export, training data access, production configuration changes) require step-up authentication with session re-validation. | 2 |
-| **5.1.2** | **Verify that** AI agents in federated or multi-system deployments authenticate via short-lived, cryptographically signed authentication tokens (e.g., signed JWT assertions) with a maximum lifetime set per a documented token policy that tiers lifetime by operation sensitivity, and including cryptographic proof of origin. | 3 |
+| **5.1.2** | **Verify that** AI agents in federated or multi-system deployments authenticate via short-lived, cryptographically signed authentication tokens (e.g., signed JWT assertions) with a defined and enforced maximum token lifetime, and including cryptographic proof of origin. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -15,7 +15,7 @@ Agent-specific authorization policies and delegation are covered in C9.6; single
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.1.1** | **Verify that** high-risk AI operations (model deployment, weight export, training data access, production configuration changes) require step-up authentication with session re-validation. | 2 |
-| **5.1.2** | **Verify that** AI agents in federated or multi-system deployments authenticate via short-lived, cryptographically signed authentication tokens (e.g., signed JWT assertions) with a defined and enforced maximum token lifetime, and including cryptographic proof of origin. | 3 |
+| **5.1.2** | **Verify that** AI agents in federated or multi-system deployments authenticate using short-lived, cryptographically signed tokens (e.g., signed JWT assertions) that bind the token to its issuer. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -42,7 +42,7 @@ Technical controls to detect and scrub bad content before it is shown to the use
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **7.3.1** | **Verify that** automated classifiers scan every response and block content that matches hate, harassment, or sexual violence categories. | 1 |
 | **7.3.2** | **Verify that** output filters detect and block responses that disclose system prompt content, including verbatim reproduction and semantically equivalent paraphrases of instructions, role definitions, or policy directives. | 2 |
-| **7.3.3** | **Verify that** LLM client applications prevent model-generated output from triggering automatic outbound requests (e.g., auto-rendered images, iframes, or link prefetching) to attacker-controlled endpoints, for example by disabling automatic external resource loading or restricting it to explicitly allowlisted origins as appropriate. | 2 |
+| **7.3.3** | **Verify that** LLM client applications prevent model-generated output from triggering automatic outbound requests (e.g., auto-rendered images, iframes, or link prefetching) to attacker-controlled endpoints, for example by disabling automatic external resource loading or by restricting it to an explicitly allowlisted set of origins. | 2 |
 | **7.3.4** | **Verify that** generated outputs are analyzed for statistical steganographic covert channels (e.g., biased token-choice patterns or output distribution anomalies) that could encode hidden data across the model's valid output space, and that detections are flagged for review. | 3 |
 
 ---

--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -39,7 +39,7 @@ Constrain tool and plugin execution, loading, and outputs to prevent unauthorize
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.3.1** | **Verify that** each tool/plugin executes in an isolated sandbox (container/VM/WASM/OS sandbox) with least-privilege filesystem, network egress, and syscall permissions appropriate to the tool's function. | 1 |
+| **9.3.1** | **Verify that** each tool/plugin executes in an isolated sandbox (container/VM/WASM/OS sandbox) with least-privilege filesystem, network egress, and syscall permissions scoped to the minimum required to perform the tool's documented function. | 1 |
 | **9.3.2** | **Verify that** per-tool quotas and timeouts (CPU, memory, disk, egress, execution time) are enforced, and that quota or timeout breaches fail closed by terminating the tool execution rather than continuing with degraded or uncontrolled behavior. | 1 |
 | **9.3.3** | **Verify that** tool outputs are validated against strict schemas and security policies before being incorporated into downstream reasoning or follow-on actions. | 1 |
 | **9.3.4** | **Verify that** quota and timeout breaches are logged with sufficient detail to identify the tool, the exceeded limit, and the time of breach. | 1 |

--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -39,7 +39,7 @@ Constrain tool and plugin execution, loading, and outputs to prevent unauthorize
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.3.1** | **Verify that** each tool/plugin executes in an isolated sandbox (container/VM/WASM/OS sandbox) with least-privilege filesystem, network egress, and syscall permissions scoped to the minimum required to perform the tool's documented function. | 1 |
+| **9.3.1** | **Verify that** each tool/plugin executes in an isolated sandbox (container/VM/WASM/OS sandbox) with least-privilege filesystem, network egress, and syscall permissions limited to those required for the tool to perform its operations. | 1 |
 | **9.3.2** | **Verify that** per-tool quotas and timeouts (CPU, memory, disk, egress, execution time) are enforced, and that quota or timeout breaches fail closed by terminating the tool execution rather than continuing with degraded or uncontrolled behavior. | 1 |
 | **9.3.3** | **Verify that** tool outputs are validated against strict schemas and security policies before being incorporated into downstream reasoning or follow-on actions. | 1 |
 | **9.3.4** | **Verify that** quota and timeout breaches are logged with sufficient detail to identify the tool, the exceeded limit, and the time of breach. | 1 |

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -30,7 +30,7 @@ Increase resilience to manipulated inputs designed to cause misclassification or
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.2.1** | **Verify that** models serving high-risk functions are evaluated against known adversarial attack techniques relevant to their modality (e.g., perturbation attacks for vision, token-manipulation attacks for text, trigger-based or instruction-injection backdoors where applicable). | 1 |
 | **11.2.2** | **Verify that** adversarial-example detection raises alerts in production pipelines, with blocking or degraded-capability responses for high-risk endpoints or use cases. | 2 |
-| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied where feasible. | 2 |
+| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied to models designated for hardening in the documented adversarial threat model. | 2 |
 | **11.2.4** | **Verify that** certified robustness metrics (e.g., certified radius, verified robust accuracy at defined perturbation bounds) are tracked and recorded per model version, and that degradation beyond defined thresholds triggers re-evaluation before deployment. | 2 |
 | **11.2.5** | **Verify that** adversarial hardening configurations and procedures are documented and reproducible. | 2 |
 | **11.2.6** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 |
@@ -86,10 +86,10 @@ Identify and neutralize manipulated, backdoored, or adversarial data entering th
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.6.1** | **Verify that** inputs from external or untrusted sources pass through anomaly detection (e.g., statistical outlier detection, consistency scoring) before model inference. | 2 |
 | **11.6.2** | **Verify that** anomaly-detection thresholds are tuned on representative clean and adversarial validation sets. | 2 |
-| **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review) appropriate to the risk level. | 2 |
+| **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review) selected per a documented gating policy that maps risk tier to action. | 2 |
 | **11.6.4** | **Verify that** the false-positive rate of anomaly detection is measured on representative data and documented per model version. | 2 |
-| **11.6.5** | **Verify that** detection methods are periodically stress-tested with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
-| **11.6.6** | **Verify that** detection efficacy metrics are logged and periodically re-evaluated against updated threat intelligence. | 3 |
+| **11.6.5** | **Verify that** detection methods are stress-tested at a defined frequency with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
+| **11.6.6** | **Verify that** detection efficacy metrics are logged and re-evaluated at a defined frequency against updated threat intelligence. | 3 |
 
 ---
 
@@ -102,7 +102,7 @@ Maintain the ability to update AI safety and guardrail policies rapidly in respo
 | **11.7.1** | **Verify that** security policies (e.g., content filters, rate-limit thresholds, guardrail configurations) can be updated without full system redeployment, and that policy versions are tracked. | 1 |
 | **11.7.2** | **Verify that** policy updates are authorized, integrity-protected (e.g., cryptographically signed), and validated before application. | 2 |
 | **11.7.3** | **Verify that** rollback procedures exist for policy changes and are tested to confirm they restore the previous policy state. | 2 |
-| **11.7.4** | **Verify that** threat-detection sensitivity can be adjusted based on risk context (e.g., elevated threat level, incident response) with appropriate authorization. | 3 |
+| **11.7.4** | **Verify that** threat-detection sensitivity can be adjusted based on risk context (e.g., elevated threat level, incident response), and that the change requires authorization from a role explicitly designated in policy as authorized to change detection sensitivity. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -30,7 +30,7 @@ Increase resilience to manipulated inputs designed to cause misclassification or
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.2.1** | **Verify that** models serving high-risk functions are evaluated against known adversarial attack techniques relevant to their modality (e.g., perturbation attacks for vision, token-manipulation attacks for text, trigger-based or instruction-injection backdoors where applicable). | 1 |
 | **11.2.2** | **Verify that** adversarial-example detection raises alerts in production pipelines, with blocking or degraded-capability responses for high-risk endpoints or use cases. | 2 |
-| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied to models serving high-risk functions. | 2 |
+| **11.2.3** | **Verify that** models serving high-risk functions are hardened against adversarial inputs using one or more techniques such as adversarial training, randomized smoothing, defensive distillation, or input transformation. | 2 |
 | **11.2.4** | **Verify that** certified robustness metrics (e.g., certified radius, verified robust accuracy at defined perturbation bounds) are tracked and recorded per model version, and that degradation beyond defined thresholds triggers re-evaluation before deployment. | 2 |
 | **11.2.5** | **Verify that** adversarial hardening configurations and procedures are documented and reproducible. | 2 |
 | **11.2.6** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 |

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -86,7 +86,7 @@ Identify and neutralize manipulated, backdoored, or adversarial data entering th
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.6.1** | **Verify that** inputs from external or untrusted sources pass through anomaly detection (e.g., statistical outlier detection, consistency scoring) before model inference. | 2 |
 | **11.6.2** | **Verify that** anomaly-detection thresholds are tuned on representative clean and adversarial validation sets. | 2 |
-| **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review) selected by a predefined mapping from anomaly type to action. | 2 |
+| **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review). | 2 |
 | **11.6.4** | **Verify that** the false-positive rate of anomaly detection is measured on representative data and documented per model version. | 2 |
 | **11.6.5** | **Verify that** detection methods are stress-tested at a defined frequency with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
 | **11.6.6** | **Verify that** detection efficacy metrics are logged and re-evaluated at a defined frequency against updated threat intelligence. | 3 |

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -30,7 +30,7 @@ Increase resilience to manipulated inputs designed to cause misclassification or
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.2.1** | **Verify that** models serving high-risk functions are evaluated against known adversarial attack techniques relevant to their modality (e.g., perturbation attacks for vision, token-manipulation attacks for text, trigger-based or instruction-injection backdoors where applicable). | 1 |
 | **11.2.2** | **Verify that** adversarial-example detection raises alerts in production pipelines, with blocking or degraded-capability responses for high-risk endpoints or use cases. | 2 |
-| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied to models designated for hardening in the documented adversarial threat model. | 2 |
+| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied to models serving high-risk functions (per 11.2.1). | 2 |
 | **11.2.4** | **Verify that** certified robustness metrics (e.g., certified radius, verified robust accuracy at defined perturbation bounds) are tracked and recorded per model version, and that degradation beyond defined thresholds triggers re-evaluation before deployment. | 2 |
 | **11.2.5** | **Verify that** adversarial hardening configurations and procedures are documented and reproducible. | 2 |
 | **11.2.6** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 |
@@ -86,7 +86,7 @@ Identify and neutralize manipulated, backdoored, or adversarial data entering th
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.6.1** | **Verify that** inputs from external or untrusted sources pass through anomaly detection (e.g., statistical outlier detection, consistency scoring) before model inference. | 2 |
 | **11.6.2** | **Verify that** anomaly-detection thresholds are tuned on representative clean and adversarial validation sets. | 2 |
-| **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review) selected per a documented gating policy that maps risk tier to action. | 2 |
+| **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review) selected by a predefined mapping from anomaly type to action. | 2 |
 | **11.6.4** | **Verify that** the false-positive rate of anomaly detection is measured on representative data and documented per model version. | 2 |
 | **11.6.5** | **Verify that** detection methods are stress-tested at a defined frequency with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
 | **11.6.6** | **Verify that** detection efficacy metrics are logged and re-evaluated at a defined frequency against updated threat intelligence. | 3 |
@@ -102,7 +102,7 @@ Maintain the ability to update AI safety and guardrail policies rapidly in respo
 | **11.7.1** | **Verify that** security policies (e.g., content filters, rate-limit thresholds, guardrail configurations) can be updated without full system redeployment, and that policy versions are tracked. | 1 |
 | **11.7.2** | **Verify that** policy updates are authorized, integrity-protected (e.g., cryptographically signed), and validated before application. | 2 |
 | **11.7.3** | **Verify that** rollback procedures exist for policy changes and are tested to confirm they restore the previous policy state. | 2 |
-| **11.7.4** | **Verify that** threat-detection sensitivity can be adjusted based on risk context (e.g., elevated threat level, incident response), and that the change requires authorization from a role explicitly designated in policy as authorized to change detection sensitivity. | 3 |
+| **11.7.4** | **Verify that** threat-detection sensitivity can be adjusted based on risk context (e.g., elevated threat level, incident response), and that the change requires authentication and a privilege explicitly granted for this operation, with the change logged. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -30,7 +30,7 @@ Increase resilience to manipulated inputs designed to cause misclassification or
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.2.1** | **Verify that** models serving high-risk functions are evaluated against known adversarial attack techniques relevant to their modality (e.g., perturbation attacks for vision, token-manipulation attacks for text, trigger-based or instruction-injection backdoors where applicable). | 1 |
 | **11.2.2** | **Verify that** adversarial-example detection raises alerts in production pipelines, with blocking or degraded-capability responses for high-risk endpoints or use cases. | 2 |
-| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied to models serving high-risk functions (per 11.2.1). | 2 |
+| **11.2.3** | **Verify that** adversarial training or equivalent hardening techniques are applied to models serving high-risk functions. | 2 |
 | **11.2.4** | **Verify that** certified robustness metrics (e.g., certified radius, verified robust accuracy at defined perturbation bounds) are tracked and recorded per model version, and that degradation beyond defined thresholds triggers re-evaluation before deployment. | 2 |
 | **11.2.5** | **Verify that** adversarial hardening configurations and procedures are documented and reproducible. | 2 |
 | **11.2.6** | **Verify that** robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases. | 3 |

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -102,7 +102,7 @@ Maintain the ability to update AI safety and guardrail policies rapidly in respo
 | **11.7.1** | **Verify that** security policies (e.g., content filters, rate-limit thresholds, guardrail configurations) can be updated without full system redeployment, and that policy versions are tracked. | 1 |
 | **11.7.2** | **Verify that** policy updates are authorized, integrity-protected (e.g., cryptographically signed), and validated before application. | 2 |
 | **11.7.3** | **Verify that** rollback procedures exist for policy changes and are tested to confirm they restore the previous policy state. | 2 |
-| **11.7.4** | **Verify that** threat-detection sensitivity can be adjusted based on risk context (e.g., elevated threat level, incident response), and that the change requires authentication and a privilege explicitly granted for this operation, with the change logged. | 3 |
+| **11.7.4** | **Verify that** threat-detection sensitivity can be adjusted based on risk context (e.g., elevated threat level, incident response). | 3 |
 
 ---
 

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -88,8 +88,8 @@ Identify and neutralize manipulated, backdoored, or adversarial data entering th
 | **11.6.2** | **Verify that** anomaly-detection thresholds are tuned on representative clean and adversarial validation sets. | 2 |
 | **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review). | 2 |
 | **11.6.4** | **Verify that** the false-positive rate of anomaly detection is measured on representative data and documented per model version. | 2 |
-| **11.6.5** | **Verify that** detection methods are stress-tested at a defined frequency with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
-| **11.6.6** | **Verify that** detection efficacy metrics are logged and re-evaluated at a defined frequency against updated threat intelligence. | 3 |
+| **11.6.5** | **Verify that** detection methods are periodically stress-tested with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
+| **11.6.6** | **Verify that** detection efficacy metrics are logged and periodically re-evaluated against updated threat intelligence. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -46,7 +46,7 @@ Monitor and detect drift and degradation across model outputs, input distributio
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **13.3.1** | **Verify that** model performance metrics (accuracy, precision, recall, F1 score, confidence scores, latency, and error rates) are continuously monitored across model versions and time periods. | 1 |
-| **13.3.2** | **Verify that** data drift detection monitors input distribution changes that may impact model performance, using statistically validated methods appropriate to the data type. | 1 |
+| **13.3.2** | **Verify that** data drift detection monitors input distribution changes that may impact model performance, using statistically validated methods documented for each input data type (e.g., KS test or PSI for tabular numeric features, embedding-distance metrics for text or image). | 1 |
 | **13.3.3** | **Verify that** baseline performance profiles are formally documented and version-controlled, and are reviewed at a defined frequency or after any model or data pipeline change. | 2 |
 | **13.3.4** | **Verify that** automated alerting triggers when performance metrics exceed predefined degradation thresholds or deviate significantly from baselines. | 2 |
 | **13.3.5** | **Verify that** hallucination detection monitors identify and flag instances when model outputs contain factually incorrect, inconsistent, or fabricated information. | 2 |

--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -46,7 +46,7 @@ Monitor and detect drift and degradation across model outputs, input distributio
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **13.3.1** | **Verify that** model performance metrics (accuracy, precision, recall, F1 score, confidence scores, latency, and error rates) are continuously monitored across model versions and time periods. | 1 |
-| **13.3.2** | **Verify that** data drift detection monitors input distribution changes that may impact model performance, using statistically validated methods documented for each input data type (e.g., KS test or PSI for tabular numeric features, embedding-distance metrics for text or image). | 1 |
+| **13.3.2** | **Verify that** data drift detection monitors input distribution changes that may impact model performance, using statistically validated methods matched to the input data type (e.g., KS test or PSI for tabular numeric features, embedding-distance metrics for text or image). | 1 |
 | **13.3.3** | **Verify that** baseline performance profiles are formally documented and version-controlled, and are reviewed at a defined frequency or after any model or data pipeline change. | 2 |
 | **13.3.4** | **Verify that** automated alerting triggers when performance metrics exceed predefined degradation thresholds or deviate significantly from baselines. | 2 |
 | **13.3.5** | **Verify that** hallucination detection monitors identify and flag instances when model outputs contain factually incorrect, inconsistent, or fabricated information. | 2 |


### PR DESCRIPTION
Closes #795.

## Summary

Tightens every requirement-level instance of "appropriate / unnecessary / where feasible / obsolete / as appropriate / with appropriate authorization / periodically" so each one anchors on a technical property the auditor can verify directly.

Scope was expanded mid-pass from the original issue to also cover the cadence qualifier "periodically" called out as a follow-up.

A first revision swapped the vague qualifiers for "per a documented X policy / schedule / threat model". That was a regression (it just relocates the vague qualifier — the auditor still has to ask "what policy?"), so a second pass reworded each one to name the technical condition itself.

## Per-requirement changes (final state)

| Req | Change |
| --- | --- |
| 1.1.2 | features limited to those required for the model's stated purpose |
| 1.1.4 | drop "where feasible" entirely; require watermarking or fingerprinting (L3) |
| 1.2.4 | purge/anonymize when no longer required for the model's stated purpose |
| 1.3.5 | require redaction, anonymization, or encryption at rest and in transit before use; drop granularity language |
| 5.1.2 | short-lived signed tokens that bind the token to its issuer |
| 7.3.3 | drop "as appropriate" qualifier on origin allowlisting |
| 9.3.1 | sandbox permissions limited to those required for the tool to perform its operations |
| 11.2.3 | scope to "models serving high-risk functions" with concrete technique list (adversarial training, randomized smoothing, defensive distillation, input transformation) |
| 11.6.3 | drop "appropriate to the risk level" qualifier; require a gating action when input is flagged |
| 11.7.4 | requires authentication and a privilege explicitly granted for the operation, with the change logged |
| 13.3.2 | "matched to the input data type" with concrete method examples per type |

## Retained as-is

- 1.4.6 keeps "appropriate defenses" because "based on risk assessment" is the anchor.
- 4.2.6 keeps "appropriate assurance level" because the FIPS 140-3 / Common Criteria EAL examples are the anchor.

Anchored hits in C03, C06, C07, C09, C11, C13 (e.g., "sufficient detail to reconstruct...", "relevant to their modality") were left alone per the inventory triage in #795.

11.6.5 and 11.6.6 ("periodically stress-tested", "periodically re-evaluated") were initially reworded in this PR but reverted. They are program/process management requirements (GRC) rather than technical control properties, so a separate proposal handles their removal rather than tightening them in place.

## Verification

Re-running the audit grep on the final tree returns only the two intentionally retained hits in the touched chapters, and no new "documented policy" framing in any reworded requirement.

No level changes. No requirement scope changes. Pure wording tightening for auditability.
