### PR TITLE
fix(C02/C07): split 2.2.4 encoding smuggling by input vs output side

### DIFF
--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -27,14 +27,14 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 
 ## C2.2 Pre-Tokenization Input Normalization
 
-AI models process text through tokenizers and embeddings that can be exploited via encoding tricks invisible to conventional input validation. Normalization before tokenization closes attack vectors such as homoglyph substitution, invisible character injection, and bidirectional text manipulation that bypass standard allow-list filters but alter model behavior.
+AI models process text through tokenizers and embeddings that can be exploited via encoding tricks invisible to conventional input validation. Normalization before tokenization closes attack vectors such as homoglyph substitution, invisible character injection, and bidirectional text manipulation that bypass standard allow-list filters but alter model behavior. For output-side encoding smuggling in model-generated content, see C7.3.5.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.2.1** | **Verify that** input normalization (Unicode NFC canonicalization, homoglyph mapping, removal of control and invisible Unicode characters, and bidirectional text neutralization) is applied before tokenization or embedding. | 1 |
 | **2.2.2** | **Verify that** inputs identified as adversarial by any detection mechanism are blocked from inclusion in prompts or execution of actions. | 1 |
 | **2.2.3** | **Verify that** inputs which still contain suspicious encoding artifacts after normalization are rejected or flagged for review. | 2 |
-| **2.2.4** | **Verify that** encoding and representation smuggling in both inputs and outputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) are detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
+| **2.2.4** | **Verify that** encoding and representation smuggling in inputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) is detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
 
 ---
 

--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -42,6 +42,7 @@ Technical controls to detect and scrub bad content before it is shown to the use
 | **7.3.2** | **Verify that** output filters detect and block responses that disclose system prompt content, including verbatim reproduction and semantically equivalent paraphrases of instructions, role definitions, or policy directives. | 2 |
 | **7.3.3** | **Verify that** LLM client applications prevent model-generated output from triggering automatic outbound requests (e.g., auto-rendered images, iframes, or link prefetching) to attacker-controlled endpoints, for example by disabling automatic external resource loading or by restricting it to an explicitly allowlisted set of origins. | 2 |
 | **7.3.4** | **Verify that** generated outputs are analyzed for statistical steganographic covert channels (e.g., biased token-choice patterns or output distribution anomalies) that could encode hidden data across the model's valid output space, and that detections are flagged for review. | 3 |
+| **7.3.5** | **Verify that** model-generated outputs are scanned for encoding and representation smuggling artifacts (e.g., invisible Unicode or control characters, homoglyph substitutions, mixed-direction text) before being returned to callers or passed to downstream systems, and that detections trigger rejection or sanitization. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -142,7 +142,7 @@ Validate, normalize, and constrain all inputs before they reach models or downst
 | Pre-tokenization input normalization (Unicode NFC, homoglyph mapping, control/invisible character removal, bidirectional text neutralization) | 2.2.1 |
 | Post-normalization suspicious artifact rejection or flagging | 2.2.3 |
 | Adversarial input quarantine and logging | 2.2.2 |
-| Encoding and representation smuggling detection and mitigation | 2.2.4 |
+| Input encoding and representation smuggling detection and mitigation | 2.2.4 |
 | Content classifiers for inbound prompts (hate, violence, sexual, illegal) with threshold-based rejection or sanitization | 2.3.1 |
 | Multilingual classifier gap evaluation with compensating controls (language detection, conservative thresholds, human review routing) | 2.3.2 |
 | Policy-violating input rejection before model propagation | 2.3.3 |
@@ -176,6 +176,7 @@ Constrain, filter, and validate model outputs before they reach users or downstr
 | Output safety classifiers (hate, harassment, violence) | 7.3.1 |
 | System prompt leakage detection in outputs (verbatim and paraphrased) | 7.3.2 |
 | Prevention of auto-triggered outbound requests from model-generated output | 7.3.3 |
+| Output encoding and representation smuggling detection and sanitization | 7.3.5 |
 | System prompt and backend data removal from explanations | 7.5.1 |
 | RAG unsupported-claim blocking or redaction before serving | 7.6.4 |
 | Authorization-aware post-inference filtering (per-caller entitlement enforcement) | 5.4.1 |


### PR DESCRIPTION
Closes #808.

2.2.4 covered two independently assessable conditions (input-side and output-side encoding smuggling). Split per option 2 from the issue:

- **2.2.4** narrowed to input-only (invisible Unicode, homoglyphs, BiDi text in user input)
- **7.3.5** added to C7.3 for output-side: model-generated outputs scanned for the same artifact classes before being returned to callers
- Cross-reference to 7.3.5 added in the C2.2 section intro
- Appendix D updated