### PR TITLE
C02: clearer wording on Input Validation requirements (no scope/intent change)

### DIFF
--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -13,7 +13,7 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.1.1** | **Verify that** all external or derived inputs that may steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier before being included in prompts or used to trigger actions. | 1 |
-| **2.1.2** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, and that inputs exceeding token limits are rejected rather than silently truncated, ensuring system instructions and safety directives are not displaced from the model's effective attention. | 1 |
+| **2.1.2** | **Verify that** input length controls prevent user-supplied content from exceeding a defined proportion of the context window, and that inputs exceeding token limits are rejected rather than silently truncated. This keeps system instructions and safety directives from being displaced from the model's effective attention. | 1 |
 | **2.1.3** | **Verify that** the system implements a character set limitation for user inputs to model prompts, allowing only characters that are explicitly required for business purposes using an allow-list approach. | 1 |
 | **2.1.4** | **Verify that** prompts originating from third-party content (web pages, PDFs, emails) are sanitized in isolation (for example, stripping instruction-like directives and neutralizing HTML, Markdown, and script content) before being concatenated into the main prompt. | 2 |
 | **2.1.5** | **Verify that** the system enforces per-request limits on the number of user-supplied demonstrations included in a single context window. | 2 |
@@ -31,7 +31,7 @@ AI models process text through tokenizers and embeddings that can be exploited v
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.2.1** | **Verify that** input normalization (Unicode NFC canonicalization, homoglyph mapping, removal of control and invisible Unicode characters, and bidirectional text neutralization) is applied before tokenization or embedding. | 1 |
+| **2.2.1** | **Verify that** input normalization is applied before tokenization or embedding. This includes Unicode NFC canonicalization, homoglyph mapping, removal of control and invisible Unicode characters, and bidirectional text neutralization. | 1 |
 | **2.2.2** | **Verify that** inputs identified as adversarial by any detection mechanism are blocked from inclusion in prompts or execution of actions. | 1 |
 | **2.2.3** | **Verify that** inputs which still contain suspicious encoding artifacts after normalization are rejected or flagged for review. | 2 |
 | **2.2.4** | **Verify that** encoding and representation smuggling in inputs (e.g., invisible Unicode/control characters, homoglyph swaps, or mixed-direction text) is detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 3 |
@@ -44,8 +44,8 @@ Syntactically valid prompts may request disallowed content such as policy-violat
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.3.1** | **Verify that** every inbound prompt is scored by a content classifier for violence, self-harm, hate, and sexual content against configurable thresholds, and that prompts exceeding those thresholds are rejected or sanitized before reaching model context. | 1 |
-| **2.3.2** | **Verify that** prompt content classification is evaluated for unsupported-language abuse and that identified gaps are mitigated through compensating controls such as language detection with rejection, conservative thresholds, or human review routing. | 1 |
+| **2.3.1** | **Verify that** every inbound prompt is scored by a content classifier for violence, self-harm, hate, and sexual content against configurable thresholds. Prompts that exceed those thresholds are rejected or sanitized before reaching model context. | 1 |
+| **2.3.2** | **Verify that** prompt content classification is evaluated for unsupported-language abuse. Identified gaps are mitigated through compensating controls such as language detection with rejection, conservative thresholds, or human review routing. | 1 |
 | **2.3.3** | **Verify that** inputs which violate policies are rejected so they do not propagate to downstream model or tool/MCP calls. | 1 |
 | **2.3.4** | **Verify that** screening logs include classifier confidence scores and policy category tags with applied stage (pre-prompt or post-response) and trace metadata (source, tool or MCP server, agent ID, session) for SOC correlation and future red-team replay. | 2 |
 
@@ -59,7 +59,7 @@ AI systems that accept non-textual inputs (images, audio, video, files) face uni
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.4.1** | **Verify that** text extracted from non-text inputs (e.g., image-to-text, speech-to-text) and hidden or embedded content (metadata, layers, alt text, comments) is treated as untrusted and screened per 2.1.1. | 1 |
 | **2.4.2** | **Verify that** image/audio inputs are checked for adversarial perturbations, steganographic payloads, or known attack patterns, and detections trigger gating (block or degrade capabilities) before model use. | 3 |
-| **2.4.3** | **Verify that** cross-modal attack detection identifies coordinated attacks spanning multiple input types (e.g., steganographic payloads in images combined with prompt injection in text) with correlation rules and alert generation, and that confirmed detections are blocked or require HITL (human-in-the-loop) approval. | 3 |
+| **2.4.3** | **Verify that** cross-modal attack detection uses correlation rules to identify coordinated attacks spanning multiple input types (e.g., steganographic payloads in images combined with prompt injection in text) and to raise alerts. Confirmed detections are blocked or require HITL (human-in-the-loop) approval. | 3 |
 
 ---
 


### PR DESCRIPTION
Hi Jim, C02 (Input Validation) is done and ready too.

5 requirements tightened - run-ons and "and that" compounds split into plainer two-sentence form (2.1.2, 2.2.1, 2.3.1, 2.3.2, 2.4.3). Wording only; IDs, levels, examples and References all unchanged. Lint and spell clean.

Two more coming tomorrow.

Raza
