### PR TITLE
Levels review for C08

### DIFF
--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -15,21 +15,20 @@ Enforce fine-grained access controls and query-time scope enforcement for every 
 | **8.1.1** | **Verify that** vector insert, update, delete, and query operations are enforced with namespace/collection/document-tag scope controls (e.g., tenant ID, user ID, data classification labels) with default-deny. | 1 |
 | **8.1.2** | **Verify that** every ingested document is tagged at write time with source, writer identity (authenticated user or system principal), timestamp, batch ID, and embedding model version. | 2 |
 | **8.1.3** | **Verify that** document metadata tags applied at ingestion are immutable after the initial write and cannot be changed by later pipeline stages or user operations. | 2 |
-| **8.1.4** | **Verify that** RAG pipeline retrieval events log the query issued, the documents or chunks retrieved, similarity scores, the knowledge source, and whether retrieved content passed prompt injection scanning before it was added to the model context. | 2 |
-| **8.1.5** | **Verify that** restricted retrieval indices include uniquely marked canary records that contain no real sensitive content, with markers that survive retrieval, embedding, and context-assembly pipelines. | 2 |
-| **8.1.6** | **Verify that** a high-severity security alert is generated whenever a canary record is selected by retrieval, matched by similarity search, or passed to the model as context. | 2 |
-| **8.1.7** | **Verify that** retrieval anomaly detection identifies embedding density outliers, repeated dominance of specific documents in similarity results, and sudden shifts in retrieval bias distribution that may indicate vector database poisoning. | 3 |
+| **8.1.4** | **Verify that** RAG pipeline retrieval events log the query issued, the documents or chunks retrieved, similarity scores, the knowledge source. | 2 |
+| **8.1.5** | **Verify that** a high-severity security alert is generated whenever a canary record is selected by retrieval, matched by similarity search, or passed to the model as context. | 2 |
+| **8.1.6** | **Verify that** retrieval anomaly detection identifies embedding density outliers, repeated dominance of specific documents in similarity results, and sudden shifts in retrieval bias distribution that may indicate vector database poisoning. | 3 |
 
 ---
 
 ## C8.2 Embedding Sanitization & Validation
 
