### PR TITLE
ci: set least-privilege permissions on workflow token

### DIFF
--- a/.github/workflows/markdown_linter.yml
+++ b/.github/workflows/markdown_linter.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   markdown-lint-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -17,6 +17,9 @@ on:
       - '**/en/*.markdown'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   spellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I work on software supply chain security and have been hardening GitHub Actions workflows across OSS projects.

Each of these workflows runs without a top-level `permissions:` block, so its `GITHUB_TOKEN` inherits the repository (or org) default, which is frequently read/write for all scopes. This PR sets `permissions: contents: read` at the workflow level for `.github/workflows/markdown_linter.yml`, `.github/workflows/spell-check.yml`, which is all these jobs need (checkout plus the build/test steps). Scoping the token to read-only shrinks what a compromised step or dependency can do, a concern made concrete by the March 2025 `tj-actions/changed-files` compromise (CVE-2025-30066), where a leaked write-scoped `GITHUB_TOKEN` was the blast radius.

No job behavior changes; the steps already only read the repository.