### PR TITLE
docs: add release policy (#814)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,4 +56,4 @@ We are looking for help with translations after v1.0 is released!
 
 ## Release Policy
 
-AISVS follows a published release policy that defines what can change in patch, minor, and major releases, and how versions are referenced across time. See [RELEASE.md](RELEASE.md) before proposing changes that add, remove, or restructure requirements.
+AISVS uses a two-part `v<MAJOR>.<MINOR>` version scheme and a published release policy that defines what can change in a minor release, what requires a major release, and how patch-level fixes are handled in-branch without a separate version. See [RELEASE.md](RELEASE.md) before proposing changes that add, remove, or restructure requirements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,3 +53,7 @@ We may also ask you to open a pull request, <https://github.com/OWASP/AISVS/pull
 ### Translations
 
 We are looking for help with translations after v1.0 is released!
+
+## Release Policy
+
+AISVS follows a published release policy that defines what can change in patch, minor, and major releases, and how versions are referenced across time. See [RELEASE.md](RELEASE.md) before proposing changes that add, remove, or restructure requirements.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ If identifiers are used without including the `v<version>` element they should b
 
 ## Versioning
 
+AISVS uses a two-part version number, `v<MAJOR>.<MINOR>` (for example, `v1.0`, `v1.01`, `v2.0`). Major versions cover chapter and section changes, minor versions cover additions, removals, and material edits to requirements within the existing structure, and patch fixes ship in-branch without a separate version. The full policy is documented in [RELEASE.md](RELEASE.md).
+
 Each stable release of AISVS is published as a numbered folder in this repository. Once a version is released its folder is locked; all future work happens in a new folder. This mirrors the approach used by [OWASP ASVS](https://github.com/OWASP/ASVS).
 
 ```text

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,103 @@
+# AISVS Release Policy
+
+AISVS addresses a fast-moving technology, so it has to update more often than most security standards. At the same time, adopters, auditors, and tooling vendors need stable identifiers they can cite. This document defines the release model that balances those two goals.
+
+## Versioning Scheme
+
+AISVS uses a two-part version number:
+
+```
+v<MAJOR>.<MINOR>
+```
+
+Examples: `v1.0`, `v1.01`, `v1.02`, `v2.0`, `v2.01`.
+
+- **MAJOR** changes when chapters or sections are added, removed, restructured, or when control objectives change.
+- **MINOR** changes when requirements are added, removed, or materially modified within the existing chapter and section structure.
+
+The public AISVS version that adopters, auditors, and tooling cite is always two-part. Patch-level fixes (typos, link corrections, language polish that does not change a requirement's meaning) are made on the active minor branch and do not produce a separate public version number. The next minor release rolls them up.
+
+> **Why two parts instead of three.** AISVS identifiers like `v1.0-C9.4.3` already encode the version that owns the requirement ID. A three-part scheme would push patch-level noise into citations without changing what the identifier means. Two parts keep the public surface simple and stable for downstream users.
+
+## Scope Rules by Release Type
+
+### Patch (in-branch fixes, no version bump)
+
+Allowed:
+
+- Typo and grammar fixes.
+- Broken or relocated reference links.
+- Editorial clarifications that do not change which evidence an auditor would request or accept.
+
+Not allowed:
+
+- Changing the verifiable condition of a requirement.
+- Changing a requirement's level.
+- Adding or removing requirements.
+
+### Minor release (for example, `v1.0` to `v1.01`)
+
+Allowed:
+
+- Adding new requirements within an existing section.
+- Removing requirements that are obsolete, duplicated, or superseded.
+- Materially modifying requirement text, including level changes, when the change reflects evolving technology or threat landscape.
+- All patch-level changes accumulated since the previous minor.
+
+Not allowed:
+
+- Adding, removing, or renaming chapters.
+- Adding, removing, or renaming sections within a chapter.
+- Changing a chapter's control objective.
+
+These limits exist because the `v<version>-Cx.y.z` referencing convention encodes chapter and section identity. If a minor release reshapes what `C9.4` means, every downstream citation against the previous minor becomes ambiguous without a major-version signal.
+
+### Major release (for example, `v1.x` to `v2.0`)
+
+Allowed:
+
+- Anything a minor release allows.
+- Adding, removing, or restructuring chapters and sections.
+- Revising control objectives.
+- Renumbering requirements where structural change requires it.
+
+A major release is the only release type that can break the meaning of existing identifiers, so it must be the only release type that does.
+
+## Cadence
+
+- **Patch and minor releases ship as the content requires.** There is no fixed calendar. If a class of AI attack or defense is established enough to specify and test, it lands in the next minor. Editorial fixes ship continuously on the active minor branch.
+- **Major releases ship when warranted, not on a schedule.** If a chapter-level rethink is needed, a new major version is preferable to overloading minor releases with breaking changes.
+
+## Parallel Maintenance
+
+When work begins on the next major version (for example, `v2.0`):
+
+- The previous major line continues to receive patch and minor updates for a defined maintenance period announced at the time the next major opens.
+- Adopters and auditors targeting the previous major are not forced to migrate before the maintenance period ends.
+- After the maintenance period, the previous major line is locked. Identifiers remain citable, but no further changes are made.
+
+The intent is that organizations should never be in a position where the only supported AISVS version requires a structural migration of their existing compliance work.
+
+## Repository Layout
+
+Each released minor version lives in its own folder, locked after release:
+
+```
+/
+├── 1.0/         <- released minor version (locked)
+├── 1.01/        <- released minor version (locked, when shipped)
+├── 1.02-dev/    <- next minor release in progress
+├── 2.0-dev/     <- next major release in progress (when applicable)
+```
+
+This mirrors the approach used by [OWASP ASVS](https://github.com/OWASP/ASVS) and makes it explicit which versions are stable, which are open for change, and which are locked.
+
+## Referencing Across Versions
+
+For citing requirements in reports, tools, audits, or other documents, use the full versioned form:
+
+```
+v<version>-C<chapter>.<section>.<requirement>
+```
+
+For example, `v1.0-C9.4.3`. The unversioned form `C9.4.3` resolves to the latest released minor, which is appropriate for casual reference but should be avoided in anything that needs to remain stable. See [How to Reference AISVS Requirements](https://github.com/OWASP/AISVS#how-to-reference-aisvs-requirements) in the README for the full convention.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,13 +15,13 @@ Examples: `v1.0`, `v1.01`, `v1.02`, `v2.0`, `v2.01`.
 - **MAJOR** changes when chapters or sections are added, removed, restructured, or when control objectives change.
 - **MINOR** changes when requirements are added, removed, or materially modified within the existing chapter and section structure.
 
-The public AISVS version that adopters, auditors, and tooling cite is always two-part. Patch-level fixes (typos, link corrections, language polish that does not change a requirement's meaning) are made on the active minor branch and do not produce a separate public version number. The next minor release rolls them up.
+The public AISVS version that adopters, auditors, and tooling cite is always two-part. Patch-level fixes (typos, link corrections, language polish that does not change a requirement's meaning) are applied directly to the in-progress minor and do not produce a separate public version number. The next minor release rolls them up.
 
 > **Why two parts instead of three.** AISVS identifiers like `v1.0-C9.4.3` already encode the version that owns the requirement ID. A three-part scheme would push patch-level noise into citations without changing what the identifier means. Two parts keep the public surface simple and stable for downstream users.
 
-## Scope Rules by Release Type
+## Scope Rules by Change Type
 
-### Patch (in-branch fixes, no version bump)
+### Patch fix (in-branch, no version bump)
 
 Allowed:
 
@@ -65,14 +65,14 @@ A major release is the only release type that can break the meaning of existing 
 
 ## Cadence
 
-- **Patch and minor releases ship as the content requires.** There is no fixed calendar. If a class of AI attack or defense is established enough to specify and test, it lands in the next minor. Editorial fixes ship continuously on the active minor branch.
+- **Minor releases ship as the content requires.** There is no fixed calendar. If a class of AI attack or defense is established enough to specify and test, it lands in the next minor. Patch-level editorial fixes ship continuously into the in-progress minor.
 - **Major releases ship when warranted, not on a schedule.** If a chapter-level rethink is needed, a new major version is preferable to overloading minor releases with breaking changes.
 
 ## Parallel Maintenance
 
 When work begins on the next major version (for example, `v2.0`):
 
-- The previous major line continues to receive patch and minor updates for a defined maintenance period announced at the time the next major opens.
+- The previous major line continues to receive minor releases and in-branch patch fixes for a defined maintenance period announced at the time the next major opens.
 - Adopters and auditors targeting the previous major are not forced to migrate before the maintenance period ends.
 - After the maintenance period, the previous major line is locked. Identifiers remain citable, but no further changes are made.
 
@@ -80,17 +80,15 @@ The intent is that organizations should never be in a position where the only su
 
 ## Repository Layout
 
-Each released minor version lives in its own folder, locked after release:
+Each released minor version lives in its own folder. Once a version is released its folder is locked, and the next version is opened in a new folder with a `-dev` suffix:
 
 ```
 /
-├── 1.0/         <- released minor version (locked)
-├── 1.01/        <- released minor version (locked, when shipped)
-├── 1.02-dev/    <- next minor release in progress
-├── 2.0-dev/     <- next major release in progress (when applicable)
+├── 1.0/         <- released (locked after release)
+├── 1.01-dev/    <- next minor release in progress
 ```
 
-This mirrors the approach used by [OWASP ASVS](https://github.com/OWASP/ASVS) and makes it explicit which versions are stable, which are open for change, and which are locked.
+When work on a new major opens, it lives alongside the active minor line in its own `-dev` folder (for example, `2.0-dev/`) so the previous major can continue to receive minor releases during the maintenance period. This mirrors the approach used by [OWASP ASVS](https://github.com/OWASP/ASVS).
 
 ## Referencing Across Versions
 
@@ -100,4 +98,4 @@ For citing requirements in reports, tools, audits, or other documents, use the f
 v<version>-C<chapter>.<section>.<requirement>
 ```
 
-For example, `v1.0-C9.4.3`. The unversioned form `C9.4.3` resolves to the latest released minor, which is appropriate for casual reference but should be avoided in anything that needs to remain stable. See [How to Reference AISVS Requirements](https://github.com/OWASP/AISVS#how-to-reference-aisvs-requirements) in the README for the full convention.
+For example, `v1.0-C9.4.3`. The unversioned form `C9.4.3` resolves to the latest released minor, which works for casual reference but should be avoided in anything that needs to remain stable across versions. See [How to Reference AISVS Requirements](https://github.com/OWASP/AISVS#how-to-reference-aisvs-requirements) in the README for the full convention.


### PR DESCRIPTION
## Summary

Closes the thread on #814 by writing down the AISVS release policy so contributors, adopters, auditors, and tooling vendors have a single source of truth.

- Adds `RELEASE.md` covering the two-part versioning scheme (`v<MAJOR>.<MINOR>`), the scope rules for patch, minor, and major releases, parallel maintenance for the previous major line, and the referencing convention.
- Links the policy from `README.md` (Versioning section) and `CONTRIBUTING.md`.
- Captures the strict minor-release rule from the issue thread: no chapter, section, or control-objective changes in a minor release, since the `v<version>-Cx.y.z` referencing convention encodes chapter and section identity.

## Notes

- Two-part versioning is consistent with what is already in the repo (`1.0/`, `1.01-dev/`) and with the `v1.0-C9.4.3` citation format already documented in the README.
- Cadence is intentionally not pinned to a calendar. Releases ship when the content warrants it.
- Parallel maintenance is described as a commitment with the specific window announced at the time the next major opens, rather than fixing a number now.

## Test plan

- [ ] Review `RELEASE.md` against the discussion in #814 and confirm both Otto's original proposal and the strict-minor adjustment are reflected.
- [ ] Confirm README and CONTRIBUTING links resolve.
- [ ] Sanity-check the repository layout block in `RELEASE.md` against current folder names.
