### PR TITLE
fix(C3): drop 3.2.8, duplicates 3.2.4

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -35,7 +35,6 @@ Models must pass defined security and safety validations before deployment.
 | **3.2.5** | **Verify that** security testing covers agent workflows, tool and MCP integrations, RAG and memory interactions, multimodal inputs, and guardrails (safety models or detection services) using a versioned evaluation harness. | 2 |
 | **3.2.6** | **Verify that** all model changes (deployment, configuration, retirement) generate immutable audit records including a timestamp, an authenticated actor identity, a change type, and before/after states, with trace metadata (environment and consuming services/agents) and a model identifier (version/digest/signature). | 2 |
 | **3.2.7** | **Verify that** models subjected to post-training quantization, pruning, or distillation are re-evaluated against the same safety and alignment test suite on the compressed artifact before deployment, and that evaluation results are retained as distinct records linked to the compressed artifact's version or digest. | 2 |
-| **3.2.8** | **Verify that** validation failures automatically block model deployment unless an explicit override approval from pre-designated authorized personnel with documented business justifications. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -292,7 +292,6 @@ Manage model deployment, rollback, retirement, and emergency response.
 | Automatic deployment block on safety evaluation threshold failure | 3.2.4 |
 | Agent workflow, tool, MCP, and RAG integration testing | 3.2.5 |
 | Immutable audit records for model changes | 3.2.6 |
-| Deployment validation with failure blocking and override approval | 3.2.8 |
 | Canary / blue-green deployments with automated rollback triggers | 3.3.1 |
 | Parallel deployment cohort isolation (A/B, canary, shadow) | 3.3.3 |
 | Atomic state restoration on rollback (weights, config, adapters, safety models) | 3.3.2 |


### PR DESCRIPTION
Closes #809.

## Why

3.2.8 was a compound requirement that duplicates an existing L1 control and mixes in two out-of-scope elements.

Original text:

> **3.2.8** Verify that validation failures automatically block model deployment unless an explicit override approval from pre-designated authorized personnel with documented business justifications.

Three problems with this:

1. **Duplicates 3.2.4.** The deploy-block half is already covered at L1: "Verify that deployment is automatically blocked when safety evaluation results do not meet the thresholds defined for the model being deployed." 3.2.4 is tighter (it names the threshold criterion) and lives at the right level.
2. **Override-by-named-role is generic access control.** Restricting who can override a deploy gate is standard CI/CD access control. It belongs in ASVS or C5, not in a model-lifecycle requirement. AISVS shouldn't re-state generic access-control properties for every workflow.
3. **"Documented business justifications" is GRC.** The AISVS review checklist (item 6) treats governance, compliance, and organizational policy as out of scope. An auditor verifying this would be reviewing paperwork, not a technical control.

The grammar issue flagged in #809 (the "unless" clause is a fragment with no verb) is moot once the row is removed.

## Changes

- Removed 3.2.8 from `0x10-C03-Model-Lifecycle-Management.md`.
- Removed the matching row from Appendix D's controls inventory.

No renumbering. Per the parent thread (#793) we're preserving numbering through 1.0.
