### PR TITLE
fix(C11/C14): order C11.5 by level, expand C14 references per #789

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -72,8 +72,8 @@ Detect and deter unauthorized model cloning through API abuse. Rate limiting, qu
 | **11.5.1** | **Verify that** inference endpoints enforce per-principal and global rate limits sized to the extraction threat model, and not solely as a generic API throttle. | 1 |
 | **11.5.2** | **Verify that** extraction-alert events include offending query metadata (e.g., source principal, query volume, input distribution statistics) to support investigation. | 2 |
 | **11.5.3** | **Verify that** query-pattern analysis (e.g., query diversity, input distribution anomalies, output-space coverage anomalies) feeds an automated extraction-attempt detector. | 2 |
-| **11.5.4** | **Verify that** model watermarking or fingerprinting techniques are applied so that unauthorized copies can be identified. | 3 |
-| **11.5.5** | **Verify that** raw model outputs (e.g., full posterior distributions, output vectors) are not directly exposed beyond the application backend, and that externally visible responses minimize output informativeness calibrated to the extraction risk level. | 2 |
+| **11.5.4** | **Verify that** raw model outputs (e.g., full posterior distributions, output vectors) are not directly exposed beyond the application backend, and that externally visible responses minimize output informativeness calibrated to the extraction risk level. | 2 |
+| **11.5.5** | **Verify that** model watermarking or fingerprinting techniques are applied so that unauthorized copies can be identified. | 3 |
 | **11.5.6** | **Verify that** detection of suspected extraction activity triggers adaptive response measures proportional to estimated extraction risk. | 3 |
 
 ---

--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -44,3 +44,11 @@ Capture human-initiated oversight events so that override and mode-change action
 ## References
 
 * [MITRE ATLAS: Human In-the-Loop for AI Agent Actions](https://atlas.mitre.org/mitigations/AML.M0029)
+* [NIST AI 100-1: AI Risk Management Framework (AI RMF 1.0)](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-1.pdf)
+* [NIST AI 600-1: Generative AI Profile (AI RMF Companion)](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf)
+* [ISO/IEC 42001:2023 Artificial Intelligence Management System](https://www.iso.org/standard/42001)
+* [ISO/IEC 23894:2023 Artificial Intelligence Risk Management Guidance](https://www.iso.org/standard/77304.html)
+* [Regulation (EU) 2024/1689 (EU AI Act), Article 14: Human Oversight](https://eur-lex.europa.eu/eli/reg/2024/1689/oj)
+* [OECD Recommendation on Artificial Intelligence](https://legalinstruments.oecd.org/en/instruments/OECD-LEGAL-0449)
+* [OWASP Top 10 for LLM Applications 2025: LLM06 Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/)
+* [OWASP AI Exchange: Human Oversight Controls](https://owaspai.org/)

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -112,7 +112,7 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 | Build signature validation at deployment | ASVS v5 V15 / SLSA |
 | Third-party model origin and integrity verification (signed records) | 6.1.1 |
 | Cryptographic signature validation for model publishers | 6.2.1, 6.2.2 |
-| Model watermarking and fingerprinting | 11.5.4 |
+| Model watermarking and fingerprinting | 11.5.5 |
 | Execution chain cryptographic binding (chain ID) for agent actions | 9.4.2 |
 | Agent action signing and timestamps for non-repudiation and traceability | 9.4.4 |
 | MCP component signature and checksum verification | 10.1.1 |


### PR DESCRIPTION
Closes #789.

## C11.5 ordering

C11.5 had an L3 watermarking control placed before an L2 raw-output exposure control, breaking the L1->L2->L3 sort that the rest of C11 follows (the convention from #736).

- 11.5.4 was L3 (watermarking), 11.5.5 was L2 (raw model outputs / output informativeness).
- Swapped: 11.5.4 is now the L2 raw-output control, 11.5.5 is the L3 watermarking control. 11.5.6 (L3 adaptive response) unchanged.
- Updated the Appendix D cross-reference for "Model watermarking and fingerprinting" from 11.5.4 to 11.5.5.

C11.7 and C11.9 were already in correct level order, so no changes there.

## C14 References

The C14 References section only listed MITRE ATLAS. Added the canonical authorities this chapter leans on:

- NIST AI 100-1 (AI RMF) and AI 600-1 (GenAI profile)
- ISO/IEC 42001:2023 and ISO/IEC 23894:2023
- EU AI Act, Article 14 (Human Oversight)
- OECD Recommendation on AI
- OWASP LLM06 Excessive Agency
- OWASP AI Exchange

## Files changed

- 1.0/en/0x10-C11-Adversarial-Robustness.md
- 1.0/en/0x10-C14-Human-Oversight.md
- 1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
