### PR TITLE
fix(AppD): repoint stale 11.6.5 reference to 11.2.6

### DIFF
--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -364,7 +364,7 @@ Test for and defend against evasion, extraction, inversion, poisoning, and align
 | Membership inference attack simulation (shadow-model, likelihood-ratio) | 11.3.3 |
 | Model extraction detection (query-pattern analysis, diversity measurement) | 11.5.3 |
 | Statistical outlier and consistency scoring on external inputs | 11.6.1 |
-| Adaptive attack evasion testing | 11.6.5 |
+| Adaptive attack evasion testing | 11.2.6 |
 | AI-augmented review of high-risk agent actions (secondary model, structured self-review, ensemble-of-judges) supplementing the deterministic policy gate (C9.7.1) | 11.8.1 |
 | AI-augmented review mechanism protected against prompt-injection bypass | 11.8.2 |
 | Self-modification restriction with scope bounds and rate limits | 11.9.1, 11.9.5 |


### PR DESCRIPTION
## Problem

Appendix D had a dangling control reference: the row

| Adaptive attack evasion testing | 11.6.5 |

points to 11.6.5, which no longer exists. Controls 11.6.5 and 11.6.6 were removed as GRC controls in #797/#798, but the Appendix D inventory row was not updated at the time, leaving a stale reference in current `main`.

## Fix

Repoint the row to **11.2.6** ("Verify that robustness evaluations use adaptive attacks (attacks specifically designed to defeat the deployed defenses) to confirm no measurable robustness loss across releases"), the existing control that covers adaptive-attack testing. This preserves the inventory entry rather than dropping it.
