### PR TITLE
fix(C12,C14): remove governance-only controls outside AISVS scope

### DIFF
--- a/1.0/en/0x10-C12-Privacy.md
+++ b/1.0/en/0x10-C12-Privacy.md
@@ -51,8 +51,7 @@ Prevent models and datasets from being used beyond their originally consented pu
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.4.1** | **Verify that** every dataset and model checkpoint carries a machine-readable purpose tag aligned to the original consent and lawful basis under which the source data was collected. | 1 |
 | **12.4.2** | **Verify that** runtime monitors detect queries inconsistent with the declared purpose of the dataset or model, and that detected queries trigger a soft refusal or are blocked pending review. | 1 |
-| **12.4.3** | **Verify that** policy-as-code gates block redeployment of models to new domains without DPIA review. | 3 |
-| **12.4.4** | **Verify that** formal traceability proofs show every personal data lifecycle remains within consented scope. | 3 |
+| **12.4.3** | **Verify that** policy-as-code gates block redeployment of a model to a purpose or domain not covered by its purpose tag (12.4.1). | 3 |
 
 ---
 

--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -27,9 +27,8 @@ Define which AI decisions and agent actions require human approval so that runti
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **14.2.1** | **Verify that** a documented human oversight policy defines which AI decisions and agent actions are classified as high-risk, the criteria used to make that determination, and the approval authority required before execution. | 1 |
+| **14.2.1** | **Verify that** a documented human oversight policy defines which AI decisions and agent actions are classified as high-risk, the criteria used to make that determination, the approval authority required before execution, and whether any deviation from fail-closed default behavior on approval TTL expiry is permitted and under what conditions. | 1 |
 | **14.2.2** | **Verify that** when a human-approval gate (per C14.2.1 and C9.2) is not satisfied within the defined approval time-to-live, the system applies a documented default action that is fail-closed (blocking the pending action). | 2 |
-| **14.2.3** | **Verify that** any deviation from the fail-closed default for an approval TTL expiry is explicitly authorized in the human oversight policy (C14.2.1) and is itself classified as a high-risk policy decision requiring approval authority sign-off. | 2 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -457,12 +457,11 @@ Require human review and approval for high-impact, irreversible, or safety-criti
 
 | Control / Technique | Requirement IDs |
 | --- | --- |
-| Documented high-risk action policy (classification criteria, approval authority) | 14.2.1 |
+| Documented high-risk action policy (classification criteria, approval authority; including authorization of any non-fail-closed TTL-expiry default) | 14.2.1 |
 | High-impact action approval gates (deploy, delete, financial, notify) | 9.2.1 |
 | Approval parameter binding (prevent approve-one-execute-another) | 9.2.2 |
 | High-impact intent confirmation with exact parameter binding and quick expiration | 9.2.3 |
 | Fail-closed default action (block pending action) when human approval is not received within TTL | 14.2.2 |
-| Any non-fail-closed TTL-expiry default explicitly authorized and classified as a high-risk policy decision requiring approval authority sign-off | 14.2.3 |
 | Human review on anomaly detection | 11.6.3 |
 | High-risk model quarantine with human review and sign-off | 6.1.3 |
 | Post-condition outcome checking with containment on mismatch | 9.7.2 |


### PR DESCRIPTION
Preface rule: 'Controls that serve only operational, governance, compliance, or business objectives are out of scope.'

- C12: remove 12.4.3 (DPIA requirement is a GDPR Article 35 legal compliance obligation: a legal document produced by a DPO, not a technical security control verifiable by an AISVS auditor)
- C12: remove 12.4.4 ('formal traceability proofs of consent scope' are legal audit evidence, not an implementable technical mechanism)
- C14: fold 14.2.3 content into 14.2.1 and remove the standalone control; the requirement describes a governance policy authorization process, not a verifiable technical mechanism