### PR TITLE
Appendix E: fix release-date wording

### DIFF
--- a/1.0/en/0x94-Appendix-E_Contributors.md
+++ b/1.0/en/0x94-Appendix-E_Contributors.md
@@ -20,4 +20,4 @@ please open an issue or pull request.
 
 ## Contributors
 
-We will generate the contributor list from automation (based on GitHub history) before we release 1.0 the end of June 2026!
+We will generate the contributor list from automation (based on GitHub history) before we release 1.0 at the end of June 2026!


### PR DESCRIPTION
Editorial fix in Appendix E: "before we release 1.0 at the end of June 2026." Adds the missing preposition.

Part of the pre-release editorial pass (one change per PR).