### PR TITLE
Fix/c01 c02 numbering and content issues

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -12,13 +12,13 @@ Training data origin and data security are critical to the security and trustwor
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **1.1.1** | **Verify that** training data 	includes only features, attributes, and fields required for the model's stated purpose. | 1 |
+| **1.1.1** | **Verify that** training data includes only features, attributes, and fields required for the model's stated purpose, as documented in the model card or system specification. | 1 |
 | **1.1.2** | **Verify that** the lineage of each dataset and its components, including all transformations, augmentations, and merges, is recorded and can be reconstructed. | 1 |
 | **1.1.3** | **Verify that** an up-to-date inventory is kept of every training-data source, including its origin, responsible party, license, collection method, intended use constraints, and processing history. | 2 |
 | **1.1.4** | **Verify that** datasets are watermarked so their use can be attributed and any unauthorized use detected. | 3 |
-| **1.2.5** | **Verify that** data integrity is provided when training data is stored and transferred. | 2 |
-| **1.2.6** | **Verify that** integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
-| **1.2.7** | **Verify that** all training datasets are uniquely identified, with change tracking, to support rollback and forensic analysis. | 3 |
+| **1.1.5** | **Verify that** data integrity is ensured when training data is stored and transferred, using cryptographic checksums or equivalent mechanisms. | 2 |
+| **1.1.6** | **Verify that** integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
+| **1.1.7** | **Verify that** all training datasets are uniquely identified, with change tracking, to support rollback and forensic analysis. | 3 |
 
 ---
 
@@ -28,10 +28,10 @@ Labeling and annotation processes must be protected against unauthorized modific
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **1.3.1** | **Verify that** labeling platforms enforce access controls that restrict who can create, modify, or approve annotations. | 1 |
-| **1.3.2** | **Verify that** all labeling activities are recorded in logs. | 1 |
-| **1.3.3** | **Verify that** cryptographic integrity is applied to labeling artifacts. | 2 |
-| **1.3.4** | **Verify that** sensitive information in labels is redacted, anonymized, or encrypted before being used in any labeling artifact. | 2 |
+| **1.2.1** | **Verify that** labeling platforms enforce access controls that restrict who can create, modify, or approve annotations. | 1 |
+| **1.2.2** | **Verify that** all labeling activities are recorded in logs. | 1 |
+| **1.2.3** | **Verify that** cryptographic integrity is applied to labeling artifacts. | 2 |
+| **1.2.4** | **Verify that** sensitive information in labels is redacted, anonymized, or encrypted before being used in any labeling artifact. | 2 |
 
 ---
 
@@ -41,10 +41,10 @@ Training data quality and security assurance controls help detect corruption, po
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **1.4.1** | **Verify that** training and fine-tuning pipelines implement poisoning detection techniques to identify potential data poisoning or unintentional corruption in training data. | 2 |
-| **1.4.2** | **Verify that** automatically generated labels are subject to confidence thresholds and consistency checks to detect misleading or low-confidence labels. | 2 |
-| **1.4.3** | **Verify that** models used in security-relevant decisions are evaluated for bias patterns. | 2 |
-| **1.4.4** | **Verify that** defenses against clean-label poisoning attacks are implemented. | 3 |
+| **1.3.1** | **Verify that** training and fine-tuning pipelines implement poisoning detection techniques to identify potential data poisoning or unintentional corruption in training data. | 2 |
+| **1.3.2** | **Verify that** automatically generated labels are subject to confidence thresholds and consistency checks to detect misleading or low-confidence labels. | 2 |
+| **1.3.3** | **Verify that** models used in security-relevant decisions are evaluated for bias patterns. | 2 |
+| **1.3.4** | **Verify that** defenses against clean-label poisoning attacks are implemented. | 3 |
 
 ---
 
