### PR TITLE
C06 implementability review

### DIFF
--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -12,8 +12,8 @@ Assess and authenticate third-party model origins and hidden behaviors before an
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.1.1** | **Verify that** every third-party model artifact includes a signed origin-and-integrity record identifying its source, version, and integrity checksum. | 1 |
-| **6.1.2** | **Verify that** models are scanned with automated tools for malicious layers or Trojan triggers before import. | 1 |
+| **6.1.1** | **Verify that** every third-party model artifact includes a signed origin-and-integrity record identifying its source, version, and integrity checksum. | 2 |
+| **6.1.2** | **Verify that** models are scanned with automated tools for malicious code or unsafe serialization payloads (e.g., pickle code execution, Keras Lambda code injection) before import. | 1 |
 | **6.1.3** | **Verify that** high-risk models (e.g., publicly uploaded weights, unverified creators) remain quarantined until human review and sign-off. | 2 |
 | **6.1.4** | **Verify that** third-party or open-source models pass a defined behavioral acceptance test suite before being imported or promoted to any non-development environment. The suite covers safety, alignment, and capability boundaries relevant to the deployment context. | 2 |
 | **6.1.5** | **Verify that** transfer-learning fine-tunes pass adversarial evaluation to detect hidden behaviors. | 3 |
@@ -37,10 +37,10 @@ Evaluate external datasets for poisoning and legal compliance, and monitor them 
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.3.1** | **Verify that** disallowed content (e.g., copyrighted material, PII) is detected and removed by automated scrubbing before training. | 1 |
+| **6.3.1** | **Verify that** disallowed content (e.g., copyrighted material) is detected and removed by automated scrubbing before training. | 1 |
 | **6.3.2** | **Verify that** external datasets undergo poisoning risk assessment (e.g., data fingerprinting, outlier detection). | 2 |
-| **6.3.3** | **Verify that** origin, lineage, and license terms for datasets are captured in AI BOM entries. | 2 |
-| **6.3.4** | **Verify that** periodic monitoring detects drift or corruption in hosted datasets. | 3 |
+| **6.3.3** | **Verify that** origin, lineage, and license terms for datasets are captured in AI BOM entries. | 1 |
+| **6.3.4** | **Verify that** periodic monitoring detects drift or corruption in hosted datasets. | 2 |
 
 ---
 
@@ -61,7 +61,7 @@ Generate and sign detailed AI-specific bills of materials (AI BOMs) so downstrea
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.5.1** | **Verify that** every model artifact publishes a version-controlled, machine-readable AI BOM (e.g., CycloneDX or SPDX) that lists datasets, weights, hyperparameters, licenses, export-control tags, and data-origin statements. | 1 |
+| **6.5.1** | **Verify that** every model artifact publishes a version-controlled, machine-readable AI BOM (e.g., CycloneDX or SPDX) that lists datasets, weights, hyperparameters, licenses, and data-origin statements. | 1 |
 | **6.5.2** | **Verify that** AI BOMs are cryptographically signed before deployment. | 2 |
 | **6.5.3** | **Verify that** AI BOM completeness checks fail the build if any component metadata (hash and license) is missing. | 2 |
 | **6.5.4** | **Verify that** downstream consumers can query AI BOMs via API to validate imported models at deployment time. | 2 |


### PR DESCRIPTION
Implementability and level review for C06 (Supply Chain Security for Models, Frameworks & Data).

## Changes

**C6.1.1** L1 -> L2: Signed origin-and-integrity record for third-party model artifacts. Carries over the cross-chapter signing-level alignment discussed in the C01 implementability review (Issue 1) and already applied to C03/C04. 

Sigstore model-signing v1.0 only GA'd in April 2025; standing up KMS/OIDC, a signing pipeline, consumer-side verification, key rotation, and a transparency log is not "every team already does this." ASVS v5.0 positions code signing at L2/L3 and SLSA Level 3 treats signed provenance as an advanced control, so L1 here was stricter than industry consensus.

**C6.1.2** text narrowed (level unchanged: L1): The original requirement bundled "malicious layers" with "Trojan triggers." Detecting malicious layers (deserialization/code-execution payloads in pickle, Keras Lambda, etc.) is trivially achievable today via ProtectAI ModelScan, Hugging Face Picklescan, and Trail of Bits Fickling, all production-ready. 

Detecting Trojan/backdoor triggers in trained weights is research-grade with no production tooling (Neural Cleanse, STRIP, activation clustering work only on small image classifiers and are not packaged for production pipelines). The L1 framing was therefore unachievable for half of the compound. Hidden-behavior detection is already covered at L3 by C6.1.5 (adversarial evaluation of fine-tunes) and C11.2.9 (post-training backdoor detection). 

Narrowed wording focuses C6.1.2 on the L1-achievable serialization-layer scanning so the level matches the control's true scope.

**C6.3.3** L2 -> L1: Dataset origin, lineage, and license terms captured in AI BOM entries. Carries over the C01 review (Issue 2). Lineage recording is mainstream (MLflow auto-logs, DVC declarative, OpenLineage near-zero-code), C1.5.1/C1.1.1 already require dataset lineage at L1, and C6.5.1 (same chapter) at L1 already requires an AI BOM listing datasets/licenses/data-origin.

**C6.3.4** L3 -> L2: Periodic monitoring detects drift or corruption in hosted datasets. Mature tooling exists (Great Expectations, Soda, Monte Carlo, Evidently AI for drift; trivial hash re-checking for corruption). C13.3.2 (L1) already covers inference-time data-drift detection and C1.2.3 (L2) covers training data integrity monitoring. The "hosted" qualifier adds re-download cost for very large external datasets (Common Crawl, LAION) but does not push the requirement into L3 niche/research territory.

**C6.3.1** "PII" example removed: bundled two controls of very different maturity. PII detection is production-ready (Presidio) but already covered by C12.1.1 (L1) which requires direct/quasi-identifier removal before training. Copyrighted-material detection is the supply-chain-specific concern that belongs in C06; PII handling belongs in C12. Dropped the PII example to reduce overlap and keep the chapter focused on supply-chain-specific disallowed content.

**C6.5.1** "export-control tags" removed from the BOM field list: EAR/ITAR classification is both non-trivial (not L1) and also GRC work, not a structurally trivial BOM field, and the broader export-control determination is a governance/compliance concern rather than a technical AI security control. Other fields (datasets, weights, hyperparameters, licenses, data-origin statements) remain.
