### PR TITLE
C01: fix ID sequence, stray tab, and Appendix D refs

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -12,13 +12,13 @@ Training data origin and data security are critical to the security and trustwor
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **1.1.1** | **Verify that** training data 	includes only features, attributes, and fields required for the model's stated purpose. | 1 |
+| **1.1.1** | **Verify that** training data includes only features, attributes, and fields required for the model's stated purpose. | 1 |
 | **1.1.2** | **Verify that** the lineage of each dataset and its components, including all transformations, augmentations, and merges, is recorded and can be reconstructed. | 1 |
 | **1.1.3** | **Verify that** an up-to-date inventory is kept of every training-data source, including its origin, responsible party, license, collection method, intended use constraints, and processing history. | 2 |
 | **1.1.4** | **Verify that** datasets are watermarked so their use can be attributed and any unauthorized use detected. | 3 |
-| **1.2.5** | **Verify that** data integrity is provided when training data is stored and transferred. | 2 |
-| **1.2.6** | **Verify that** integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
-| **1.2.7** | **Verify that** all training datasets are uniquely identified, with change tracking, to support rollback and forensic analysis. | 3 |
+| **1.1.5** | **Verify that** data integrity is provided when training data is stored and transferred. | 2 |
+| **1.1.6** | **Verify that** integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
+| **1.1.7** | **Verify that** all training datasets are uniquely identified, with change tracking, to support rollback and forensic analysis. | 3 |
 
 ---
 


### PR DESCRIPTION
Follow-up fixup for 7461adefd928ae827e466353781284ee689c9920 (Jim's C01 cleanup).

**ID sequence** -- 1.2.5/1.2.6/1.2.7 sit under the C1.1 section heading but carry C1.2 IDs. Renamed to 1.1.5/1.1.6/1.1.7 to restore NO-GAP numbering.

**Stray tab** -- tab between "training data" and "includes" in 1.1.1 removed (if present).

**Appendix D** -- AD.14 data-minimization ref updated from 1.1.2 to 1.1.1 to match the renumbering (if not already done).

Wording, scope, and levels unchanged throughout.

Closes #904 