### PR TITLE
fix(C04): lower 4.3.5 egress restriction to L2

### DIFF
--- a/1.0/en/0x10-C04-Infrastructure.md
+++ b/1.0/en/0x10-C04-Infrastructure.md
@@ -43,7 +43,7 @@ Implement zero-trust networking with default-deny policies and encrypted communi
 | **4.3.2** | **Verify that** AI workloads across environments (development, testing, production) run in isolated network segments with no direct internet access and no shared identity roles, security groups, or cross-environment connectivity. | 1 | D/V |
 | **4.3.3** | **Verify that** administrative and remote access protocols and access to cloud metadata services are restricted and require strong authentication. | 1 | D/V |
 | **4.3.4** | **Verify that** inter-service communication uses mutual TLS with certificate validation and regular automated rotation. | 2 | D/V |
-| **4.3.5** | **Verify that** egress traffic is restricted to approved destinations and all requests are logged. | 3 | D/V |
+| **4.3.5** | **Verify that** egress traffic is restricted to approved destinations and all requests are logged. | 2 | D/V |
 
 ---
 


### PR DESCRIPTION
Levels review on C04 (Infrastructure, Configuration & Deployment Security), in the style of #821 and the C03 pass (#840) - focused on level assignment vs. current tooling maturity and intra-chapter consistency.

## 4.3.5: L3 -> L2

Restricting egress to approved destinations with request logging is standard intermediate practice, achievable today with Kubernetes NetworkPolicies, cloud egress firewalls, or service-mesh egress gateways. Level 3 overstated the difficulty.

It also partly overlaps **4.3.1** (default-deny egress with only required services allowed), which is already Level 1, so anchoring 4.3.5 at Level 2 keeps the egress controls coherent and aligns it with comparable network controls such as **4.3.4** (mutual TLS, Level 2).
