### PR TITLE
fix(C13): split 13.1.1 field enumeration into two requirements

### DIFF
--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -12,11 +12,12 @@ This chapter focuses on controls unique to AI systems for monitoring, logging an
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **13.1.1** | **Verify that** AI interactions are logged with security-relevant metadata (e.g., timestamp, user ID, session ID, model version, token count, input hash, system prompt version, confidence score, safety filter outcome, and safety filter decisions). | 1 |
-| **13.1.2** | **Verify that** AI interaction logs exclude prompt and response content by default, and that content logging is enabled only on explicit opt-in with documented justification. | 1 |
-| **13.1.3** | **Verify that** policy decisions and safety filtering actions are logged with sufficient detail to enable audit and debugging of content moderation systems. | 2 |
-| **13.1.4** | **Verify that** log entries for AI inference events capture a structured, interoperable schema that includes at minimum model identifier, token usage (input and output), provider name, and operation type, to enable consistent AI observability across tools and platforms. | 2 |
-| **13.1.5** | **Verify that** full prompt and response content is logged only when a security-relevant event is detected (e.g., safety filter trigger, prompt injection detection, anomaly flag), or when required by explicit user consent and a documented legal basis. | 2 |
+| **13.1.1** | **Verify that** AI interactions are logged with basic session and model context: timestamp, user ID, session ID, and model version. | 1 |
+| **13.1.2** | **Verify that** AI interaction log entries include AI-specific telemetry: token count, input hash, system prompt version, confidence score where the model or provider exposes one, and safety filter outcome. | 1 |
+| **13.1.3** | **Verify that** AI interaction logs exclude prompt and response content by default, and that content logging is enabled only on explicit opt-in with documented justification. | 1 |
+| **13.1.4** | **Verify that** policy decisions and safety filtering actions are logged with sufficient detail to enable audit and debugging of content moderation systems. | 2 |
+| **13.1.5** | **Verify that** log entries for AI inference events capture a structured, interoperable schema that includes at minimum model identifier, token usage (input and output), provider name, and operation type, to enable consistent AI observability across tools and platforms. | 2 |
+| **13.1.6** | **Verify that** full prompt and response content is logged only when a security-relevant event is detected (e.g., safety filter trigger, prompt injection detection, anomaly flag), or when required by explicit user consent and a documented legal basis. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -64,7 +64,7 @@ Protect stored data, models, secrets, logs, and backups through encryption.
 | --- | --- |
 | Training data encryption at rest | ASVS v5 V6 |
 | Labeled data encryption | 1.3.5 |
-| Log encryption at rest | 13.1.4 |
+| Log encryption at rest | 13.1.5 |
 
 **Common pitfalls:** encrypting the database but not model checkpoints or embeddings; not encrypting logs that contain prompt/response data; storing encryption keys alongside the data they protect.
 
@@ -79,7 +79,7 @@ Protect data moving between services, agents, tools, and edge devices.
 | Mutual TLS with certificate validation for inter-service communication | 4.3.4 |
 | Authenticated streamable-HTTP transport with TLS 1.3 for MCP | 10.3.1, 10.3.2 |
 | SSE private channel with TLS enforcement | 10.3.2 |
-| Log encryption in transit | 13.1.4 |
+| Log encryption in transit | 13.1.5 |
 | MCP client minimum protocol version enforcement against downgrade negotiation | 10.3.5 |
 
 **Common pitfalls:** allowing plaintext interconnects in multi-tenant GPU clusters; using SSE over public internet without TLS; not validating certificates on internal service calls.
@@ -385,12 +385,13 @@ Capture security-relevant events with integrity protection for forensic analysis
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Security-relevant metadata logging for AI interactions (timestamp, user ID, session ID, model version, token count, input hash, confidence score, safety filter outcome) | 13.1.1 |
-| AI interaction logs exclude prompt and response content by default, with content logging requiring explicit opt-in and documented justification | 13.1.2 |
-| Secure, access-controlled log repositories with retention policies | 13.1.3 |
-| Log encryption at rest and in transit | 13.1.4 |
-| PII, credential, and proprietary information redaction in logs | 13.1.5 |
-| Policy decision and safety filtering action logging | 13.1.3 |
+| Basic session and model context logging (timestamp, user ID, session ID, model version) | 13.1.1 |
+| AI-specific telemetry logging (token count, input hash, system prompt version, confidence score, safety filter outcome) | 13.1.2 |
+| AI interaction logs exclude prompt and response content by default, with content logging requiring explicit opt-in and documented justification | 13.1.3 |
+| Secure, access-controlled log repositories with retention policies | 13.1.4 |
+| Log encryption at rest and in transit | 13.1.5 |
+| PII, credential, and proprietary information redaction in logs | 13.1.6 |
+| Policy decision and safety filtering action logging | 13.1.4 |
 | Audit log context fields sufficient for forensic reconstruction (actor, delegation, policy, parameters, outcomes) | 9.4.3 |
 | Agent action cryptographic chain ID binding | 9.4.2 |
 | Agent action signing and timestamps for non-repudiation | 9.4.4 |


### PR DESCRIPTION
Closes part of #793.

**13.1.1** listed 9 fields in one requirement making it hard to audit independently. Split by category:
- **13.1.1**: basic session and model context (timestamp, user ID, session ID, model version)
- **13.1.2** (new): AI-specific telemetry (token count, input hash, system prompt version, confidence score, safety filter outcome, safety filter decisions)

Former 13.1.2-13.1.5 renumbered to 13.1.3-13.1.6. Appendix D updated.