### PR TITLE
Appendix B: add USENIX Security 2026 malicious agent skills measurement study

### DIFF
--- a/1.0/en/0x91-Appendix-B_References.md
+++ b/1.0/en/0x91-Appendix-B_References.md
@@ -35,3 +35,7 @@ The following standards, frameworks, and publications are referenced throughout 
 
 * [Open Policy Agent (OPA)](https://www.openpolicyagent.org/)
 * [Cedar Policy Language](https://www.cedarpolicy.com/)
+
+## Academic Research
+
+* ["Do Not Mention This to the User": Detecting and Understanding Malicious Agent Skills in the Wild](https://arxiv.org/abs/2602.06547) — USENIX Security 2026; measurement study of 98,380 agent skills from public marketplaces, confirming 157 malicious skills carrying 632 vulnerabilities (73.2% implementing user-hidden "shadow" behavior). Empirical context for the C06 (Supply Chain) and C09 (Orchestration & Agentic Action) threat landscape.


### PR DESCRIPTION
Follow-up to #916.

Per @RicoKomenda's guidance on #916 — keep chapter reference lists (C06/C09) as normative/guidance pointers and instead acknowledge empirical research in Appendix B — this PR adds the paper to Appendix B under a new **Academic Research** section.

**Added entry:** ["Do Not Mention This to the User": Detecting and Understanding Malicious Agent Skills in the Wild](https://arxiv.org/abs/2602.06547) (USENIX Security 2026).

The study analyzed 98,380 agent skills from public marketplaces and confirmed 157 malicious skills carrying 632 vulnerabilities, with 73.2% implementing user-hidden "shadow" behavior — empirical context for the C06 (Supply Chain) and C09 (Orchestration & Agentic Action) threat landscape.

**Disclosure:** I am an author of the paper; the numbers are independently verifiable via the public dataset linked from the paper.