### PR TITLE
fix(C03): raise 3.1.2 model signing to L2

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -15,7 +15,7 @@ Only authorized models with verified integrity reach production environments.
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **3.1.1** | **Verify that** a model registry maintains an inventory of all deployed model artifacts. | 1 |
-| **3.1.2** | **Verify that** all model artifacts (weights, configurations, tokenizers, base models, fine-tunes, adapters, and safety/policy models) are cryptographically signed by authorized entities. | 1 |
+| **3.1.2** | **Verify that** all model artifacts (weights, configurations, tokenizers, base models, fine-tunes, adapters, and safety/policy models) are cryptographically signed by authorized entities. | 2 |
 | **3.1.3** | **Verify that** model artifact signatures and integrity checksums are verified at deployment admission and on load, and unsigned, tampered, or mismatched artifacts are rejected. | 1 |
 | **3.1.4** | **Verify that** lineage and dependency tracking maintains a dependency graph that enables identification of all consuming services and agents per environment (e.g., dev, staging, prod). | 3 |
 | **3.1.5** | **Verify that** model origin integrity and trace records include an authorizing entity's identity, training data checksums, validation test results with pass/fail status, signature fingerprint/certificate chain ID, a creation timestamp, and approved deployment environments. | 3 |


### PR DESCRIPTION
Levels review on C03 (Model Lifecycle Management), in the style of #821 -- focused on level assignment vs. 2025-2026 tooling maturity and cross-chapter consistency.

## 3.1.2: L1 -> L2

Requiring the *full* model artifact set (weights, configs, tokenizers, base models, fine-tunes, adapters, safety/policy models) to be cryptographically signed by authorized entities requires PKI and signing-pipeline integration. OpenSSF Model Signing (OMS) v1.0 makes this production-ready but it still needs integration work, and signing remains non-universal on public hubs. This exceeds baseline capability and aligns with C01 1.3.4, which places signatures at L2.

Signature and checksum verification (3.1.3) is intentionally left at L1: it covers integrity-checksum verification, which needs no PKI and is the appropriate baseline integrity gate.
