### PR TITLE
Levels review C04

### DIFF
--- a/1.0/en/0x10-C04-Infrastructure.md
+++ b/1.0/en/0x10-C04-Infrastructure.md
@@ -31,7 +31,7 @@ Secure AI-specific hardware components including GPUs, TPUs, and specialized AI 
 | **4.2.1** | **Verify that** before workload execution, AI accelerator integrity is validated using hardware-based attestation mechanisms (e.g., TPM, DRTM, or equivalent). | 2 |
 | **4.2.2** | **Verify that** accelerator (GPU) memory is isolated between workloads through partitioning mechanisms with memory sanitization between jobs. | 2 |
 | **4.2.3** | **Verify that** AI accelerator firmware is version-pinned, signed, and attested at boot; unsigned or debug firmware is blocked. | 2 |
-| **4.2.4** | **Verify that** VRAM and on-package memory are zeroed between jobs/tenants and that device reset policies prevent cross-tenant data remanence. | 2 |
+| **4.2.4** | **Verify that** VRAM and on-package memory are zeroed between jobs/tenants and that device reset policies prevent cross-tenant data remanence. | 3 |
 | **4.2.5** | **Verify that** partitioning/isolation features (e.g., MIG/VM partitioning) are enforced per tenant and prevent peer-to-peer memory access across partitions. | 2 |
 | **4.2.6** | **Verify that** hardware security modules (HSMs) or equivalent tamper-resistant hardware protect AI model weights and cryptographic keys, with certification to an appropriate assurance level (e.g., FIPS 140-3 Level 3 or Common Criteria EAL4+). | 3 |
 | **4.2.7** | **Verify that** accelerator interconnects (NVLink/PCIe/InfiniBand/RDMA/NCCL) are restricted to approved topologies and authenticated endpoints; plaintext cross-tenant links are disallowed. | 3 |
@@ -46,7 +46,7 @@ Secure distributed AI deployments including edge computing, federated learning, 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------ | :---: |
 | **4.3.1** | **Verify that** edge AI devices authenticate to central infrastructure using mutual authentication with certificate validation (e.g., mutual TLS). | 1 |
-| **4.3.2** | **Verify that** models deployed to edge or mobile devices are cryptographically signed during packaging, and that the on-device runtime validates these signatures or checksums before loading or inference; unverified or altered models must be rejected. | 1 |
+| **4.3.2** | **Verify that** models deployed to edge or mobile devices are cryptographically signed during packaging, and that the on-device runtime validates these signatures or checksums before loading or inference; unverified or altered models must be rejected. | 2 |
 | **4.3.3** | **Verify that** distributed AI coordination uses Byzantine fault-tolerant consensus mechanisms with participant validation and malicious node detection. | 3 |
 | **4.3.4** | **Verify that** on-device inference runtimes enforce process, memory, and file access isolation to prevent model dumping, debugging, or extraction of intermediate embeddings and activations. | 3 |
 | **4.3.5** | **Verify that** model weights and sensitive parameters stored locally are encrypted using hardware-backed key stores or secure enclaves (e.g., Android Keystore, iOS Secure Enclave, TPM/TEE), with keys inaccessible to user space. | 3 |


### PR DESCRIPTION
Polishing pass on C04 focused on level assignments and implementability.

## Changes

### C4.2.4: L2 -> L3

Rationale: VRAM zeroing between jobs/tenants is not achievable on standard GPU deployments. CUDA `cudaMalloc()` does NOT zero memory. No cloud provider (AWS, GCP, Azure) guarantees VRAM sanitization between VMs. The only production mechanism is NVIDIA Confidential Computing mode (H100+ with CPU TEE), which requires specific hardware, a CPU with TEE, and explicit firmware toggle. This is a known vulnerability since 2014 with no general-purpose fix. L2 implies security-conscious orgs should implement this, but there is no broadly available path to do so.

Question to reviewers: should we drop this requirement completely? Keeping this means L3 implementation requires use of NVIDIA Confidential Computing mode (H100+ with CPU TEE).

### C4.3.2: L1 -> L2

Rationale: Model signing requires KMS/OIDC identity, signing pipeline integration, consumer-side verification, key rotation, and transparency log. Sigstore/model-signing v1.0 only GA April 2025. No on-device ML runtime (TF Lite, Core ML, ONNX Runtime, PyTorch Mobile) has built-in signature verification. Consistent with C3.1.2 and C3.1.3 (both moved to L2 in levelsreviewc03 PR). ASVS v5.0 places code signing at L2/L3.
