### PR TITLE
C08: plain-English readability pass on Memory & Vector DB requirements

### DIFF
--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -14,8 +14,8 @@ Enforce fine-grained access controls and query-time scope enforcement for every 
 | :--: | --- | :---: |
 | **8.1.1** | **Verify that** vector insert, update, delete, and query operations are enforced with namespace/collection/document-tag scope controls (e.g., tenant ID, user ID, data classification labels) with default-deny. | 1 |
 | **8.1.2** | **Verify that** every ingested document is tagged at write time with source, writer identity (authenticated user or system principal), timestamp, batch ID, and embedding model version. | 2 |
-| **8.1.3** | **Verify that** document metadata tags applied at ingestion are immutable after initial write and cannot be modified by subsequent pipeline stages or user operations. | 2 |
-| **8.1.4** | **Verify that** RAG pipeline retrieval events log the query issued, the documents or chunks retrieved, similarity scores, the knowledge source, and whether retrieved content passed prompt injection scanning before being incorporated into model context. | 2 |
+| **8.1.3** | **Verify that** document metadata tags applied at ingestion are immutable after the initial write and cannot be changed by later pipeline stages or user operations. | 2 |
+| **8.1.4** | **Verify that** RAG pipeline retrieval events log the query issued, the documents or chunks retrieved, similarity scores, the knowledge source, and whether retrieved content passed prompt injection scanning before it was added to the model context. | 2 |
 | **8.1.5** | **Verify that** restricted retrieval indices include uniquely marked canary records that contain no real sensitive content, with markers that survive retrieval, embedding, and context-assembly pipelines. | 2 |
 | **8.1.6** | **Verify that** a high-severity security alert is generated whenever a canary record is selected by retrieval, matched by similarity search, or passed to the model as context. | 2 |
 | **8.1.7** | **Verify that** retrieval anomaly detection identifies embedding density outliers, repeated dominance of specific documents in similarity results, and sudden shifts in retrieval bias distribution that may indicate vector database poisoning. | 3 |
@@ -28,7 +28,7 @@ Pre-screen content before vectorization; treat memory writes as untrusted inputs
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.2.1** | **Verify that** regulated data and sensitive fields are detected prior to embedding and are masked, tokenized, transformed, or dropped based on policy, recognizing that data once embedded cannot be reliably redacted from the resulting index. | 1 |
+| **8.2.1** | **Verify that** regulated data and sensitive fields are detected before embedding and are masked, tokenized, transformed, or dropped based on policy, since data once embedded cannot be reliably redacted from the resulting index. | 1 |
 | **8.2.2** | **Verify that** content intended to poison retrieval (e.g., text crafted to project to attacker-chosen embedding neighborhoods, hidden instructions intended for downstream model context, or steganographic payloads in non-text inputs) is detected and rejected or quarantined before vectorization. | 1 |
 | **8.2.3** | **Verify that** vectors that fall outside normal clustering patterns are flagged and quarantined before entering production indices. | 2 |
 | **8.2.4** | **Verify that** agent outputs, tool outputs, and orchestration results are not automatically written to trusted agent memory without explicit source validation (e.g., content-origin checks or write-authorization controls that verify the content's source before committing writes). | 2 |
@@ -43,7 +43,7 @@ Retention and revocation must be explicit and enforceable for memory and RAG ind
 | # | Description | Level |
 | :--: | --- | :---: |
 | **8.3.1** | **Verify that** expired vectors are excluded from retrieval results within a measured and monitored propagation window. | 2 |
-| **8.3.2** | **Verify that** memory can be reset for security reasons (quarantine, selective purge, full reset) through an operation that is separate and independent from the retention deletion process. | 2 |
+| **8.3.2** | **Verify that** memory can be reset for security reasons (quarantine, selective purge, full reset) through an operation that is separate from the retention deletion process. | 2 |
 | **8.3.3** | **Verify that** quarantined content is retained for investigation but is excluded from all retrieval results while under quarantine. | 2 |
 
 ---
@@ -67,7 +67,7 @@ Prevent cross-tenant and cross-user leakage in retrieval and prompt assembly.
 | **8.5.1** | **Verify that** every retrieval operation enforces scope constraints (tenant/user/classification) **in the vector engine query** and verifies them again **before prompt assembly** (post-filter). | 1 |
 | **8.5.2** | **Verify that** vector identifiers, namespaces, and metadata indexing prevent cross-scope collisions and enforce uniqueness per tenant. | 1 |
 | **8.5.3** | **Verify that** retrieval results that match similarity criteria but fail scope checks are discarded. | 1 |
-| **8.5.4** | **Verify that** multi-tenant tests simulate adversarial retrieval attempts (prompt-based and query-based) and demonstrate zero out-of-scope document inclusion in prompts and outputs. | 2 |
+| **8.5.4** | **Verify that** multi-tenant tests simulate adversarial retrieval attempts (prompt-based and query-based) and show that no out-of-scope documents appear in prompts or outputs. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -43,7 +43,7 @@ Retention and revocation must be explicit and enforceable for memory and RAG ind
 | # | Description | Level |
 | :--: | --- | :---: |
 | **8.3.1** | **Verify that** expired vectors are excluded from retrieval results within a measured and monitored propagation window. | 2 |
-| **8.3.2** | **Verify that** memory can be reset for security reasons (quarantine, selective purge, full reset) through an operation that is separate from the retention deletion process. | 2 |
+| **8.3.2** | **Verify that** memory can be reset for security reasons (quarantine, selective purge, full reset) through an operation that is separate and independent from the retention deletion process. | 2 |
 | **8.3.3** | **Verify that** quarantined content is retained for investigation but is excluded from all retrieval results while under quarantine. | 2 |
 
 ---


### PR DESCRIPTION
Hey guys - C07 and C08 done! Clean, no lint issues.

Readability pass on the "Verify that" requirements in C08. Plain, simpler
wording with no change to any ID, level, example, or meaning.

- 8.1.3  "after the initial write"; "changed by later pipeline stages"
- 8.1.4  "before it was added to the model context"
- 8.2.1  "before embedding"; "since data once embedded..."
- 8.3.2  dropped redundant "and independent from"
- 8.5.4  "show that no out-of-scope documents appear in prompts or outputs"
