### PR TITLE
C11: clarify 11.1.5 evaluation-awareness wording

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -16,7 +16,7 @@ Guard against harmful or policy-breaking outputs through systematic testing and 
 | **11.1.2** | **Verify that** an alignment test suite, including red-team prompts, jailbreak probes, disallowed-content checks, and multilingual or code-switching abuse cases, is version-controlled and run on every model update or release. | 1 |
 | **11.1.3** | **Verify that** an automated evaluator measures harmful-content rate and flags regressions beyond a defined threshold. | 2 |
 | **11.1.4** | **Verify that** alignment and safety training procedures (e.g., RLHF, constitutional AI, or equivalent) are documented and reproducible. | 2 |
-| **11.1.5** | **Verify that** alignment evaluation includes assessments for evaluation awareness, where the model may behave differently when it detects it is being tested versus deployed. | 3 |
+| **11.1.5** | **Verify that** alignment evaluation includes assessments for evaluation awareness: the risk that a model behaves differently when it detects it is being tested rather than deployed. | 3 |
 
 ---
 


### PR DESCRIPTION
Readability pass on C11 11.1.5. Replaces the trailing "where the model may..." relative clause with a colon and a crisp restatement of the same risk. Scope, level (3), and intent are unchanged.

Part of the pre-release editorial pass (one change per PR).