### PR TITLE
C1.2: trim intro promises not delivered by any 1.3.x requirement

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -24,7 +24,7 @@ Training data origin and data security are critical to the security and trustwor
 
 ## C1.2 Data Labeling and Annotation Security
 
-Labeling and annotation processes must be protected against unauthorized modification, attribution loss, data leakage, and integrity compromise. Annotation platforms should enforce access control, preserve auditability, retain verified annotator attribution, and protect labeling artifacts, preference data, and sensitive label content throughout the training pipeline.
+Labeling and annotation processes must be protected against unauthorized modification, data leakage, and integrity compromise. Annotation platforms should enforce access control, preserve auditability, and protect labeling artifacts and sensitive label content throughout the training pipeline.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |


### PR DESCRIPTION
Trims the C1.2 section intro to drop promises no 1.3.x requirement delivers: "attribution loss", "retain verified annotator attribution", and "preference data". The remaining intro claims map to the shipped requirements — 1.3.1 (access control), 1.3.2 (auditability), 1.3.3 (artifact integrity), 1.3.4 (sensitive label content).

Scope: the intro paragraph only. No requirement text, IDs, or levels touched.

Refs #909 (point 3, as discussed there).
