### PR TITLE
C11: simplify 11.8.1 phrasing

### DIFF
--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -108,7 +108,7 @@ For agentic AI systems, supplement deterministic policy gates (C9.2, C9.7) with 
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **11.8.1** | **Verify that** agentic systems include an AI-augmented review of planned high-risk actions before execution (e.g., a secondary model, structured self-review step, or ensemble-of-judges check) that operates in addition to and not in place of the deterministic policy gate. | 2 |
+| **11.8.1** | **Verify that** agentic systems include an AI-augmented review of planned high-risk actions before execution (e.g., a secondary model, structured self-review step, or ensemble-of-judges check) that supplements the deterministic policy gate rather than replacing it. | 2 |
 | **11.8.2** | **Verify that** the AI-augmented review mechanism in 11.8.1 is protected against manipulation by adversarial inputs, so that the review step cannot be overridden or bypassed through prompt injection or instruction smuggling in agent context. | 2 |
 
 ---


### PR DESCRIPTION
Readability pass on C11 11.8.1. Replaces the double-negative "in addition to and not in place of" with "supplements ... rather than replacing it." Same meaning, plainer phrasing. Scope, level (2), and intent are unchanged.

Part of the pre-release editorial pass (one change per PR).