### PR TITLE
C02 levels review

### DIFF
--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -13,15 +13,15 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.1.1** | **Verify that** all external or derived inputs that may steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier before being included in prompts or used to trigger actions. | 1 |
-| **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. | 3 |
-| **2.1.3** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, and that inputs exceeding token limits are rejected rather than silently truncated, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
-| **2.1.4** | **Verify that** the system implements a character set limitation for user inputs to model prompts, allowing only characters that are explicitly required for business purposes using an allow-list approach. | 1 |
-| **2.1.5** | **Verify that** the instruction hierarchy is preserved across multi-step interactions and tool-augmented workflows, including prompt composition and intermediate outputs, such that user-controlled content cannot override system or developer instructions. | 3 |
-| **2.1.6** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
-| **2.1.7** | **Verify that** the system enforces per-request limits on the number of user-supplied demonstrations included in a single context window. | 2 |
-| **2.1.8** | **Verify that** the system detects patterns indicative of systematic in-context behavioral override attempts consistent with many-shot jailbreaking. | 3 |
-| **2.1.9** | **Verify that** detected in-context behavioral override attempts are classified and handled as prompt injection events. | 3 |
-| **2.1.10** | **Verify that** prompt injection screening respects user-specific policies (age and regional legal constraints) via attribute-based rules resolved at request time, including the role or permission level of the calling agent. | 2 |
+| **2.1.2** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, and that inputs exceeding token limits are rejected rather than silently truncated, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
+| **2.1.3** | **Verify that** the system implements a character set limitation for user inputs to model prompts, allowing only characters that are explicitly required for business purposes using an allow-list approach. | 1 |
+| **2.1.4** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
+| **2.1.5** | **Verify that** the system enforces per-request limits on the number of user-supplied demonstrations included in a single context window. | 2 |
+| **2.1.6** | **Verify that** prompt injection screening respects user-specific policies (age and regional legal constraints) via attribute-based rules resolved at request time, including the role or permission level of the calling agent. | 2 |
+| **2.1.7** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. | 3 |
+| **2.1.8** | **Verify that** the instruction hierarchy is preserved across multi-step interactions and tool-augmented workflows, including prompt composition and intermediate outputs, such that user-controlled content cannot override system or developer instructions. | 3 |
+| **2.1.9** | **Verify that** the system detects patterns indicative of systematic in-context behavioral override attempts consistent with many-shot jailbreaking. | 3 |
+| **2.1.10** | **Verify that** detected in-context behavioral override attempts are classified and handled as prompt injection events. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -13,14 +13,14 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.1.1** | **Verify that** all external or derived inputs that may steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier before being included in prompts or used to trigger actions. | 1 |
-| **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. | 1 |
+| **2.1.2** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. | 3 |
 | **2.1.3** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, and that inputs exceeding token limits are rejected rather than silently truncated, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
 | **2.1.4** | **Verify that** the system implements a character set limitation for user inputs to model prompts, allowing only characters that are explicitly required for business purposes using an allow-list approach. | 1 |
-| **2.1.5** | **Verify that** the instruction hierarchy is preserved across multi-step interactions and tool-augmented workflows, including prompt composition and intermediate outputs, such that user-controlled content cannot override system or developer instructions. | 1 |
+| **2.1.5** | **Verify that** the instruction hierarchy is preserved across multi-step interactions and tool-augmented workflows, including prompt composition and intermediate outputs, such that user-controlled content cannot override system or developer instructions. | 3 |
 | **2.1.6** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
 | **2.1.7** | **Verify that** the system enforces per-request limits on the number of user-supplied demonstrations included in a single context window. | 2 |
-| **2.1.8** | **Verify that** the system detects patterns indicative of systematic in-context behavioral override attempts consistent with many-shot jailbreaking. | 2 |
-| **2.1.9** | **Verify that** detected in-context behavioral override attempts are classified and handled as prompt injection events. | 2 |
+| **2.1.8** | **Verify that** the system detects patterns indicative of systematic in-context behavioral override attempts consistent with many-shot jailbreaking. | 3 |
+| **2.1.9** | **Verify that** detected in-context behavioral override attempts are classified and handled as prompt injection events. | 3 |
 | **2.1.10** | **Verify that** prompt injection screening respects user-specific policies (age and regional legal constraints) via attribute-based rules resolved at request time, including the role or permission level of the calling agent. | 2 |
 
 ---
