### PR TITLE
C1.1: restore L1→L2→L3 row order, renumber sequentially

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -15,9 +15,9 @@ Training data origin and data security are critical to the security and trustwor
 | **1.1.1** | **Verify that** training data includes only features, attributes, and fields required for the model's stated purpose. | 1 |
 | **1.1.2** | **Verify that** the lineage of each dataset and its components, including all transformations, augmentations, and merges, is recorded and can be reconstructed. | 1 |
 | **1.1.3** | **Verify that** an up-to-date inventory is kept of every training-data source, including its origin, responsible party, license, collection method, intended use constraints, and processing history. | 2 |
-| **1.1.4** | **Verify that** datasets are watermarked so their use can be attributed and any unauthorized use detected. | 3 |
-| **1.1.5** | **Verify that** data integrity is provided when training data is stored and transferred. | 2 |
-| **1.1.6** | **Verify that** integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
+| **1.1.4** | **Verify that** data integrity is provided when training data is stored and transferred. | 2 |
+| **1.1.5** | **Verify that** integrity monitoring is applied to guard against unauthorized modifications or corruption of training data. | 2 |
+| **1.1.6** | **Verify that** datasets are watermarked so their use can be attributed and any unauthorized use detected. | 3 |
 | **1.1.7** | **Verify that** all training datasets are uniquely identified, with change tracking, to support rollback and forensic analysis. | 3 |
 
 ---


### PR DESCRIPTION
Reorders the C1.1 table to L1→L2→L3 and renumbers IDs to stay sequential, per the numbering call in #906: the two L2 integrity rows move up to 1.1.4/1.1.5 and watermarking moves from 1.1.4 to 1.1.6. No wording, scope, or level changes.

Note: open issue #908 refers to watermarking by its old ID (1.1.4 → now 1.1.6).

Scope: C1.1 rows only — Appendix D untouched, per the split agreed in #906.

Refs #906 (C1.1 ordering item only).