-Pre-screen content before vectorization; treat memory writes as untrusted inputs; prevent ingestion of unsafe payloads.
+Pre-screen content before vectorization; treat memory writes as untrusted inputs; prevent ingestion of unsafe payloads. Hidden instructions and other prompt-injection payloads in ingested or retrieved content are screened by the same input-validation pipeline as direct user input.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.2.1** | **Verify that** regulated data and sensitive fields are detected before embedding and are masked, tokenized, transformed, or dropped based on policy, since data once embedded cannot be reliably redacted from the resulting index. | 1 |
-| **8.2.2** | **Verify that** content intended to poison retrieval (e.g., text crafted to project to attacker-chosen embedding neighborhoods, hidden instructions intended for downstream model context, or steganographic payloads in non-text inputs) is detected and rejected or quarantined before vectorization. | 1 |
+| **8.2.1** | **Verify that** sensitive fields are detected before embedding and are masked, tokenized, transformed, or dropped, since data once embedded cannot be reliably redacted from the resulting index. | 1 |
+| **8.2.2** | **Verify that** content crafted to manipulate retrieval geometry (e.g., text engineered to project into attacker-chosen embedding neighborhoods so it is preferentially retrieved) is detected and rejected or quarantined before vectorization. | 3 |
 | **8.2.3** | **Verify that** vectors that fall outside normal clustering patterns are flagged and quarantined before entering production indices. | 2 |
 | **8.2.4** | **Verify that** agent outputs, tool outputs, and orchestration results are not automatically written to trusted agent memory without explicit source validation (e.g., content-origin checks or write-authorization controls that verify the content's source before committing writes). | 2 |
 | **8.2.5** | **Verify that** new content written to memory is checked for contradictions with what is already stored and that conflicts trigger alerts. | 3 |
@@ -42,7 +41,7 @@ Retention and revocation must be explicit and enforceable for memory and RAG ind
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.3.1** | **Verify that** expired vectors are excluded from retrieval results within a measured and monitored propagation window. | 2 |
+| **8.3.1** | **Verify that** expired vectors are excluded from retrieval results within a defined propagation window. | 2 |
 | **8.3.2** | **Verify that** memory can be reset for security reasons (quarantine, selective purge, full reset) through an operation that is separate and independent from the retention deletion process. | 2 |
 | **8.3.3** | **Verify that** quarantined content is retained for investigation but is excluded from all retrieval results while under quarantine. | 2 |
 
@@ -64,7 +63,7 @@ Prevent cross-tenant and cross-user leakage in retrieval and prompt assembly.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.5.1** | **Verify that** every retrieval operation enforces scope constraints (tenant/user/classification) **in the vector engine query** and verifies them again **before prompt assembly** (post-filter). | 1 |
+| **8.5.1** | **Verify that** every retrieval operation enforces scope constraints (tenant/user/classification) **in the vector engine query** and verifies them again **before prompt assembly** (post-filter). | 2 |
 | **8.5.2** | **Verify that** vector identifiers, namespaces, and metadata indexing prevent cross-scope collisions and enforce uniqueness per tenant. | 1 |
 | **8.5.3** | **Verify that** retrieval results that match similarity criteria but fail scope checks are discarded. | 1 |
 | **8.5.4** | **Verify that** multi-tenant tests simulate adversarial retrieval attempts (prompt-based and query-based) and show that no out-of-scope documents appear in prompts or outputs. | 2 |


### PR DESCRIPTION
Implementability and level review for C08.

Two requirement changes (one level raise for cross-chapter consistency, one narrow + relevel of a compound, partly research-grade requirement)

## Changes

**C8.1.4** kept L2, narrowed: remove requirement to add scanning as metadata. Note that C8.2 requires the scanning anyway.

**8.1.5** removed: niche technique; canary tokens and similar do exist but aren't very broadly used, and thus requiring it in relatively new RAG technology is unreasonable expectation at this point. Should be considered later.

**C8.2.2** L1 -> L3, narrowed: Poisoning content detection before vectorization. The original requirement was compound (three sub-parts of very different difficulty) and unachievable at L1 for two of the three:
- text crafted to project into attacker-chosen embedding neighborhoods is research-grade (only academic prototypes; no production pre-embedding tooling);
- hidden instructions / indirect prompt injection in ingested documents is already covered at L1 by **C2.1.3** (the C02 control objective explicitly states retrieved documents carry the same risk as direct input);
- steganographic payloads in non-text inputs is already covered at L3 by **C2.3.5** (coordinated multi-modal attacks including steganographic payloads).

Narrowed to the unique, vector-DB-specific concern (retrieval-geometry manipulation / embedding-neighborhood poisoning) and moved to L3, the honest level for a research-grade concern with no production tooling. This aligns with 8.1.7 (L3 retrieval-poisoning anomaly detection) and 8.2.5 (L3). Same pattern as the C06 narrowing of the malicious-layers requirement (dropped research-grade Trojan-trigger detection) and the C01 split of adversarial defenses into L2-standard + L3-research.

**C8.2 section intro** add mention of scanning requirement applicability for clarity so that no explicit mention is required, see also change in C8.1.4.

**8.3.1** narrowed to ensure implementation stays L2: "measured and monitored" can interpreted as requiring explicit external process of measuring and monitoring, whereas the intention is just to ensure the vectors get excluded within defined time.

**C8.5.1** L1 -> L2: Scope enforcement in the vector engine query + post-filter re-verification. This is the vector-DB articulation of **C5.3.1** (L2), and is actually stricter (it mandates both in-engine pre-filter AND post-filter re-verification across tenant/user/classification). The same control sitting at two different levels is the kind of cross-chapter inconsistency this review targets. The per-user/classification authorization-context part is the L2-difficulty concern (the service-account anti-pattern is the default in most RAG deployments; FGA/RLS/hybrid pre+post-filter is non-trivial engineering, as established in the C05 review). The trivial part (coarse native tenant/namespace filtering) is already captured separately by 8.1.1 (L1) and 8.5.2 (L1), and 8.5.3 (L1) remains the always-do baseline floor. The layering now mirrors C5.2.1 (L1) -> C5.3.1 (L2).

## Flagged for discussion

These items should be reconsidered if we want to keep:

- **C8.2.5** - is this actually necessary for security purposes? There are tons of legitimate cases for inserting contradictory data.
- **C8.2.2** - see above justification for L1->L3 change; this requirement is very difficult to implement, and attacks are today pretty much just research.
- **C8.2.4** - will this end up as rubberstamped requirement where developers essentially consider all included tools and outputs as trusted (provided other checks have passed) so there really won't be any specific implementation of the requirement?
- **8.4.1** - membership inference, especially in context of vector databases, and defending against is pretty much just research currently.

## Reviewed and kept

| Req | Level | Why kept |
|---|---|---|
| C8.1.1 | L1 | Coarse store-level scope controls (tenant/collection/tag) with default-deny is native and trivial in every vector DB. Maps to C5.2.1 (L1) RBAC default-deny. |
| C8.1.2 | L2 | Ingestion metadata fields are trivial on their own, but the full provenance bundle (source + authenticated writer identity + batch ID + embedding model version) plus its pairing with 8.1.3 immutability is non-trivial pipeline work. |
| C8.1.3 | L2 | No vector DB supports native write-once / immutable metadata (Pinecone, Qdrant, Milvus, Chroma, Weaviate all allow upsert). Requires app-layer versioning + downgrade rejection. |
| C8.1.6 | L2 | Alerting on canary retrieval is a string/ID match once 8.1.5 markers exist. Paired with 8.1.5 at L2. |
| C8.1.7 | L3 | No native vector DB anomaly detection. Embedding-density-outlier and retrieval-bias-distribution-shift detection is advanced and situational. Sits above generic anomaly detection (C11.6.x L2) because statistical embedding-distribution monitoring is harder. |
| C8.2.1 | L1 | PII / regulated-data detection before embedding uses mature tooling (Presidio, cloud DLP), the same base as C12.1.1 (L1). The irreversibility of embeddings argues for a non-skippable baseline, not for elevation. |
| C8.2.3 | L2 | sklearn LOF / Isolation Forest and Cleanlab make outlier scoring trivial, but the quarantine workflow + clustering-baseline tuning is L2 effort. Aligns with C1.4.2 (L2). |
| C8.2.4 | L2 | Source validation before writing tool/agent output to trusted memory. Aligns with C9.7.3 (L2 write authorization) and C9.3.3 (L1 tool-output schema validation). |
| C8.2.5 | L3 | DeBERTa-NLI contradiction detection exists, but applying it to agent memory at scale with low false positives (soft vs hard contradictions, context-dependency) is genuinely hard and situational. |
| C8.3.1 | L2 | Native TTL exists (Milvus entity-level, Qdrant, Redis), but guaranteeing exclusion within a measured propagation window across derivative indices and caches is engineering. |
| C8.3.2 | L2 | A security reset (quarantine / selective purge / full reset) independent from the retention deletion process is operational workflow design. |
| C8.3.3 | L2 | Quarantine-retain-but-exclude-from-retrieval pairs with 8.2.3 / 8.3.2. |
| C8.4.1 | L3 | Embedding inversion (vec2text-class) and membership-inference defenses are research-grade; there is no production privacy/utility leakage-regression framework for embeddings. Aligns with C11.3.3 (L3). |
| C8.5.2 | L1 | Unique vector IDs + per-tenant namespaces preventing cross-scope collisions is structural hygiene, native and trivial in every vector DB. |
| C8.5.3 | L1 | Discarding out-of-scope similarity matches is the always-do baseline floor (post-filter of already-retrieved results, trivial). Sits below the fuller C8.5.1 (now L2). |
| C8.5.4 | L2 | Multi-tenant adversarial retrieval red-team testing is meaningful engineering / QA effort. |