### PR TITLE
Levels review C07

### DIFF
--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -2,7 +2,7 @@
 
 ## Control Objective
 
-This control category ensures that model outputs are technically constrained, validated, and monitored so that unsafe, malformed, or high-risk responses cannot reach users or downstream systems. The chapter focuses on AI-specific output handling concerns: format and schema enforcement for model output, confidence and uncertainty handling, output safety filtering, and explainability artifacts. Schema output validation (7.1.1) applies only to applications that expect structured output (e.g., JSON, XML, typed function-call responses); free-form text outputs are out of scope for schema validation.
+This control category ensures that model outputs are technically constrained, validated, and monitored so that unsafe, malformed, or high-risk responses cannot reach users or downstream systems. The chapter focuses on AI-specific output handling concerns: format and schema enforcement for model output, confidence and uncertainty handling, output safety filtering, and explainability artifacts.
 
 ---
 
@@ -14,7 +14,7 @@ Ensure the model outputs data in a way that helps prevent injection.
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **7.1.1** | **Verify that** the application validates all model outputs against a strict schema (like JSON Schema) and rejects any output that does not match. | 1 |
 | **7.1.2** | **Verify that** the system uses "stop sequences" or token limits to cut off generation before it can overflow buffers or execute unintended commands. | 1 |
-| **7.1.3** | **Verify that** model outputs crossing a trust boundary into downstream interpreters (e.g., databases, shells, deserializers, template engines, browsers) are treated as untrusted input and processed using the corresponding safe APIs as defined in OWASP ASVS v5 chapters V1.2 and V1.5. | 1 |
+| **7.1.3** | **Verify that** model outputs crossing a trust boundary into downstream interpreters (e.g., databases, shells, deserializers, template engines, browsers) are treated as untrusted input and processed using the corresponding safe APIs as defined in respective OWASP ASVS guidance. | 1 |
 
 ---
 
@@ -24,11 +24,9 @@ Detect when the model produces potentially inaccurate or fabricated content and 
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.2.1** | **Verify that** the system assesses the reliability of generated answers using a confidence or uncertainty estimation method (e.g., confidence scoring, retrieval-based verification, or model uncertainty estimation). | 1 |
+| **7.2.1** | **Verify that** the system assesses and logs the reliability of generated answers using a confidence or uncertainty estimation method (e.g., confidence scoring, retrieval-based verification, or model uncertainty estimation). | 2 |
 | **7.2.2** | **Verify that** the application automatically blocks answers or switches to a fallback message if the confidence score drops below a defined threshold. | 2 |
-| **7.2.3** | **Verify that** hallucination events (low-confidence responses) are logged with input/output metadata for analysis. | 2 |
-| **7.2.4** | **Verify that** the system tracks tool and function invocation history within a request chain and flags high-confidence factual assertions that were not preceded by relevant verification tool usage, as a practical hallucination detection signal independent of confidence scoring. | 2 |
-| **7.2.5** | **Verify that** for responses classified as high-risk or high-impact by policy, the system performs an additional verification step through an independent mechanism, such as retrieval-based grounding against authoritative sources, deterministic rule-based validation, tool-based fact-checking, or consensus review by a separately provisioned model. | 3 |
+| **7.2.3** | **Verify that** for responses classified as high-risk or high-impact by policy, the system performs an additional verification step through an independent mechanism, such as retrieval-based grounding against authoritative sources, deterministic rule-based validation, tool-based fact-checking, or consensus review by a separately provisioned model. | 3 |
 
 ---
 
@@ -38,46 +36,35 @@ Technical controls to detect and scrub bad content before it is shown to the use
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.3.1** | **Verify that** automated classifiers scan every response and block content that matches hate, harassment, or sexual violence categories. | 1 |
-| **7.3.2** | **Verify that** output filters detect and block responses that disclose system prompt content, including word-for-word copies and paraphrases that carry the same meaning of instructions, role definitions, or policy directives. | 2 |
-| **7.3.3** | **Verify that** LLM client applications prevent model-generated output from triggering automatic outbound requests (e.g., auto-rendered images, iframes, or link prefetching) to attacker-controlled endpoints, for example by turning off automatic external resource loading or by restricting it to an allowlisted set of origins. | 2 |
-| **7.3.4** | **Verify that** the model's outputs are checked for signs that hidden information may be encoded in them (for example, through unusual word choices or output patterns). Any suspicious outputs should be flagged for further review. | 3 |
+| **7.3.1** | **Verify that** automated classifiers scan every response and block content that matches defined harmful content categories. | 1 |
+| **7.3.2** | **Verify that** output filters detect and block responses that disclose system prompt content. | 2 |
+| **7.3.3** | **Verify that** LLM client applications prevent model-generated output from triggering automatic arbitrary outbound requests (e.g., auto-rendered images, iframes, or link prefetching), for example by turning off automatic external resource loading or by restricting it to an allowlisted set of origins. | 2 |
 | **7.3.5** | **Verify that** model-generated outputs are scanned for encoding and representation smuggling artifacts (e.g., invisible Unicode or control characters, homoglyph substitutions, mixed-direction text) before being returned to callers or passed to downstream systems, and that detections trigger rejection or sanitization. | 3 |
 
 ---
 
 ## C7.4 Explainability & Transparency
 
