### PR TITLE
fix(C03/C06): sharpen AI BOM boundary per #787

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -14,7 +14,7 @@ Only authorized models with verified integrity reach production environments.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **3.1.1** | **Verify that** a model registry maintains an inventory of all deployed model artifacts and produces a machine-readable Model/AI Bill of Materials (MBOM/AIBOM) (e.g., SPDX or CycloneDX). | 1 |
+| **3.1.1** | **Verify that** a model registry maintains an inventory of all deployed model artifacts with version, environment, and integrity metadata. AI BOM publication is covered in C6.5. | 1 |
 | **3.1.2** | **Verify that** all model artifacts (weights, configurations, tokenizers, base models, fine-tunes, adapters, and safety/policy models) are cryptographically signed by authorized entities. | 1 |
 | **3.1.3** | **Verify that** model artifact signatures and integrity checksums are verified at deployment admission and on load, and unsigned, tampered, or mismatched artifacts are rejected. | 1 |
 | **3.1.4** | **Verify that** lineage and dependency tracking maintains a dependency graph that enables identification of all consuming services and agents per environment (e.g., dev, staging, prod). | 3 |

--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -14,7 +14,7 @@ Only authorized models with verified integrity reach production environments.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **3.1.1** | **Verify that** a model registry maintains an inventory of all deployed model artifacts with version, environment, and integrity metadata. AI BOM publication is covered in C6.5. | 1 |
+| **3.1.1** | **Verify that** a model registry maintains an inventory of all deployed model artifacts. | 1 |
 | **3.1.2** | **Verify that** all model artifacts (weights, configurations, tokenizers, base models, fine-tunes, adapters, and safety/policy models) are cryptographically signed by authorized entities. | 1 |
 | **3.1.3** | **Verify that** model artifact signatures and integrity checksums are verified at deployment admission and on load, and unsigned, tampered, or mismatched artifacts are rejected. | 1 |
 | **3.1.4** | **Verify that** lineage and dependency tracking maintains a dependency graph that enables identification of all consuming services and agents per environment (e.g., dev, staging, prod). | 3 |

--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -63,7 +63,7 @@ Generate and sign detailed AI-specific bills of materials (AI BOMs) so downstrea
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.5.1** | **Verify that** every model artifact publishes a version-controlled AI BOM that lists datasets, weights, hyperparameters, licenses, export-control tags, and data-origin statements. | 1 |
+| **6.5.1** | **Verify that** every model artifact publishes a version-controlled, machine-readable AI BOM (e.g., CycloneDX or SPDX) that lists datasets, weights, hyperparameters, licenses, export-control tags, and data-origin statements. | 1 |
 | **6.5.2** | **Verify that** AI BOMs are cryptographically signed before deployment. | 2 |
 | **6.5.3** | **Verify that** AI BOM completeness checks fail the build if any component metadata (hash and license) is missing. | 2 |
 | **6.5.4** | **Verify that** downstream consumers can query AI BOMs via API to validate imported models at deployment time. | 2 |

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -255,7 +255,8 @@ Verify origin and authenticity, scan dependencies, and enforce integrity of mode
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Model registry with AI BOM (SPDX, CycloneDX) | 3.1.1, 6.5.1 |
+| Model registry inventory of deployed model artifacts | 3.1.1 |
+| AI BOM publication (CycloneDX, SPDX) | 6.5.1 |
 | Model dependency graph tracking (services, agents, environments) | 3.1.4 |
 | Model origin records (source, training data checksums, authorship) | 3.1.5, 6.1.1 |
 | Automated reproducible builds | ASVS v5 V15 / SLSA |


### PR DESCRIPTION
Closes #787.

3.1.1 and 6.5.1 were both L1 controls demanding AI BOM production. Auditors hit them as duplicates and tooling that maps controls would have to pick one arbitrarily. The whole C6.5 section is dedicated to AI BOMs (signing, completeness, query API) and the supporting references (CycloneDX MLBOM, OWASP AIBOM) live in C06, so C6.5.1 is the natural canonical home.

## Changes

- **C3.1.1** trimmed to a minimal registry inventory statement. The AI BOM clause is gone. C3.1.1 keeps the registry function (which artifacts exist), C6.5.1 owns BOM content (what is in each artifact). The two are no longer in tension.
- **C6.5.1** picks up the machine-readable format guidance (CycloneDX, SPDX) that previously lived in 3.1.1, so nothing is lost.
- **Appendix D** AD.12 row split so 3.1.1 maps to registry inventory and 6.5.1 maps to AI BOM publication.

## Notes

- 3.1.1 deliberately does not cross-reference C6.5. Each control stands alone.
- Glossary already lists AI BOM as canonical with AIBOM/MBOM as aliases, so no glossary edit needed.
- Terminology now consistent: dropped the "MBOM/AIBOM" double-name in favor of "AI BOM" (matches the rest of C06 and the references).
- Symmetry with C3.5.1 (hosted model inventory, L1) is preserved: 3.1.1 covers self-hosted model inventory at L1.
