### PR TITLE
fix(C11): remove 11.6.5 and 11.6.6 as GRC per #797

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -88,8 +88,6 @@ Identify and neutralize manipulated, backdoored, or adversarial data entering th
 | **11.6.2** | **Verify that** anomaly-detection thresholds are tuned on representative clean and adversarial validation sets. | 2 |
 | **11.6.3** | **Verify that** inputs flagged as anomalous trigger gating actions (blocking, capability degradation, or human review) appropriate to the risk level. | 2 |
 | **11.6.4** | **Verify that** the false-positive rate of anomaly detection is measured on representative data and documented per model version. | 2 |
-| **11.6.5** | **Verify that** detection methods are periodically stress-tested with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
-| **11.6.6** | **Verify that** detection efficacy metrics are logged and periodically re-evaluated against updated threat intelligence. | 3 |
 
 ---
 


### PR DESCRIPTION
Closes #797.

## Summary

Removes 11.6.5 and 11.6.6 from C11.6. Both describe program-management cadence (run stress tests on a recurring basis; review metrics on a recurring basis) rather than technical properties of an AI security control. They fit the Review Checklist exclusion: "Governance, compliance, and organizational policy are out of scope."

## What was removed

```
| **11.6.5** | **Verify that** detection methods are periodically stress-tested with current adversarial techniques, including adaptive attacks designed to evade the specific detectors in use. | 3 |
| **11.6.6** | **Verify that** detection efficacy metrics are logged and periodically re-evaluated against updated threat intelligence. | 3 |
```

## What's left in C11.6

The technical detection capability is complete without these two:

- 11.6.1: anomaly detection on inputs from external sources
- 11.6.2: tuning thresholds on validation sets
- 11.6.3: gating actions when inputs are flagged
- 11.6.4: false-positive rate measured and documented per model version

The "do this on a recurring basis" instruction layered on top is testing-program management — covered by ISO/IEC 27001 (clauses 9 and 10) and NIST CSF.

No renumbering needed; both removed entries sit at the end of the section.