@@ -47,7 +47,7 @@ Syntactically valid prompts may request disallowed content such as policy-violat
 | **2.3.1** | **Verify that** every inbound prompt is scored by a content classifier for violence, self-harm, hate, sexual content, and illegal requests against configurable thresholds, and that prompts exceeding those thresholds are rejected or sanitized before reaching model context. | 1 |
 | **2.3.2** | **Verify that** prompt content classification is evaluated for unsupported-language abuse and that identified gaps are mitigated through compensating controls such as language detection with rejection, conservative thresholds, or human review routing. | 1 |
 | **2.3.3** | **Verify that** inputs which violate policies are rejected so they do not propagate to downstream model or tool/MCP calls. | 1 |
-| **2.3.4** | **Verify that** screening logs include classifier confidence scores and policy category tags with applied stage (pre-prompt or post-response) and trace metadata (source, tool or MCP server, agent ID, session) for SOC correlation and future red-team replay. | 3 |
+| **2.3.4** | **Verify that** screening logs include classifier confidence scores and policy category tags with applied stage (pre-prompt or post-response) and trace metadata (source, tool or MCP server, agent ID, session) for SOC correlation and future red-team replay. | 2 |
 
 ---
 
@@ -58,7 +58,7 @@ AI systems that accept non-textual inputs (images, audio, video, files) face uni
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.4.1** | **Verify that** text extracted from non-text inputs (e.g., image-to-text, speech-to-text) and hidden or embedded content (metadata, layers, alt text, comments) is treated as untrusted and screened per 2.1.1. | 1 |
-| **2.4.2** | **Verify that** image/audio inputs are checked for adversarial perturbations, steganographic payloads, or known attack patterns, and detections trigger gating (block or degrade capabilities) before model use. | 2 |
+| **2.4.2** | **Verify that** image/audio inputs are checked for adversarial perturbations, steganographic payloads, or known attack patterns, and detections trigger gating (block or degrade capabilities) before model use. | 3 |
 | **2.4.3** | **Verify that** cross-modal attack detection identifies coordinated attacks spanning multiple input types (e.g., steganographic payloads in images combined with prompt injection in text) with correlation rules and alert generation, and that confirmed detections are blocked or require HITL (human-in-the-loop) approval. | 3 |
 
 ---

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -131,14 +131,14 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | Control / Technique | Requirement IDs |
 | --- | --- |
 | Prompt injection detection ruleset / service | 2.1.1 |
-| Instruction hierarchy enforcement (system > developer > user) | 2.1.2 |
-| Instruction hierarchy preservation across multi-step and tool-augmented workflows, including prompt composition | 2.1.5 |
-| Per-request demonstration count limits in context window | 2.1.7 |
-| Many-shot jailbreaking pattern detection (systematic in-context behavioral override) | 2.1.8 |
-| In-context behavioral override attempts classified as prompt injection events | 2.1.9 |
-| Context window proportion limits and token limit enforcement (reject, not truncate) | 2.1.3 |
-| Third-party content sanitization | 2.1.6 |
-| Character set allow-listing for model prompt inputs | 2.1.4 |
+| Instruction hierarchy enforcement (system > developer > user) | 2.1.7 |
+| Instruction hierarchy preservation across multi-step and tool-augmented workflows, including prompt composition | 2.1.8 |
+| Per-request demonstration count limits in context window | 2.1.5 |
+| Many-shot jailbreaking pattern detection (systematic in-context behavioral override) | 2.1.9 |
+| In-context behavioral override attempts classified as prompt injection events | 2.1.10 |
+| Context window proportion limits and token limit enforcement (reject, not truncate) | 2.1.2 |
+| Third-party content sanitization | 2.1.4 |
+| Character set allow-listing for model prompt inputs | 2.1.3 |
 | Pre-tokenization input normalization (Unicode NFC, homoglyph mapping, control/invisible character removal, bidirectional text neutralization) | 2.2.1 |
 | Post-normalization suspicious artifact rejection or flagging | 2.2.3 |
 | Adversarial input quarantine and logging | 2.2.2 |