-Ensure the user knows why a decision was made.
+Ensure user and other downstream consumers can interpret decisions by AI and recognize AI-generated media.
 
 | # | Description | Level |
 | :-------: | ------------------------------------------------------------------------------------------------------------------------------ | :---: |
 | **7.4.1** | **Verify that** explanations shown to the user are sanitized to remove system prompts or backend data. | 1 |
 | **7.4.2** | **Verify that** technical evidence of the model's decision, such as model interpretability artifacts (e.g., attention maps, feature attributions), is logged. | 3 |
+| **7.4.1** | **Verify that** all generated media includes an invisible watermark or cryptographic signature to prove it was AI-generated. | 3 |
 
 ---
 
-## C7.5 Generative Media Safeguards
-
-Provide cryptographic provenance for synthetic media so that downstream consumers can distinguish AI-generated content from authentic content.
-
-| # | Description | Level |
-| :-------: | -------------------------------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.5.1** | **Verify that** all generated media includes an invisible watermark or cryptographic signature to prove it was AI-generated. | 3 |
-
----
-
-## C7.6 Source Attribution & Citation Integrity
+## C7.5 Source Attribution & Citation Integrity
 
 Ensure RAG-grounded outputs are traceable to their source documents and that cited claims are verifiably supported by retrieved content.
 
 | # | Description | Level |
 | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.6.1** | **Verify that** responses generated using retrieval-augmented generation (RAG) include attribution to the source documents that grounded the response. | 1 |
-| **7.6.2** | **Verify that** RAG attributions are derived from retrieval metadata and are not generated by the model, so provenance cannot be fabricated. | 1 |
-| **7.6.3** | **Verify that** each sourced claim in a RAG-grounded response can be traced to a specific retrieved chunk. | 3 |
-| **7.6.4** | **Verify that** the system detects and flags responses where claims are not supported by any retrieved content before the response is served. | 3 |
-| **7.6.5** | **Verify that** RAG responses with detected unsupported claims are blocked or redacted before being served to the user. | 3 |
+| **7.5.1** | **Verify that** responses generated using retrieval-augmented generation (RAG) include attribution to the source documents that grounded the response. | 1 |
+| **7.5.2** | **Verify that** RAG attributions are derived from retrieval metadata and are not generated by the model, so provenance cannot be fabricated. | 1 |
+| **7.5.3** | **Verify that** each sourced claim in a RAG-grounded response can be traced to a specific retrieved chunk. | 2 |
+| **7.5.4** | **Verify that** the system detects and flags responses where claims are not supported by any retrieved content, and unsupported claims are blocked or redacted before being served to the user. | 2 |
 
 ---
 


### PR DESCRIPTION
Implementability and level review for C07.

Contains minor restructuring, simplification and combining of requirements, in line with leads call decisions today.

## Changes

**7.1.3** remove reference to specific OWASP ASVS version and chapters, replace with a generic reference.

**C7.2.1** L1 -> L2: Reliability assessment of generated answers. No single method in the disjunction is universally trivial. Token logprobs are available on OpenAI, Azure, Vertex, self-hosted (vLLM/TGI), Cohere, and Mistral, but Anthropic Claude (a top-3 production LLM) does not expose logprobs at all, and OpenAI reasoning models hide them when reasoning is enabled. Retrieval-based verification only applies to RAG-enabled apps. Model uncertainty estimation via self-consistency or model-as-judge costs Nx inference and requires custom engineering; verbalized confidence is known to be poorly calibrated. The L1 bar is "tooling must be trivial or universal" - neither holds. L2 fits: production-grade reliability signals exist, but require provider-specific or architectural choices.

Combined previous **7.2.3** to this requirement by adding "and logs".

The question is if this is a requirement we consider worth keeping. Reliability signals have value, but they would require downstream users to actually use them which is not very common today in practice as far as I am aware.

