### PR TITLE
Replace broken link for MITRE ATLAS: Adversarial Input Detection in C02

### DIFF
--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -38,5 +38,5 @@ Syntactically valid prompts may request disallowed content such as policy-violat
 
 * [OWASP LLM01:2025 Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)
 * [LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html)
-* [MITRE ATLAS: Adversarial Input Detection](https://atlas.mitre.org/mitigations/AML.M00150)
+* [MITRE ATLAS: Adversarial Input Detection](https://atlas.mitre.org/mitigations/AML.M0015)
 * [Mitigate jailbreaks and prompt injections](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks)


### PR DESCRIPTION
Change from the [broken link](https://atlas.mitre.org/mitigations/AML.M00150) to the [correct / up to date link](https://atlas.mitre.org/mitigations/AML.M0015).