### PR TITLE
fix(C01,C03,C05,C11,C12,AppC): correct requirement level assignments

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -28,7 +28,7 @@ Training data must be protected against tampering, corruption, and poisoning thr
 | **1.2.1** | **Verify that** when training data is retired or removed, an impact assessment is documented covering all models trained on that data, the assessed residual memorization risk, and the selected mitigation (targeted fine-tuning, machine unlearning, model retraining, or documented risk acceptance). | 1 |
 | **1.2.2** | **Verify that** cryptographic hashes or digital signatures are used to ensure data integrity during training data storage and transfer. | 2 |
 | **1.2.3** | **Verify that** automated integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
-| **1.2.4** | **Verify that** all training dataset versions are uniquely identified, stored immutably, and auditable to support rollback and forensic analysis. | 3 |
+| **1.2.4** | **Verify that** all training dataset versions are uniquely identified, stored immutably, and auditable to support rollback and forensic analysis. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -64,7 +64,7 @@ Prevent cross-tenant information leakage through AI-specific shared infrastructu
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
-| **5.6.1** | **Verify that** inference-time KV-cache entries are partitioned by authenticated session or tenant identity and that automatic prefix caching does not share cached prefixes across distinct security principals, to prevent timing-based prompt reconstruction attacks. | 2 |
+| **5.6.1** | **Verify that** inference-time KV-cache entries are partitioned by authenticated session or tenant identity and that automatic prefix caching does not share cached prefixes across distinct security principals, to prevent timing-based prompt reconstruction attacks. | 3 |
 | **5.6.2** | **Verify that** shared model serving infrastructure prevents one tenant's fine-tuning, inference, or embedding operations from influencing or observing another tenant's operations through shared model state, adapter weights, or compute resources. | 2 |
 
 ---

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -57,7 +57,7 @@ Prevent reconstruction of private training data or sensitive attributes from mod
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.4.1** | **Verify that** model-inferred sensitive attributes are not directly returned in outputs; where such attributes must be exposed, they are returned as generalized categories (e.g., ranges, buckets) or one-way transforms to limit reconstruction of underlying training records. | 1 |
-| **11.4.2** | **Verify that** query-rate limits throttle repeated adaptive queries from the same principal at thresholds calibrated to the inversion threat model (e.g., the number of queries required to reconstruct training data or sensitive attributes), and not solely as a generic anti-automation control. | 1 |
+| **11.4.2** | **Verify that** query-rate limits throttle repeated adaptive queries from the same principal at thresholds calibrated to the inversion threat model (e.g., the number of queries required to reconstruct training data or sensitive attributes), and not solely as a generic anti-automation control. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C12-Privacy.md
+++ b/1.0/en/0x10-C12-Privacy.md
@@ -62,7 +62,7 @@ Enforce consent at AI-specific decision points (training data ingestion, inferen
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.5.1** | **Verify that** model inference validates consent scope before processing, covering both the requested operation and the data subjects whose data materially influences the response. | 2 |
+| **12.5.1** | **Verify that** model inference validates consent scope before processing, covering both the requested operation and the data subjects whose data materially influences the response. | 3 |
 | **12.5.2** | **Verify that** when validated consent scope does not cover the requested operation or the data subjects whose data materially influences the response, the system refuses or downgrades the response before serving it to the caller. | 2 |
 | **12.5.3** | **Verify that** withdrawal of consent triggers the same AI-artifact propagation pipeline as a deletion request (see 12.2.1), and that inference paths relying on the withdrawn data are disabled within the same SLA. | 2 |
 

--- a/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
+++ b/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
@@ -133,7 +133,7 @@ Auditors, defenders, and the developers themselves need to be able to see why a 
 | # | Description | Level |
 | --- | --- | --- |
 | **AC.5.1** | Verify that prompt-and-response pairs are logged with stable correlation identifiers, so that an investigator can later replay the whole chain: prompt → response → commit → build → deployment. | 1 |
-| **AC.5.2** | Verify that developers can pull up the citations (training snippets, retrieved documents, MCP tool outputs) that support a suggestion, and that the citation chain travels with the artifact. | 2 |
+| **AC.5.2** | Verify that developers can pull up the citations (training snippets, retrieved documents, MCP tool outputs) that support a suggestion, and that the citation chain travels with the artifact. | 3 |
 | **AC.5.3** | Verify that explainability reports, AI-event logs, and citation records are kept in tamper-evident storage (append-only, WORM, or an immutable log store) and are referenced during security reviews. | 3 |
 
 **Mappings & References:**
@@ -216,8 +216,8 @@ Deployment and promotion pipelines need to validate the cryptographic origin and
 <!-- markdownlint-disable MD013 -->
 | # | Description | Level |
 | --- | --- | --- |
-| **AC.9.1** | Verify that AI-generated artifacts carry signed origin and generation metadata (in-toto or SLSA provenance attestations, AI-BOM entries) identifying the AI system that produced them, the generation context, the humans involved, and the associated audit records. | 1 |
-| **AC.9.2** | Verify that deployment pipelines check the presence, signature, and integrity of origin and generation metadata on AI-generated artifacts before promotion, using a trusted verifier (Sigstore/cosign, in-toto verification). | 2 |
+| **AC.9.1** | Verify that AI-generated artifacts carry signed origin and generation metadata (in-toto or SLSA provenance attestations, AI-BOM entries) identifying the AI system that produced them, the generation context, the humans involved, and the associated audit records. | 2 |
+| **AC.9.2** | Verify that deployment pipelines check the presence, signature, and integrity of origin and generation metadata on AI-generated artifacts before promotion, using a trusted verifier (Sigstore/cosign, in-toto verification). | 3 |
 | **AC.9.3** | Verify that artifacts are rejected at deployment and quarantined for review when they are missing required origin and generation information, signed by untrusted keys, or produced by an unapproved AI system or environment. | 3 |
 
 **Mappings & References:**


### PR DESCRIPTION
Level calibration against L1=baseline / L2=standard / L3=high-assurance.

- C01 1.2.4: L3 -> L2. Dataset versioning (DVC, MLflow, Git-LFS) is standard MLOps practice, not high-assurance.
- C03 3.2.4: L1 -> L2. Automated deployment blocking on safety evaluation failure requires CI/CD pipeline infrastructure not assumed at baseline.
- C05 5.6.1: L2 -> L3. KV-cache partitioning requires access to inference framework internals most operators do not have.
- C11 11.4.2: L1 -> L2. Calibrating rate limits to a specific inversion threat model requires threat modeling work not present at baseline.
- C12 12.5.1: L2 -> L3. Validating consent scope covering data subjects whose data materially influenced a response requires determining training data influence per inference, an open problem.
- AppC AC.9.1: L1 -> L2. Signed SLSA/in-toto provenance attestations require a mature MLOps provenance pipeline, not present at baseline.
- AppC AC.9.2: L2 -> L3. Restores level progression after AC.9.1 move.
- AppC AC.5.2: L2 -> L3, plus conditioner. Most commercial AI coding tools do not surface training citations.