### PR TITLE
fix(C12): split 12.5.1 consent scope validation from enforcement

### DIFF
--- a/1.0/en/0x10-C12-Privacy.md
+++ b/1.0/en/0x10-C12-Privacy.md
@@ -62,8 +62,9 @@ Enforce consent at AI-specific decision points (training data ingestion, inferen
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.5.1** | **Verify that** model inference validates consent scope before processing and refuses or downgrades the response when the scope does not cover the requested operation, the data subjects whose data materially influences the response, or both. | 2 |
-| **12.5.2** | **Verify that** withdrawal of consent triggers the same AI-artifact propagation pipeline as a deletion request (see 12.2.1), and that inference paths relying on the withdrawn data are disabled within the same SLA. | 2 |
+| **12.5.1** | **Verify that** model inference validates consent scope before processing, covering both the requested operation and the data subjects whose data materially influences the response. | 2 |
+| **12.5.2** | **Verify that** when validated consent scope does not cover the requested operation or the data subjects whose data materially influences the response, the system refuses or downgrades the response before serving it to the caller. | 2 |
+| **12.5.3** | **Verify that** withdrawal of consent triggers the same AI-artifact propagation pipeline as a deletion request (see 12.2.1), and that inference paths relying on the withdrawn data are disabled within the same SLA. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -325,8 +325,9 @@ Protect personal data and enforce data subject rights throughout the AI lifecycl
 | Empirical (black-box) differential privacy audits | 12.3.2 |
 | Formal differential privacy proofs (including post-training and embeddings) | 12.3.3 |
 | Purpose tags with machine-readable alignment and runtime enforcement | 12.4.1, 12.4.2 |
-| Consent-aware inference scope validation (refuse or downgrade off-scope responses) | 12.5.1 |
-| Consent withdrawal propagation through AI artifacts (aligned with deletion SLA) | 12.5.2 |
+| Consent scope validation before model inference (operation and data subjects) | 12.5.1 |
+| Consent scope enforcement: refuse or downgrade response before serving | 12.5.2 |
+| Consent withdrawal propagation through AI artifacts (aligned with deletion SLA) | 12.5.3 |
 | Local or central differential privacy in federated learning | 12.6.1 |
 | Differentially private training metrics | 12.6.2 |
 | Federated canary-based privacy auditing | 12.6.3 |


### PR DESCRIPTION
Closes #811.

12.5.1 bundled two independently testable conditions. Split into:

- **12.5.1** — validate consent scope before processing (operation and data subjects)
- **12.5.2** — refuse or downgrade the response before serving when scope does not cover either condition

Former 12.5.2 (consent withdrawal propagation) renumbered to 12.5.3. Appendix D updated.