**C7.2.3** (previously 7.2.4) Remove or L2 -> L3: Tool-invocation-history-aware hallucination detection. The building blocks (tool call logs, claim extraction) exist, but no production framework (LangChain, LlamaIndex, Guardrails AI, RAGAS) implements this pattern out of the box, and the matching logic between claim semantics and "relevant" verification tool is domain-specific glue with no shared abstraction. L2 implies "mature tooling exists, requires engineering"; here the tooling does not exist. C7.2.5 (independent verification) sits at L3 with similar custom-engineering bar.

Suggested to be removed, but if kept raised to L3. Tool call logs are standard functionality, but without significant engineering not useful for hallucination detection. No evidence of this exist as working pattern.

**C7.3.1** rather than using prescriptive categories, allow developers to define harmful categories based on the system use cases, keeping it more appropriate for L1 requirement with more flexibility.

**7.3.2** simplify requirement to keep it L2; otherwise would be L3 with the amount of required engineering.

**7.3.4** suggested to be removed because of lack of proof of any production implementation.

**7.5.1** combine with C7.4 section, and revise section intro accordingly.

**C7.5.3** L3 -> L2: Per-claim chunk traceability in RAG. RAGAS faithfulness, TruLens groundedness, Patronus Lynx, Vectara HHEM-2.1, and FaithJudge (EMNLP 2025) all provide production-ready DeBERTa-based NLI per-claim attribution. Serve-time adds 200-500ms latency but is documented. The tooling baseline matches the L2 standard ("production / customer-facing / consequential decisions, mature tooling exists, non-trivial engineering").

**C7.5.4** L3 -> L2: Unsupported-claim detection in RAG responses. Same tooling base as C7.6.3 (RAGAS, TruLens, Guardrails AI ProvenanceLLM). Production-ready with documented shadow-mode-then-enforce integration pattern. Now aligned with C7.6.3 leveling.

**C7.5.5** L3 -> L2: Block or redact RAG responses with unsupported claims before serving. Guardrails AI ProvenanceLLM v0.10.0+ implements synchronous serve-time blocking with documented latency (+200-500ms) and reask token cost (~12%). The detect-and-block chain (7.6.4 -> 7.6.5) now reads coherently at L2. _Combined to 7.6.4 since the implementation lives in the same component._

## Reviewed and kept

| Req | Level | Why kept |
|---|---|---|
| C7.1.1 | L1 | OpenAI Structured Outputs (GA Aug 2024), Pydantic AI, Guardrails AI, Outlines, Instructor make JSON Schema validation of structured output trivial. Chapter scope note explicitly excludes free-form text. |
| C7.1.2 | L1 | `stop_sequences` / `max_tokens` are universal LLM API parameters. |
| C7.1.3 | L1 | Treating outputs as untrusted to downstream interpreters is fundamental SDLC discipline; explicit ASVS V1.2/V1.5 reference grounds it in mature web-security practice. |
| C7.2.2 | L2 | Once a confidence score exists, threshold-routing is trivial, but defining calibrated thresholds and fallback UX is non-trivial. |
| C7.2.3 | L2 | Hallucination event logging depends on detection (C7.2.1/2 chain) and meaningful classification, not just generic confidence-score logging (which is C13.1.2 at L1). |
| C7.2.4 (was 7.2.5) | L3 | Independent verification has multiple production patterns (RAGAS, multi-model consensus) but classifying responses as high-risk by policy plus operating a parallel verification pipeline is genuine defense-in-depth territory. |
| C7.3.3 | L2 | ChatGPhish (May 2026) is unpatched in ChatGPT/Claude, but the mitigations the requirement names (disable auto external resource loading, allowlist origins) are standard web-security hardening achievable in any new LLM client app. |
| C7.3.5 | L3 | Mirrors C2.2.4 (input-side, L3) by deliberate split (PR #836). Read as the "still-suspicious-after-mitigation" tier on top of L1 input normalization; the underlying scan is trivial but the L3 framing is consistent with the input/output split. |
| C7.4.1 | L1 | Explanation sanitization is a trivial output filter (regex/allowlist), same difficulty as not logging secrets. |
| C7.4.2 | L3 | Attention-map / feature-attribution logging is computationally infeasible at production LLM scale (hundreds of MB per request). Mature on classical ML, research-only on transformers. |
| C7.5.1 | L3 | SynthID and C2PA Content Credentials are deployed at scale by Google/OpenAI/Meta, but SynthID for image/audio/video is not open-source, C2PA metadata strips on format conversion, and self-hosted open-source generators have limited turnkey watermarking. "All generated media" makes universality the L3 bar. |
| C7.6.1 | L1 | Source-document attribution is the standard LangChain/LlamaIndex/Haystack RAG pattern. |
| C7.6.2 | L1 | Rendering attribution from retrieval metadata rather than model output is the default architecture in mature RAG frameworks. |
