### PR TITLE
C09: plain-English readability fix on Orchestration & Agentic Action

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -78,7 +78,7 @@ Ensure every action is authorized at execution time and constrained by scope.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.6.1** | **Verify that** agent actions are authorized against fine-grained policies enforced by the runtime that restrict which tools an agent may invoke, which parameter values it may supply (e.g., allowed resources, data scopes, action types), and that policy violations are blocked. | 1 |
+| **9.6.1** | **Verify that** agent actions are authorized against fine-grained policies enforced by the runtime that restrict which tools an agent may invoke, which parameter values it may supply (e.g., allowed resources, data scopes, action types), and block policy violations. | 1 |
 | **9.6.2** | **Verify that** when an agent acts on a user's behalf, the runtime propagates an integrity-protected delegation context (user ID, tenant, session, scopes) and enforces that context at every downstream call without using the user's credentials. | 2 |
 | **9.6.3** | **Verify that** all access control decisions are enforced by application logic or a policy engine, never by the AI model itself, and that model-generated output (e.g., "the user is allowed to do this") cannot override or bypass access control checks. | 2 |
 | **9.6.4** | **Verify that** secrets and credentials required by an agent at runtime are not exposed within the model's observable context, including the context window, system prompts, or tool call parameters, and are instead provided via out-of-band mechanisms such as credential proxies, secrets manager injection, runtime sidecar authentication, or short-lived scoped tokens. | 2 |


### PR DESCRIPTION
Hey guys - C9 and C10 done. C10 is quite tight anyway, well edited already.

Light readability/grammar pass on the "Verify that" requirements. No change to any ID, level, example, or meaning.

- 9.6.1  fixed parallelism so the trailing clause agrees with "policies ... that restrict ...": "and that policy violations are blocked" -> "and block policy violations".

(9.9.1 left untouched - precise normative wording, on the flag list.)

Thanks,
Raza
