### PR TITLE
fix(C3): drop 3.3.4 and 3.3.5, kill-switch lives in C14.1 (#786)

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -48,8 +48,6 @@ Model deployments must be controlled, monitored, and reversible.
 | **3.3.1** | **Verify that** production deployments implement gradual rollout mechanisms (e.g., canary or blue-green deployments) with automated rollback triggers based on pre-agreed error rates, latency thresholds, guardrail alerts, or tool/MCP failure rates. | 2 |
 | **3.3.2** | **Verify that** rollback capabilities restore the complete model state (weights, configurations, dependencies including adapters and safety/policy models) atomically. | 2 |
 | **3.3.3** | **Verify that** model versions running in parallel (e.g., A/B tests, canary, shadow deployments) use isolated runtime state so that AI-specific shared resources (e.g., KV caches, prompt caches, session state, retrieval indices) are not shared across deployment cohorts. | 2 |
-| **3.3.4** | **Verify that** emergency model shutdown capabilities can disable model endpoints within a pre-defined response time. | 3 |
-| **3.3.5** | **Verify that** emergency shutdown cascades to all parts of the system including e.g. deactivating agent tool and MCP access, RAG connectors, database and API credentials, and memory-store bindings. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -295,8 +295,6 @@ Manage model deployment, rollback, retirement, and emergency response.
 | Canary / blue-green deployments with automated rollback triggers | 3.3.1 |
 | Parallel deployment cohort isolation (A/B, canary, shadow) | 3.3.3 |
 | Atomic state restoration on rollback (weights, config, adapters, safety models) | 3.3.2 |
-| Emergency model shutdown capability with pre-defined response time | 3.3.4 |
-| Shutdown cascade to tools, MCP, RAG, credentials, memory stores | 3.3.5 |
 | Development / test / production environment separation | 3.4.1 |
 | No shared infrastructure across environment boundaries | 3.4.2 |
 | Version control for all development artifacts (hyperparams, scripts, prompts, policies) | 3.4.3 |


### PR DESCRIPTION
## Summary

Closes #786.

C3.3 had two requirements (3.3.4 and 3.3.5) that duplicated kill-switch controls in C14.1 with worse leveling:

- **3.3.4 (L3)** "emergency model shutdown ... within a pre-defined response time" duplicated **14.1.1 (L1)** "manual kill-switch ... to immediately halt AI model inference and outputs"
- **3.3.5 (L3)** "emergency shutdown cascades to ... agent tool and MCP access, RAG connectors, ..." overlapped **14.1.3 (L2)** "two intermediate operational states ... disabling specific tools or MCP servers, removing a retrieval source, ..."

C14's preface already declares C3 the home for rollback and C14 the home for kill-switch, so the C3.3 entries were redundant. Manual kill-switch as L1 is the right level: it is table-stakes per EU AI Act Article 14, NIST AI RMF, and OWASP LLM Top 10 (LLM06). Cascading/intermediate-state at L2 reflects that wiring up tool, MCP, and retrieval cutoffs is more complex but achievable wherever a tool inventory exists.

Rollback proper (3.3.1, 3.3.2, 3.6.5) is unchanged; it does not collide with C14.

## Changes

- Removed 3.3.4 and 3.3.5 from `0x10-C03-Model-Lifecycle-Management.md`.
- Removed the two matching entries from Appendix D (`0x93-Appendix-D_AI_Security_Controls_Inventory.md`); the equivalent 14.1.1 and 14.1.3 entries are already in the appendix under C14.

Note: the `research/` chapter material under `research/chapters/C03-...` still references 3.3.4 and 3.3.5. That is a separate research wiki and will be updated in a follow-up.

## Test plan

- [ ] Confirm 3.3.4 and 3.3.5 no longer appear in C3.3.
- [ ] Confirm C3.3 still has 3.3.1, 3.3.2, 3.3.3 with no numbering gap visible to readers.
- [ ] Confirm Appendix D no longer lists the two removed inventory entries pointing to 3.3.4/3.3.5.
- [ ] Confirm 14.1.1 and 14.1.3 in C14 read as the canonical kill-switch and intermediate-state controls.
