### PR TITLE
Add Mayur Agnihotri to contributors list

### DIFF
--- a/.github/workflows/config/local-custom.txt
+++ b/.github/workflows/config/local-custom.txt
@@ -150,3 +150,6 @@ Clopper
 Pearson
 f-DP
 reconstructable
+Agnihotri
+Mayur
+Mayur021

--- a/1.0/en/0x94-Appendix-E_Contributors.md
+++ b/1.0/en/0x94-Appendix-E_Contributors.md
@@ -45,7 +45,7 @@ please open an issue or pull request.
 * William Jawad ([wiljav](https://github.com/wiljav))
 * hackwither ([hackwither](https://github.com/hackwither))
 * Boone Carlson ([KeystoneSmartQuotes](https://github.com/KeystoneSmartQuotes))
-
+* Mayur Agnihotri ([Mayur021](https://github.com/Mayur021))
 ---
 
 ## Reviewers

--- a/1.0/en/0x94-Appendix-E_Contributors.md
+++ b/1.0/en/0x94-Appendix-E_Contributors.md
@@ -46,6 +46,7 @@ please open an issue or pull request.
 * hackwither ([hackwither](https://github.com/hackwither))
 * Boone Carlson ([KeystoneSmartQuotes](https://github.com/KeystoneSmartQuotes))
 * Mayur Agnihotri ([Mayur021](https://github.com/Mayur021))
+  
 ---
 
 ## Reviewers


### PR DESCRIPTION
Add Mayur Agnihotri (Mayur021) to the Contributors section of Appendix E.

  Project contributions to date:
  - PR #822 (merged 2026-05-27): added C9.2.6 (L2) reversibility-classification gating and C9.2.7 (L3) orthogonal worst-case blast-radius to the C09 next-version research chapter at research/chapters/C09-Orchestration-and-Agents/, prefixed "Proposed for 1.01"
  - Issue #828: proposed C14.2.4 reversibility-bridge (closed with "after 1.0" label for post-1.0 reopen)
  - Issue #829: proposed validation-point matrix (closed pre-1.0)
  - Substantive review comments on PR #834 (CONTRIBUTING.md AI-policy)

  Per the Appendix E criteria ("everyone who has submitted pull requests, opened issues, or provided reviews since the start of the AISVS project") and following the precedent set by PR #763 (Boone Carlson self-add, merged 2026-05-08).

  Note: the substantive PR #822 work is in the next-version research path, not the 1.0 spec content. If the project prefers to defer the Contributors-list addition until the 1.01 release window, happy to close this PR and re-file at that time.