@@ -146,7 +146,7 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | Content classifiers for inbound prompts (hate, violence, sexual, illegal) with threshold-based rejection or sanitization | 2.3.1 |
 | Multilingual classifier gap evaluation with compensating controls (language detection, conservative thresholds, human review routing) | 2.3.2 |
 | Policy-violating input rejection before model propagation | 2.3.3 |
-| User-specific and agent-aware policy screening | 2.1.10 |
+| User-specific and agent-aware policy screening | 2.1.6 |
 | Extracted and hidden content from non-text inputs treated as untrusted | 2.4.1 |
 | Adversarial perturbation detection on image/audio inputs | 2.4.2 |
 | Cross-modal attack detection | 2.4.3 |


### PR DESCRIPTION
# C02 levels review

Final polishing pass on C02 (Input Validation) focused exclusively on level assignments and implementability.

Numbering kept as is intentionally, left for later.

## Changes

### C2.1.2: L1 -> L3

Rationale: Instruction hierarchy is a model-specific capability (notably OpenAI's GPT-4o and later) rather than an application-layer control. Teams using open-source models (Llama, Mistral) or non-OpenAI APIs cannot enforce it without model modification or fine-tuning. L1 and L2 require universal implementability including internal/low-risk tools on a single laptop to normal SaaS apps; this does not meet that bar. The baseline L1 prompt-injection defenses remain intact via C2.1.1 (input screening), C2.1.3 (length controls), and C2.1.4 (charset limits).

L3 justified because this may with many model providers implementation would require fine-tuning currently.

We should consider if we want to keep this requirement as is.

### C2.1.5: L1 -> L3

Rationale: Multi-step preservation of instruction hierarchy is harder than single-turn enforcement and is equally model-dependent. Consistent with C2.1.2 moving to L3. Application-layer mitigations (delimiters, prompt templates, re-injection) provide partial coverage but cannot guarantee hierarchy preservation when the underlying model does not support it.

We should consider if we want to keep this requirement as is.

### C2.1.8: L2 -> L3

Rationale: Many-shot jailbreak (MSJ) detection is research-grade. No production tool specifically addresses the MSJ attack vector (long-context flooding with benign-appearing examples). Available guardrails (OpenAI Guardrails SDK, NeMo Guardrails, LlamaFirewall) operate on prompt-level or short multi-turn patterns (up to ~10 turns), not context-length-based drift. Anthropic's Constitutional Classifiers demonstrated strong robustness but are proprietary and not publicly available. Prevention via C2.1.7 (per-request demonstration limits) remains at L2; detection of this advanced attack belongs at L3, consistent with C13.2.7 (session-level multi-turn jailbreak detection at L3).

### C2.1.9: L2 -> L3

Rationale: Follows C2.1.8. Handling of detected many-shot attempts aligns with the detection level.

### C2.3.4: L3 -> L2

Rationale: Logging classifier confidence scores and policy tags is standard practice. Commercial content safety APIs (Azure AI Content Safety, OpenAI Moderation) return this data by default. Distributed tracing (OpenTelemetry, Jaeger) is mature infrastructure. Comparable logging requirements in C13 are L1-L2 (C13.1.1 L1, C13.1.3 L2, C13.1.4 L2). L3 overstates the difficulty.

### C2.4.2: L2 -> L3

Rationale: Inference-time detection of adversarial perturbations and steganographic payloads in images/audio lacks mature production tooling. pixmask (sanitizer, not detector) and IBM ART (research framework) exist but are not turnkey. Neural steganography (e.g., Odysseus/NDSS 2026) evades classical detection. Audio adversarial and stego detection is essentially unaddressed in production pipelines. C11.2.2 places adversarial-example detection at L2 but scopes it to high-risk functions; C2.4.2 has no such scoping and additionally covers steganography.
