### PR TITLE
Levels review C05

### DIFF
--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -10,7 +10,7 @@ AI systems introduce access control challenges beyond traditional application se
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
-| **5.1.1** | **Verify that** high-risk AI operations (model deployment, weight export, training data access, production configuration changes) require step-up authentication with session re-validation. | 2 |
+| **5.1.1** | **Verify that** high-risk AI operations (model deployment, weight export, training data access, production configuration changes) require step-up authentication with session re-validation. | 3 |
 | **5.1.2** | **Verify that** AI agents in federated or multi-system deployments authenticate using short-lived, cryptographically signed tokens (e.g., signed JWT assertions) where the signature key is bound to the issuing system's identity (e.g., via JWKS, x5c, or sender-constrained tokens such as DPoP or mTLS). | 3 |
 
 ---
@@ -21,7 +21,7 @@ AI systems introduce access control challenges beyond traditional application se
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.2.1** | **Verify that** every AI resource (datasets, models, endpoints, vector collections, embedding indices, compute instances) enforces access controls (e.g., RBAC, ABAC) with explicit allow-lists and default-deny policies. | 1 |
 | **5.2.2** | **Verify that** privileged access to model weights, training pipelines, and production AI configuration is granted just in time, with a defined maximum session duration and automatic expiry. Permanent standing privileged access to these resources is not permitted. | 2 |
-| **5.2.3** | **Verify that** a documented data classification taxonomy covering AI-specific data types (embeddings, model weights, prompt templates, RAG context assemblies, fine-tuning datasets, agent tool schemas) is defined. Verify that AI assets are labeled in accordance with this taxonomy. | 2 |
+| **5.2.3** | **Verify that** a documented data classification taxonomy covering AI-specific data types (embeddings, model weights, prompt templates, RAG context assemblies, fine-tuning datasets, agent tool schemas) is defined. Verify that all AI production assets are labeled in accordance with this taxonomy. | 2 |
 | **5.2.4** | **Verify that** data classification labels (PII, PHI, proprietary, etc.) automatically propagate to derived resources (embeddings, prompt caches, model outputs). | 3 |
 
 ---
@@ -32,7 +32,7 @@ Enforce the caller's authorization context through AI-specific query pipelines (
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
-| **5.3.1** | **Verify that** AI inference and retrieval pipelines (e.g., RAG queries, embedding lookups) enforce the end-user's authorization context at each retrieval and assembly stage, rather than relying solely on the service account's permissions. | 1 |
+| **5.3.1** | **Verify that** AI inference and retrieval pipelines (e.g., RAG queries, embedding lookups) enforce the end-user's authorization context at each retrieval and assembly stage, rather than relying solely on the service account's permissions. | 2 |
 
 ---
 
@@ -42,8 +42,8 @@ Ensure that AI-generated outputs, including citations and source attributions, r
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
-| **5.4.1** | **Verify that** post-inference filtering mechanisms prevent responses from including classified information or proprietary data that the requestor is not authorized to receive. | 1 |
-| **5.4.2** | **Verify that** citations, references, and source attributions in model outputs are validated against caller entitlements and removed if unauthorized access is detected. | 2 |
+| **5.4.1** | **Verify that** post-inference filtering mechanisms prevent responses from including classified information or proprietary data that the requestor is not authorized to receive. | 2 |
+| **5.4.2** | **Verify that** citations, references, and source attributions in model outputs are validated against caller entitlements and removed if unauthorized access is detected. | 3 |
 
 ---
 
@@ -65,7 +65,8 @@ Prevent cross-tenant information leakage through AI-specific shared infrastructu
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
 | **5.6.1** | **Verify that** inference-time KV-cache entries are partitioned by authenticated session or tenant identity. Verify that automatic prefix caching does not share cached prefixes across distinct security principals, to prevent timing-based prompt reconstruction attacks. | 3 |
-| **5.6.2** | **Verify that** shared model serving infrastructure prevents one tenant's fine-tuning, inference, or embedding operations from influencing or observing another tenant's operations through shared model state, adapter weights, or compute resources. | 2 |
+| **5.6.2** | **Verify that** shared model serving infrastructure prevents one tenant's fine-tuning, inference, or embedding operations from influencing or observing another tenant's operations through shared model state or adapter weights. | 2 |
+| **5.6.3** | **Verify that** one tenant cannot influence or observe another tenant's operations through shared compute resources, including timing and other side channels arising from co-located execution. Because no software-only mitigation exists in current shared inference servers, satisfying this requirement typically requires hardware partitioning (e.g., NVIDIA MIG, SR-IOV virtual functions), confidential computing (e.g., NVIDIA Confidential Computing on H100+, AWS Nitro Enclaves), or dedicated per-tenant compute allocation. | 3 |
 
 ---
 


### PR DESCRIPTION
Implementability and level review for C05.

## Changes

**C5.1.1** L2 -> L3: Step-up authentication for high-risk AI operations. IdP-native step-up (Okta, Entra ID) is mature but no major MLOps platform (SageMaker, Databricks, Vertex AI, MLflow) has native step-up support. Every deployment requires custom API gateway + IdP integration (Lambda authorizer, Kong plugin etc) integrating auth validation into model deployment / weight export / training data APIs. 

No standard pattern exists currently. The combination of "no native platform support" plus "session re-validation per high-risk action" pushes this beyond the L2 "mature tooling, requires engineering" tier into L3 situational/advanced territory.

**C5.3.1** L1 -> L2: End-user authorization context enforcement in RAG/embedding lookups. Pinecone+SpiceDB, pgvector RLS, Weaviate multi-tenancy are production-ready but require non-trivial integration; LangChain/LlamaIndex have no first-party native RLS. The "service account anti-pattern" is the current default in most RAG deployments. Not an L1 "every team does this" baseline.

**C5.4.1** L1 -> L2: Post-inference filtering against caller entitlements. Broader than PII redaction: requires the system to know caller entitlements AND classify model output by sensitivity at inference time.

**C5.4.2** L2 -> L3: Citation/source attribution entitlement validation. Currently unaddressed in production: no standard pattern, custom implementation required to parse citations, map to sources, and check ACLs. Harder than 5.4.1 output filtering.

**C5.6.2 split into C5.6.2 (L2) and C5.6.3 (new, L3)**: The original requirement was a compound control spanning two materially different difficulty tiers. Per-tenant isolation of model state and adapter weights is L2-achievable today (LoRAX, vLLM with multi-LoRA, S-LoRA provide per-request adapter isolation and gateway-enforced tenant scoping). 

Compute-resource side-channel resistance is L3 because no software-only mitigation exists in current shared inference servers; satisfying it typically requires hardware partitioning (NVIDIA MIG, SR-IOV), confidential computing (NVIDIA CC on H100+, AWS Nitro Enclaves), or dedicated per-tenant compute, with the corresponding utilization cost. C5.6.3 names these implementation paths explicitly so readers understand the requirement is satisfiable but not via shared-resource software mitigation. Splitting lets organizations target L2 confidently while keeping the harder side-channel requirement at L3 where it belongs. By our release policy, we can remove the _Because no software-only mitigation exists in current shared inference servers_ sentence if technology changes.

Alternatively, we could keep this as one requirement but make it L3, or completely remove wording about side-channels since it is largely unmitigated currently without mentioned costly and limited technology choices. Discussion very welcome.

**C5.2.3**: Added small coverage qualifier to improve testability and clarity of the requirement to avoid PR for this simple change :)
