### PR TITLE
fix(C08): split 8.1.5 canary provisioning from canary alerting

### DIFF
--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -16,8 +16,9 @@ Enforce fine-grained access controls and query-time scope enforcement for every 
 | **8.1.2** | **Verify that** every ingested document is tagged at write time with source, writer identity (authenticated user or system principal), timestamp, batch ID, and embedding model version. | 2 |
 | **8.1.3** | **Verify that** document metadata tags applied at ingestion are immutable after initial write and cannot be modified by subsequent pipeline stages or user operations. | 2 |
 | **8.1.4** | **Verify that** RAG pipeline retrieval events log the query issued, the documents or chunks retrieved, similarity scores, the knowledge source, and whether retrieved content passed prompt injection scanning before being incorporated into model context. | 2 |
-| **8.1.5** | **Verify that** restricted retrieval indices include uniquely marked canary records that contain no real sensitive content and generate a high-severity security alert if selected by retrieval, matched by similarity search, or passed to the model as context. | 2 |
-| **8.1.6** | **Verify that** retrieval anomaly detection identifies embedding density outliers, repeated dominance of specific documents in similarity results, and sudden shifts in retrieval bias distribution that may indicate vector database poisoning. | 3 |
+| **8.1.5** | **Verify that** restricted retrieval indices include uniquely marked canary records that contain no real sensitive content, with markers that survive retrieval, embedding, and context-assembly pipelines. | 2 |
+| **8.1.6** | **Verify that** a high-severity security alert is generated whenever a canary record is selected by retrieval, matched by similarity search, or passed to the model as context. | 2 |
+| **8.1.7** | **Verify that** retrieval anomaly detection identifies embedding density outliers, repeated dominance of specific documents in similarity results, and sudden shifts in retrieval bias distribution that may indicate vector database poisoning. | 3 |
 
 ---
 


### PR DESCRIPTION
Closes part of #793.

**8.1.5** bundled two independently testable concerns:
- **8.1.5**: canary records exist, are uniquely marked, and contain no real sensitive content
- **8.1.6** (new): a high-severity alert is generated whenever a canary is selected by retrieval, matched by similarity search, or passed to the model as context

Former 8.1.6 (retrieval anomaly detection) renumbered to 8.1.7.