### PR TITLE
C14: plain-English readability pass on Human Oversight and Trust

### DIFF
--- a/1.0/en/0x10-C14-Human-Oversight.md
+++ b/1.0/en/0x10-C14-Human-Oversight.md
@@ -15,9 +15,9 @@ Provide shutdown or rollback paths when unsafe behavior of the AI system is obse
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **14.1.1** | **Verify that** a manual kill-switch mechanism exists to immediately halt AI model inference and outputs. | 1 |
-| **14.1.2** | **Verify that** kill-switch and intermediate-state mechanisms are exercised at a defined frequency, and that each test confirms the system reaches the target state within the documented response time and that all dependent components (e.g., agent runtimes, tool/MCP servers, retrieval connectors) transition as specified. | 2 |
+| **14.1.2** | **Verify that** kill-switch and intermediate-state mechanisms are tested at a defined frequency, and that each test confirms the system reaches the target state within the documented response time and that all dependent components (e.g., agent runtimes, tool/MCP servers, retrieval connectors) transition as specified. | 2 |
 | **14.1.3** | **Verify that** the system can be placed into at least two intermediate operational states between full operation and complete shutdown (e.g., disabling specific tools or MCP servers, removing a retrieval source, switching to a safer or smaller model, enforcing read-only mode for agents), and that each state has defined entry triggers and can be exited independently without requiring a full system restart or shutdown. | 2 |
-| **14.1.4** | **Verify that** override and kill-switch commands for autonomous agents are delivered through an out-of-band channel (e.g., infrastructure controls, hypervisor-level signals, network-layer isolation) that is architecturally isolated from the agent runtime, ensuring commands remain enforceable even if the agent runtime is compromised or manipulated. | 3 |
+| **14.1.4** | **Verify that** override and kill-switch commands for autonomous agents are delivered through an out-of-band channel (e.g., infrastructure controls, hypervisor-level signals, network-layer isolation) that is architecturally isolated from the agent runtime, so the commands stay enforceable even if the agent runtime is compromised or manipulated. | 3 |
 
 ---
 


### PR DESCRIPTION
C14 - last chapter, also done!

this closes out the readability pass across all 14 chapters.

same approach as the rest: plain-English wording only. no changes to meaning,
IDs, levels, technical terms, examples or spellings. every "Verify that..."
requirement still verifies the same thing, it just reads more clearly.

C14 (Human Oversight and Trust) - 2 small wording fixes:
14.1.2, 14.1.4

kept this one light on purpose since it maps to EU AI Act Article 14.
