### PR TITLE
fix(C01): remove ASVS-duplicate controls 1.2.1–1.2.3, rewrite 1.2.4

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -21,17 +21,14 @@ Training data origin and traceability are critical to the security and trustwort
 
 ## C1.2 Training Data Security & Integrity
 
-Training data must be protected against unauthorized access, disclosure, tampering, corruption, and poisoning throughout its lifecycle. Storage systems and data pipelines should enforce access control, preserve auditability, protect confidentiality through encryption, validate integrity during storage and transfer, and maintain immutable dataset versions for rollback and forensic analysis.
+Training data must be protected against tampering, corruption, and poisoning throughout its lifecycle. Generic data security controls -- access control on storage, access logging, and encryption at rest and in transit -- are covered by OWASP ASVS v5 (V6, V7, V8) and must be implemented as a baseline. This section addresses AI-specific concerns: integrity verification against data poisoning, immutable dataset versioning for rollback, and the residual-memorization risk that persists in trained models after training data is retired.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **1.2.1** | **Verify that** access controls protect training data storage and pipelines. | 1 |
-| **1.2.2** | **Verify that** all access to training data is logged, including user, time, and action. | 1 |
-| **1.2.3** | **Verify that** training datasets are encrypted in transit and at rest, using current recommended cryptographic algorithms and key management practices. | 1 |
-| **1.2.4** | **Verify that** training data is securely purged or anonymized when it is no longer required for the model's stated purpose. | 1 |
-| **1.2.5** | **Verify that** cryptographic hashes or digital signatures are used to ensure data integrity during training data storage and transfer. | 2 |
-| **1.2.6** | **Verify that** automated integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
-| **1.2.7** | **Verify that** all training dataset versions are uniquely identified, stored immutably, and auditable to support rollback and forensic analysis. | 3 |
+| **1.2.1** | **Verify that** when training data is retired or removed, the impact on models trained on that data is assessed, and that residual memorization risks are addressed (e.g., via targeted fine-tuning, machine unlearning, or model retraining). | 1 |
+| **1.2.2** | **Verify that** cryptographic hashes or digital signatures are used to ensure data integrity during training data storage and transfer. | 2 |
+| **1.2.3** | **Verify that** automated integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
+| **1.2.4** | **Verify that** all training dataset versions are uniquely identified, stored immutably, and auditable to support rollback and forensic analysis. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -21,7 +21,7 @@ Training data origin and traceability are critical to the security and trustwort
 
 ## C1.2 Training Data Security & Integrity
 
-Training data must be protected against tampering, corruption, and poisoning throughout its lifecycle. Generic data security controls -- access control on storage, access logging, and encryption at rest and in transit -- are covered by OWASP ASVS v5 (V6, V7, V8) and must be implemented as a baseline. This section addresses AI-specific concerns: integrity verification against data poisoning, immutable dataset versioning for rollback, and the residual-memorization risk that persists in trained models after training data is retired.
+Training data must be protected against tampering, corruption, and poisoning throughout its lifecycle. Generic data security controls (access control on storage, access logging, and encryption at rest and in transit) are covered by OWASP ASVS v5 (V6, V7, V8) and must be implemented as a baseline. This section addresses AI-specific concerns: integrity verification against data poisoning, immutable dataset versioning for rollback, and the residual-memorization risk that persists in trained models after training data is retired.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -62,7 +62,7 @@ Protect stored data, models, secrets, logs, and backups through encryption.
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Training data encryption at rest | 1.2.3 |
+| Training data encryption at rest | ASVS v5 V6 |
 | Labeled data encryption | 1.3.5 |
 | Log encryption at rest | 13.1.4 |
 
@@ -105,7 +105,7 @@ Verify authenticity and detect tampering of models, artifacts, messages, logs, a
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Cryptographic hashes for training data integrity | 1.2.5, 1.3.4 |
+| Cryptographic hashes for training data integrity | 1.2.2, 1.3.4 |
 | Cryptographic model signing | 3.1.2 |
 | Model signature and checksum verification at deployment and load | 3.1.3 |
 | Signed build artifacts with build-origin metadata | ASVS v5 V15 / SLSA |


### PR DESCRIPTION
Closes #794.

## Changes

**Removed 1.2.1, 1.2.2, 1.2.3** -- generic data security controls (storage access controls, access logging, encryption at rest/in transit) that are fully covered by OWASP ASVS v5 V6/V7/V8 with no AI-specific framing. The section intro now cross-references ASVS for these baseline controls.

**Rewrote 1.2.4** (now 1.2.1) to address the AI-specific concern that generic ASVS does not cover: retiring training data does not automatically remove what the model memorized. The requirement now explicitly calls out residual memorization and the need for machine unlearning, fine-tuning, or retraining.

**1.2.5, 1.2.6, 1.2.7 kept** (renumbered to 1.2.2–1.2.4) -- cryptographic integrity checks, automated integrity monitoring, and immutable dataset versioning are all AI-specific in that their primary purpose is detecting training data poisoning.

Appendix D updated accordingly.