### PR TITLE
C04: clearer wording on Infrastructure requirements (no scope/intent change)

### DIFF
--- a/1.0/en/0x10-C04-Infrastructure.md
+++ b/1.0/en/0x10-C04-Infrastructure.md
@@ -14,8 +14,8 @@ Isolate untrusted AI models in secure sandboxes and protect sensitive AI workloa
 | :--------: | ------------------------------------------------------------------------------------------ | :---: |
 | **4.1.1** | **Verify that** external or untrusted AI models execute in isolated sandboxes. | 1 |
 | **4.1.2** | **Verify that** sandboxed workloads have no outbound network connectivity by default, with any required access explicitly defined. | 1 |
-| **4.1.3** | **Verify that** model artifact loading enforces an explicit allowlist of serialization formats that do not permit arbitrary code execution during deserialization, and that formats capable of arbitrary code execution (e.g., Python pickle with unrestricted globals) are rejected by default. | 1 |
-| **4.1.4** | **Verify that** workload attestation is performed before model loading, ensuring cryptographic proof that the execution environment has not been tampered with. | 2 |
+| **4.1.3** | **Verify that** model artifact loading enforces an explicit allowlist of serialization formats that do not permit arbitrary code execution during deserialization. Formats that can execute arbitrary code (e.g., Python pickle with unrestricted globals) are rejected by default. | 1 |
+| **4.1.4** | **Verify that** workload attestation is performed before model loading. The attestation provides cryptographic proof that the execution environment has not been tampered with. | 2 |
 | **4.1.5** | **Verify that** confidential workloads execute within a trusted execution environment (TEE) that provides hardware-enforced isolation, memory encryption, and integrity protection. | 3 |
 | **4.1.6** | **Verify that** confidential inference services prevent model extraction through encrypted computation with sealed model weights and protected execution. | 3 |
 | **4.1.7** | **Verify that** secure multi-party computation (SMPC) enables collaborative AI training without exposing individual datasets or model parameters. | 3 |
@@ -28,14 +28,14 @@ Secure AI-specific hardware components including GPUs, TPUs, and specialized AI 
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------ | :---: |
-| **4.2.1** | **Verify that** before workload execution, AI accelerator integrity is validated using hardware-based attestation mechanisms (e.g., TPM, DRTM, or equivalent). | 2 |
+| **4.2.1** | **Verify that** AI accelerator integrity is validated using hardware-based attestation mechanisms (e.g., TPM, DRTM, or equivalent) before each workload executes. | 2 |
 | **4.2.2** | **Verify that** accelerator (GPU) memory is isolated between workloads through partitioning mechanisms with memory sanitization between jobs. | 2 |
 | **4.2.3** | **Verify that** AI accelerator firmware is version-pinned, signed, and attested at boot; unsigned or debug firmware is blocked. | 2 |
 | **4.2.4** | **Verify that** VRAM and on-package memory are zeroed between jobs/tenants and that device reset policies prevent cross-tenant data remanence. | 2 |
 | **4.2.5** | **Verify that** partitioning/isolation features (e.g., MIG/VM partitioning) are enforced per tenant and prevent peer-to-peer memory access across partitions. | 2 |
 | **4.2.6** | **Verify that** hardware security modules (HSMs) or equivalent tamper-resistant hardware protect AI model weights and cryptographic keys, with certification to an appropriate assurance level (e.g., FIPS 140-3 Level 3 or Common Criteria EAL4+). | 3 |
 | **4.2.7** | **Verify that** accelerator interconnects (NVLink/PCIe/InfiniBand/RDMA/NCCL) are restricted to approved topologies and authenticated endpoints; plaintext cross-tenant links are disallowed. | 3 |
-| **4.2.8** | **Verify that** accelerator telemetry (power draw, temperature, error correction, performance counters) is exported to centralized security monitoring and alerts on anomalies indicative of side-channels or covert channels. | 3 |
+| **4.2.8** | **Verify that** accelerator telemetry (power draw, temperature, error correction, performance counters) is exported to centralized security monitoring. Monitoring alerts on anomalies that indicate side-channels or covert channels. | 3 |
 
 ---
 


### PR DESCRIPTION
Hi Jim, C04 (Infrastructure, Configuration & Deployment) next.

4 requirements tightened - 4.1.3, 4.1.4 and 4.2.8 now in plainer two-sentence form, and 4.2.1 moves the "before workload execution" timing to the end so the subject comes first. Wording only. Lint and spell clean.

Rebased on top of the #849 renumbering so it applies cleanly.

Thanks Jim - will do another two tomorrow. :)

Raza