@@ -53,4 +53,4 @@ Training data quality and security assurance controls help detect corruption, po
 * [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
 * [EU AI Act: Article 10: Data & Data Governance](https://artificialintelligenceact.eu/article/10/)
 * [CISA Advisory: Securing Data for AI Systems](https://www.cisa.gov/news-events/cybersecurity-advisories/aa25-142a)
-* [OpenAI Privacy Center: Data Deletion Controls](https://privacy.openai.com/policies?modal=take-control)
+* [MITRE ATLAS: Poison Training Data](https://atlas.mitre.org/techniques/AML.T0020)

--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -8,17 +8,19 @@ Robust validation of all inputs is a first-line defense against some of the most
 
 ## C2.1 Prompt Injection Defense
 
-Prompt injection is one of the top risks for AI systems. Defenses against this tactic employ a combination of pattern filters, data classifiers and instruction hierarchy enforcement.
+Prompt injection is one of the top risks for AI systems. Defenses against this tactic employ a combination of pattern filters, data classifiers, and instruction hierarchy enforcement.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.1.1** | **Verify that** input normalization is applied before tokenization or embedding. | 1 |
 | **2.1.2** | **Verify that** encoding and representation smuggling in inputs is detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 1 |
 | **2.1.3** | **Verify that** all inputs that may steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier and blocked. | 1 |
-| **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window, and that inputs exceeding token limits are rejected rather than truncated. | 1 |
-| **2.1.5** | **Verify that** the system implements a character set limitation for all inputs, allowing only characters that are explicitly required using an allow-list approach. | 1 |
-| **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. | 2 |
+| **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window, and that inputs exceeding token limits are rejected rather than truncated. Truncation is prohibited as it can silently displace system instructions or safety directives from the model's effective attention. | 1 |
+| **2.1.5** | **Verify that** the system implements a character set limitation for inputs, allowing only characters that are explicitly required using an allow-list approach, where the use case permits. | 1 |
+| **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after processing user instructions. This enforcement must be preserved across multi-step interactions and tool-augmented workflows, such that prompt composition or intermediate outputs cannot allow user-controlled content to override system or developer instructions. | 2 |
 | **2.1.7** | **Verify that** the system detects many-shot jailbreaking patterns. | 3 |
+
+---
 
 ## C2.2 Content & Policy Screening
 
@@ -26,11 +28,11 @@ Syntactically valid prompts may request disallowed content such as policy-violat
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.3.1** | **Verify that** every prompt is scored by a content classifier for violence, self-harm, hate, and sexual content against configurable thresholds. Prompts that exceed those thresholds are rejected or sanitized before reaching model context. | 1 |
-| **2.3.2** | **Verify that** prompt content classification is evaluated for languages that are not supported. | 1 |
-| **2.3.3** | **Verify that** screening logs include classifier confidence scores and policy category tags with applied stage and trace metadata. | 2 |
-| **2.3.4** | **Verify that** non-text inputs (image/video/audio) are checked for adversarial perturbations, steganographic payloads, hidden or embedded content, or known attack patterns. | 2 |
-| **2.3.5** | **Verify that** coordinated attacks spanning multiple input types (e.g., steganographic payloads in images combined with prompt injection in text) are detected and blocked. | 3 |
+| **2.2.1** | **Verify that** every prompt is scored by a content classifier for violence, self-harm, hate, and sexual content against configurable thresholds. Prompts that exceed those thresholds are rejected or sanitized before reaching model context. | 1 |
+| **2.2.2** | **Verify that** prompt content classification is evaluated for languages that are not supported. | 1 |
+| **2.2.3** | **Verify that** screening logs include classifier confidence scores and policy category tags with applied stage and trace metadata. | 2 |
+| **2.2.4** | **Verify that** non-text inputs (image/video/audio) are checked for adversarial perturbations, steganographic payloads, hidden or embedded content, or known attack patterns. | 2 |
+| **2.2.5** | **Verify that** coordinated attacks spanning multiple input types (e.g., steganographic payloads in images combined with prompt injection in text) are detected and blocked. | 3 |
 
 ---
 


### PR DESCRIPTION
## Summary

  This PR fixes requirement ID numbering mismatches across C01 and C02 and tightens several control
  descriptions that were too vague to be reliably verified.

  ### C01 — Training Data Integrity & Traceability

  **Numbering fix:**
  Requirements `1.2.5`, `1.2.6`, `1.2.7` appeared inside the C1.1 table despite carrying a `1.2.x` prefix
  — a sign of an earlier restructuring where section headers were renumbered but requirement IDs were
  not. Similarly, C1.2's requirements were numbered `1.3.x` and C1.3's were `1.4.x`. All IDs are now
  aligned with their containing sections:
  - `1.2.5–1.2.7` → `1.1.5–1.1.7`
  - `1.3.1–1.3.4` → `1.2.1–1.2.4`
  - `1.4.1–1.4.4` → `1.3.1–1.3.4`

  **Content fixes:**
  - `1.1.1`: Added "as documented in the model card or system specification" so the stated-purpose
  constraint is verifiable rather than open-ended.
  - `1.1.5`: Replaced vague "data integrity is provided" with "using cryptographic checksums or
  equivalent mechanisms" to give implementers a concrete target.
  - Fixed stray tab character in `1.1.1`.
  - Replaced the OpenAI Privacy Center reference (about consumer data deletion rights, unrelated to
  training data security) with MITRE ATLAS AML.T0020 (Poison Training Data), which directly supports the
  controls in this chapter.

  ### C02 — Input Validation

  **Numbering fix:**
  The C2.2 "Content & Policy Screening" section used `2.3.x` IDs instead of `2.2.x`, leaving the entire
  `2.2.x` range absent. Renumbered `2.3.1–2.3.5` → `2.2.1–2.2.5`.

  **Content fixes:**
  - Added missing `---` horizontal rule separator after the C2.1 table, consistent with formatting used
  throughout the document.
  - Fixed missing Oxford comma in the C2.1 section intro.
  - `2.1.4`: Added rationale for why truncation is prohibited — it can silently displace system
  instructions, enabling position-based injection attacks.
  - `2.1.5`: Scoped character set allow-listing with "where the use case permits" to avoid making Level 1
  unachievable for multilingual or creative writing deployments.
  - `2.1.6`: Expanded instruction hierarchy requirement to explicitly cover multi-step interactions and
  tool-augmented workflows, closing a gap where prompt composition across turns or tool outputs could
  allow user-controlled content to override system instructions.

  ## Testing
  All changes are editorial — no functional logic. Verified that requirement IDs are now sequentially
  consistent with their section numbers across both chapters.