### PR TITLE
C11: split 11.1.2 for readability

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -13,7 +13,7 @@ Guard against harmful or policy-breaking outputs through systematic testing and 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **11.1.1** | **Verify that** refusal and safe-completion guardrails are enforced to prevent the model from generating disallowed content categories. | 1 |
-| **11.1.2** | **Verify that** an alignment test suite, including red-team prompts, jailbreak probes, disallowed-content checks, and multilingual or code-switching abuse cases, is version-controlled and run on every model update or release. | 1 |
+| **11.1.2** | **Verify that** a version-controlled alignment test suite is run on every model update or release. The suite includes red-team prompts, jailbreak probes, disallowed-content checks, and multilingual or code-switching abuse cases. | 1 |
 | **11.1.3** | **Verify that** an automated evaluator measures harmful-content rate and flags regressions beyond a defined threshold. | 2 |
 | **11.1.4** | **Verify that** alignment and safety training procedures (e.g., RLHF, constitutional AI, or equivalent) are documented and reproducible. | 2 |
 | **11.1.5** | **Verify that** alignment evaluation includes assessments for evaluation awareness, where the model may behave differently when it detects it is being tested versus deployed. | 3 |


### PR DESCRIPTION
Readability pass on C11 11.1.2. The requirement now leads with the testable assertion and moves the list of probe types into a second sentence, so the subject and verb are no longer separated by a long inclusion list. Scope, level (1), and intent are unchanged.

Part of the pre-release editorial pass (one change per PR).