### PR TITLE
fix(C13): clarify 13.6.1 and 13.6.2 with concrete actionable wording

### DIFF
--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -84,8 +84,8 @@ Detect and prevent security threats arising from proactive (agent-initiated) beh
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **13.6.1** | **Verify that** proactive agent behaviors are security-validated before execution with risk assessment integration. | 1 || **13.6.1** | **Verify that** proactive agent behaviors and the outcome of their pre-execution policy evaluation are recorded in the monitoring log with sufficient context to reconstruct the proposed action, the evaluation decision, and the basis for that decision. | 1 |
-| **13.6.2** | **Verify that** autonomous initiative triggers include security context evaluation and threat landscape assessment. | 2 || **13.6.2** | **Verify that** autonomous initiative triggers include security context evaluation covering the agent's current authorization scope and the action classification under the human oversight policy. | 2 |
+| **13.6.1** | **Verify that** proactive agent behaviors and the outcome of their pre-execution policy evaluation are recorded in the monitoring log with sufficient context to reconstruct the proposed action, the evaluation decision, and the basis for that decision. | 1 |
+| **13.6.2** | **Verify that** autonomous initiative triggers include security context evaluation covering the agent's current authorization scope and the action classification under the human oversight policy. | 2 |
 | **13.6.3** | **Verify that** proactive behavior patterns are analyzed for potential security implications and unintended consequences. | 2 |
 | **13.6.4** | **Verify that** audit logs capture the complete approval chain for security-critical proactive actions, including approver identity, timestamp, action parameters, and decision outcome. | 3 |
 | **13.6.5** | **Verify that** behavioral anomaly detection identifies deviations in proactive agent patterns that may indicate compromise. | 3 |

--- a/1.0/en/0x10-C13-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C13-Monitoring-and-Logging.md
@@ -84,8 +84,8 @@ Detect and prevent security threats arising from proactive (agent-initiated) beh
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **13.6.1** | **Verify that** proactive agent behaviors are security-validated before execution with risk assessment integration. | 1 |
-| **13.6.2** | **Verify that** autonomous initiative triggers include security context evaluation and threat landscape assessment. | 2 |
+| **13.6.1** | **Verify that** proactive agent behaviors are security-validated before execution with risk assessment integration. | 1 || **13.6.1** | **Verify that** proactive agent behaviors and the outcome of their pre-execution policy evaluation are recorded in the monitoring log with sufficient context to reconstruct the proposed action, the evaluation decision, and the basis for that decision. | 1 |
+| **13.6.2** | **Verify that** autonomous initiative triggers include security context evaluation and threat landscape assessment. | 2 || **13.6.2** | **Verify that** autonomous initiative triggers include security context evaluation covering the agent's current authorization scope and the action classification under the human oversight policy. | 2 |
 | **13.6.3** | **Verify that** proactive behavior patterns are analyzed for potential security implications and unintended consequences. | 2 |
 | **13.6.4** | **Verify that** audit logs capture the complete approval chain for security-critical proactive actions, including approver identity, timestamp, action parameters, and decision outcome. | 3 |
 | **13.6.5** | **Verify that** behavioral anomaly detection identifies deviations in proactive agent patterns that may indicate compromise. | 3 |


### PR DESCRIPTION
Resurrects two requirement rewrites from #847 (closed without merge) that Otto Sulin endorsed in his 2026-06-02 review-thread comment as "a very good addition" because "the original wording is very ambiguous and not yet actionable."

This version strips cross-references per the direction from #867 ("make requirements independent") and #872. The rewrites stand on their own substance — the architectural anchoring from Appendix D framing (AD.19) remains unchanged.

## 13.6.1

Current: "proactive agent behaviors are security-validated before execution with risk assessment integration" — abstract, not testable.

Proposed: "proactive agent behaviors and the outcome of their pre-execution policy evaluation are recorded in the monitoring log with sufficient context to reconstruct the proposed action, the evaluation decision, and the basis for that decision."

Gives C13.6.1 a concrete logging dimension that an auditor can verify by inspecting monitoring records. Level (1) unchanged.

## 13.6.2

Current: "autonomous initiative triggers include security context evaluation and threat landscape assessment" — "threat landscape assessment" is not realistic to operationalize in most enterprise environments.

Proposed: "autonomous initiative triggers include security context evaluation covering the agent's current authorization scope and the action classification under the human oversight policy."

Replaces the vague phrase with two concrete evaluable signals (authorization scope, action classification). Level (2) unchanged.

## What is not in this PR

- No new cross-references between requirements (per #867 / #872)
- No level changes
- No ID changes
- No changes to 13.6.3, 13.6.4, 13.6.5

## Acknowledgment

The substantive content of these rewrites originated in vtknightmare's PR #847. The cross-reference removals from those rewrites have been applied here per the current AISVS editorial direction.