### PR TITLE
fix(AppE): update reviewer GitHub username to tetsuoseto

### DIFF
--- a/.github/workflows/config/local-custom.txt
+++ b/.github/workflows/config/local-custom.txt
@@ -84,7 +84,7 @@ tokenizer
 Gatto
 Walid
 Alamri
-Setotet
+tetsuoseto
 Tetsuo
 Seto
 Schwoebel

--- a/1.0/en/0x94-Appendix-E_Contributors.md
+++ b/1.0/en/0x94-Appendix-E_Contributors.md
@@ -50,7 +50,7 @@ please open an issue or pull request.
 
 ## Reviewers
 
-* Tetsuo Seto ([Setotet](https://github.com/Setotet))
+* Tetsuo Seto ([tetsuoseto](https://github.com/tetsuoseto))
 * Deepak Pandey ([deepakrpandey12](https://github.com/deepakrpandey12))
 * Starr Brown ([mamicidal](https://github.com/mamicidal))
 * Stuart Small ([stusmall](https://github.com/stusmall))


### PR DESCRIPTION
Closes #826.

Updates Tetsuo Seto's GitHub profile link in the Reviewers section of Appendix E from `Setotet` to `tetsuoseto` as requested.