### PR TITLE
fix(C14): port 14.1.4 L3 raise to published 1.0/en/ track

### DIFF
--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -17,7 +17,7 @@ Provide shutdown or rollback paths when unsafe behavior of the AI system is obse
 | **14.1.1** | **Verify that** a manual kill-switch mechanism exists to immediately halt AI model inference and outputs. | 1 |
 | **14.1.2** | **Verify that** kill-switch and intermediate-state mechanisms are exercised at a defined frequency, and that each test confirms the system reaches the target state within the documented response time and that all dependent components (e.g., agent runtimes, tool/MCP servers, retrieval connectors) transition as specified. | 2 |
 | **14.1.3** | **Verify that** the system can be placed into at least two intermediate operational states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined entry triggers and can be exited independently without requiring a full system restart or shutdown. | 2 |
-| **14.1.4** | **Verify that** override and kill-switch commands for autonomous agents are delivered through an out-of-band channel (e.g., infrastructure controls, hypervisor-level signals, network-layer isolation) that is architecturally isolated from the agent runtime, ensuring commands remain enforceable even if the agent runtime is compromised or manipulated. | 2 |
+| **14.1.4** | **Verify that** override and kill-switch commands for autonomous agents are delivered through an out-of-band channel (e.g., infrastructure controls, hypervisor-level signals, network-layer isolation) that is architecturally isolated from the agent runtime, ensuring commands remain enforceable even if the agent runtime is compromised or manipulated. | 3 |
 
 ---
 


### PR DESCRIPTION
Follow-up to #855.

PR #855 raised C14.1.4 from L2 to L3 in the research wiki file
(`research/chapters/C14-Human-Oversight/C14-Human-Oversight.md`). The
published-track file (`1.0/en/0x10-C14-Human-Oversight.md`) was not
updated in that PR and still shows C14.1.4 at L2. This PR applies the
same L2 → L3 change to the published-track file so it ships in the
2026-06-24 AISVS 1.0 release.

## Rationale (per #855)

C14.1.4 requires that override and kill-switch commands be delivered
through a channel "architecturally isolated from the agent runtime,
ensuring commands remain enforceable even if the agent runtime is
compromised or manipulated." This is the same architectural-isolation
threat model that drives C5.5.1 (PDP runtime isolation, L3). Both
controls require:

- An out-of-band or runtime-isolated enforcement mechanism
- Resilience against adversarial agent-runtime compromise
- Platform-engineering investment beyond standard operational hygiene
  (hypervisor-level signals, network-layer isolation, or equivalent)

SP 800-53 Rev. 5 supports the L3 placement through the same anchors
that back C5.5.1: AC-25 (Reference Monitor) for "tamperproof, always
invoked" enforcement, and SC-3 (Security Function Isolation) for
separation of security functions from the supervised environment.

C5.5.1 sits at L3 in `1.0/en/0x10-C05-Access-Control-and-Identity.md`.
C14.1.4 should sit at L3 in `1.0/en/0x10-C14-Human-Oversight.md` for
consistency.

Closes the gap between #855 and the published 1.0 release.