### PR TITLE
C6, C7, C8 lead cleanup initial draft

### DIFF
--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -6,65 +6,43 @@ AI supply-chain attacks exploit third-party models, frameworks, or datasets to e
 
 ---
 
-## C6.1 Pretrained Model Vetting & Origin Integrity
+## C6.1 Model Artifact Integrity & Source Trust
 
-Assess and authenticate third-party model origins and hidden behaviors before any fine-tuning or deployment.
-
-| # | Description | Level |
-| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.1.1** | **Verify that** every third-party model artifact includes a signed origin-and-integrity record identifying its source, version, and integrity checksum. | 2 |
-| **6.1.2** | **Verify that** models are scanned with automated tools for malicious code or unsafe serialization payloads (e.g., pickle code execution, embedded executable payloads) before import. | 1 |
-| **6.1.3** | **Verify that** high-risk models (e.g., publicly uploaded weights, unverified creators) remain quarantined until human review and sign-off. | 2 |
-| **6.1.4** | **Verify that** third-party or open-source models pass a defined behavioral acceptance test suite before being imported or promoted to any non-development environment. The suite covers safety, alignment, and capability boundaries relevant to the deployment context. | 2 |
-| **6.1.5** | **Verify that** transfer-learning fine-tunes pass adversarial evaluation to detect hidden behaviors. | 3 |
-
----
-
-## C6.2 Trusted Source Enforcement for AI Artifacts
-
-Allow AI artifact downloads only from organization-approved sources and verify model publisher identity.
+Authenticate third-party model origins and check for hidden behavior before fine-tuning or deployment. Download AI artifacts only from approved sources.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.2.1** | **Verify that** model weights, datasets, and fine-tuning adapters are downloaded only from approved sources or internal registries. | 1 |
-| **6.2.2** | **Verify that** the cryptographic signing keys used to authenticate model publishers are pinned per source registry. When a key is rotated, verify that it is explicitly re-approved before the updated key is trusted. | 3 |
+| **6.1.1** | **Verify that** every third-party model artifact can be attested or integrity-verified. | 2 |
+| **6.1.2** | **Verify that** models are scanned for malicious code before import. | 1 |
+| **6.1.3** | **Verify that** high-risk models remain quarantined until human review and sign-off. | 2 |
+| **6.1.4** | **Verify that** third-party or open-source models pass a behavioral acceptance test suite before being imported or promoted to any non-development environment. | 2 |
+| **6.1.5** | **Verify that** model weights, datasets, and fine-tuning adapters are downloaded only from approved sources. | 1 |
+| **6.1.6** | **Verify that** transfer-learning fine-tuned models are tested against adversarial inputs before deployment. | 3 |
 
 ---
 
-## C6.3 Third-Party Dataset Risk Assessment
+## C6.2 Dataset Risk Assessment
 
 Evaluate external datasets for poisoning and legal compliance, and monitor them throughout their lifecycle.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.3.1** | **Verify that** disallowed content (e.g., copyrighted material) is detected and removed by automated scrubbing before training. | 1 |
-| **6.3.2** | **Verify that** external datasets undergo poisoning risk assessment (e.g., data fingerprinting, outlier detection). | 2 |
-| **6.3.3** | **Verify that** origin, lineage, and license terms for datasets are captured in AI BOM entries. | 1 |
-| **6.3.4** | **Verify that** periodic monitoring detects drift or corruption in hosted datasets. | 2 |
+| **6.2.1** | **Verify that** disallowed content is detected and removed by automated scrubbing before training. | 1 |
+| **6.2.2** | **Verify that** external datasets undergo poisoning risk assessment. | 2 |
+| **6.2.3** | **Verify that** periodic monitoring detects drift or corruption in hosted datasets. | 2 |
 
 ---
 
-## C6.4 Supply Chain Attack Monitoring
+## C6.3 AI BOM & Supply Chain Monitoring
 
-Detect AI-specific supply-chain threats through threat intelligence enrichment and incident response readiness.
-
-| # | Description | Level |
-| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.4.1** | **Verify that** incident response playbooks include procedures specific to compromised AI artifacts, such as rollback of poisoned models, revocation of model signatures, and re-evaluation of downstream systems that consumed affected artifacts. | 2 |
-| **6.4.2** | **Verify that** threat-intelligence enrichment tags AI-specific indicators (e.g., model-poisoning indicators of compromise) in alert triage. | 3 |
-
----
-
-## C6.5 AI BOM for Model Artifacts
-
-Generate and sign detailed AI-specific bills of materials (AI BOMs) so downstream consumers can verify component integrity at deploy time.
+Generate and sign detailed AI-specific bills of materials and ensure readiness to respond to supply chain compromise events.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **6.5.1** | **Verify that** every model artifact publishes a version-controlled, machine-readable AI BOM (e.g., CycloneDX or SPDX) that lists datasets, weights, hyperparameters, licenses, and data-origin statements. | 1 |
-| **6.5.2** | **Verify that** AI BOMs are cryptographically signed before deployment. | 2 |
-| **6.5.3** | **Verify that** AI BOM completeness checks fail the build if any component metadata (hash and license) is missing. | 2 |
-| **6.5.4** | **Verify that** downstream consumers can query AI BOMs via API to validate imported models at deployment time. | 2 |
+| **6.3.1** | **Verify that** every model artifact publishes a version-controlled, machine-readable AI BOM listing datasets, weights, licenses, and data-origin statements. | 1 |
+| **6.3.2** | **Verify that** AI BOMs are cryptographically signed before deployment. | 2 |
+| **6.3.3** | **Verify that** AI BOM completeness checks fail the build if any component metadata is missing. | 2 |
+| **6.3.4** | **Verify that** incident response playbooks include procedures specific to compromised AI artifacts, such as rollback of poisoned models and revocation of model signatures. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -12,9 +12,9 @@ Ensure the model outputs data in a way that helps prevent injection.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.1.1** | **Verify that** the application validates all model outputs against a strict schema (like JSON Schema) and rejects any output that does not match. | 1 |
-| **7.1.2** | **Verify that** the system uses "stop sequences" or token limits to cut off generation before it can overflow buffers or execute unintended commands. | 1 |
-| **7.1.3** | **Verify that** model outputs crossing a trust boundary into downstream interpreters (e.g., databases, shells, deserializers, template engines, browsers) are treated as untrusted input and processed using the corresponding safe APIs as defined in respective OWASP ASVS guidance. | 1 |
+| **7.1.1** | **Verify that** the application validates all model outputs against a defined schema and rejects any output that does not match. | 1 |
+| **7.1.2** | **Verify that** the system uses stop sequences or token limits to prevent generation from overflowing buffers or executing unintended commands. | 1 |
+| **7.1.3** | **Verify that** model outputs crossing a trust boundary into downstream interpreters are treated as untrusted input and processed using safe APIs. | 1 |
 
 ---
 
@@ -24,47 +24,39 @@ Detect when the model produces potentially inaccurate or fabricated content and 
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.2.1** | **Verify that** the system assesses and logs the reliability of generated answers using a confidence or uncertainty estimation method (e.g., confidence scoring, retrieval-based verification, or model uncertainty estimation). | 2 |
+| **7.2.1** | **Verify that** the system assesses and logs the reliability of generated answers using a confidence or uncertainty estimation method. | 2 |
 | **7.2.2** | **Verify that** the application automatically blocks answers or switches to a fallback message if the confidence score drops below a defined threshold. | 2 |
-| **7.2.3** | **Verify that** for responses classified as high-risk or high-impact by policy, the system performs an additional verification step through an independent mechanism, such as retrieval-based grounding against authoritative sources, deterministic rule-based validation, tool-based fact-checking, or consensus review by a separately provisioned model. | 3 |
+| **7.2.3** | **Verify that** for responses classified as high-risk by policy, the system performs an additional verification step through an independent mechanism such as retrieval-based grounding or deterministic rule-based validation. | 3 |
 
 ---
 
-## C7.3 Output Safety & Privacy Filtering
+## C7.3 Output Safety, Privacy & Explainability
 
-Technical controls to detect and scrub bad content before it is shown to the user.
+Technical controls to detect and scrub unsafe content before it is shown to the user, and to ensure interpretability of AI decisions.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **7.3.1** | **Verify that** automated classifiers scan every response and block content that matches defined harmful content categories. | 1 |
 | **7.3.2** | **Verify that** output filters detect and block responses that disclose system prompt content. | 2 |
-| **7.3.3** | **Verify that** LLM client applications prevent model-generated output from triggering automatic arbitrary outbound requests (e.g., auto-rendered images, iframes, or link prefetching), for example by turning off automatic external resource loading or by restricting it to an allowlisted set of origins. | 2 |
-| **7.3.5** | **Verify that** model-generated outputs are scanned for encoding and representation smuggling artifacts (e.g., invisible Unicode or control characters, homoglyph substitutions, mixed-direction text) before being returned to callers or passed to downstream systems, and that detections trigger rejection or sanitization. | 3 |
+| **7.3.3** | **Verify that** model-generated output is prevented from triggering automatic arbitrary outbound requests. | 2 |
+| **7.3.4** | **Verify that** model outputs are checked for hidden or obfuscated content created through encoding before being returned or passed to downstream systems. | 3 |
+| **7.3.5** | **Verify that** model outputs are checked for hidden or misleading content created through alternate representations, such as markup, formatting, metadata, or structured fields. | 3 |
+| **7.3.6** | **Verify that** any detected smuggling artifacts are blocked, sanitized, or safely handled before the output is returned or processed further. | 3 |
+| **7.3.7** | **Verify that** explanations shown to the user are sanitized to remove system prompts or backend data. | 1 |
+| **7.3.8** | **Verify that** all generated media includes a watermark or cryptographic signature to prove it was AI-generated. | 3 |
 
 ---
 
-## C7.4 Explainability & Transparency
-
-Ensure user and other downstream consumers can interpret decisions by AI and recognize AI-generated media.
-
-| # | Description | Level |
-| :-------: | ------------------------------------------------------------------------------------------------------------------------------ | :---: |
-| **7.4.1** | **Verify that** explanations shown to the user are sanitized to remove system prompts or backend data. | 1 |
-| **7.4.2** | **Verify that** technical evidence of the model's decision, such as model interpretability artifacts (e.g., attention maps, feature attributions), is logged. | 3 |
-| **7.4.1** | **Verify that** all generated media includes an invisible watermark or cryptographic signature to prove it was AI-generated. | 3 |
-
----
-
-## C7.5 Source Attribution & Citation Integrity
+## C7.4 Source Attribution & Citation Integrity
 
 Ensure RAG-grounded outputs are traceable to their source documents and that cited claims are verifiably supported by retrieved content.
 
 | # | Description | Level |
 | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------- | :---: |
-| **7.5.1** | **Verify that** responses generated using retrieval-augmented generation (RAG) include attribution to the source documents that grounded the response. | 1 |
-| **7.5.2** | **Verify that** RAG attributions are derived from retrieval metadata and are not generated by the model, so provenance cannot be fabricated. | 1 |
-| **7.5.3** | **Verify that** each sourced claim in a RAG-grounded response can be traced to a specific retrieved chunk. | 2 |
-| **7.5.4** | **Verify that** the system detects and flags responses where claims are not supported by any retrieved content, and unsupported claims are blocked or redacted before being served to the user. | 2 |
+| **7.4.1** | **Verify that** responses generated using retrieval-augmented generation (RAG) include attribution to the source documents that grounded the response. | 1 |
+| **7.4.2** | **Verify that** RAG attributions are derived from retrieval metadata and are not generated by the model, so provenance cannot be fabricated. | 1 |
+| **7.4.3** | **Verify that** each sourced claim in a RAG-grounded response can be traced to a specific retrieved chunk. | 2 |
+| **7.4.4** | **Verify that** responses where claims are not supported by any retrieved content are flagged, and unsupported claims are blocked or redacted before being served to the user. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -12,61 +12,52 @@ Enforce fine-grained access controls and query-time scope enforcement for every 
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.1.1** | **Verify that** vector insert, update, delete, and query operations are enforced with namespace/collection/document-tag scope controls (e.g., tenant ID, user ID, data classification labels) with default-deny. | 1 |
-| **8.1.2** | **Verify that** every ingested document is tagged at write time with source, writer identity (authenticated user or system principal), timestamp, batch ID, and embedding model version. | 2 |
-| **8.1.3** | **Verify that** document metadata tags applied at ingestion are immutable after the initial write and cannot be changed by later pipeline stages or user operations. | 2 |
-| **8.1.4** | **Verify that** RAG pipeline retrieval events log the query issued, the documents or chunks retrieved, similarity scores, the knowledge source. | 2 |
-| **8.1.5** | **Verify that** a high-severity security alert is generated whenever a canary record is selected by retrieval, matched by similarity search, or passed to the model as context. | 2 |
-| **8.1.6** | **Verify that** retrieval anomaly detection identifies embedding density outliers, repeated dominance of specific documents in similarity results, and sudden shifts in retrieval bias distribution that may indicate vector database poisoning. | 3 |
+| **8.1.1** | **Verify that** vector store operations are enforced with namespace and collection scope controls with default-deny. | 1 |
+| **8.1.2** | **Verify that** every ingested document is tagged at write time with source, writer identity, and timestamp. | 2 |
+| **8.1.3** | **Verify that** document metadata tags are immutable after the initial write and cannot be changed by later pipeline stages or user operations. | 2 |
+| **8.1.4** | **Verify that** RAG pipeline retrieval events are logged, including the query, documents retrieved, and knowledge source. | 2 |
+| **8.1.5** | **Verify that** a high-severity alert is generated whenever a canary record is selected by retrieval or passed to the model as context. | 2 |
+| **8.1.6** | **Verify that** retrieval anomaly detection identifies unusual retrieval patterns that may indicate vector database poisoning. | 3 |
 
 ---
 
 ## C8.2 Embedding Sanitization & Validation
 
-Pre-screen content before vectorization; treat memory writes as untrusted inputs; prevent ingestion of unsafe payloads. Hidden instructions and other prompt-injection payloads in ingested or retrieved content are screened by the same input-validation pipeline as direct user input.
+Pre-screen content before vectorization and treat memory writes as untrusted inputs to prevent ingestion of unsafe payloads.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.2.1** | **Verify that** sensitive fields are detected before embedding and are masked, tokenized, transformed, or dropped, since data once embedded cannot be reliably redacted from the resulting index. | 1 |
-| **8.2.2** | **Verify that** content crafted to manipulate retrieval geometry (e.g., text engineered to project into attacker-chosen embedding neighborhoods so it is preferentially retrieved) is detected and rejected or quarantined before vectorization. | 3 |
+| **8.2.1** | **Verify that** sensitive fields are detected before embedding and are masked, tokenized, or dropped, since data once embedded cannot be reliably redacted. | 1 |
+| **8.2.2** | **Verify that** content crafted to manipulate retrieval results is detected and rejected or quarantined before vectorization. | 3 |
 | **8.2.3** | **Verify that** vectors that fall outside normal clustering patterns are flagged and quarantined before entering production indices. | 2 |
-| **8.2.4** | **Verify that** agent outputs, tool outputs, and orchestration results are not automatically written to trusted agent memory without explicit source validation (e.g., content-origin checks or write-authorization controls that verify the content's source before committing writes). | 2 |
+| **8.2.4** | **Verify that** agent outputs and tool outputs are not automatically written to trusted agent memory without explicit source validation. | 2 |
 | **8.2.5** | **Verify that** new content written to memory is checked for contradictions with what is already stored and that conflicts trigger alerts. | 3 |
 
 ---
 
-## C8.3 Memory Expiry, Revocation & Deletion
+## C8.3 Memory Expiry, Revocation & Leakage Prevention
 
-Retention and revocation must be explicit and enforceable for memory and RAG indices, and deletions must propagate through derivative indices and caches within a measured propagation window.
+Retention and revocation must be explicit and enforceable for memory and RAG indices, and systems must address embedding inversion and attribute inference risks.
 
 | # | Description | Level |
 | :--: | --- | :---: |
 | **8.3.1** | **Verify that** expired vectors are excluded from retrieval results within a defined propagation window. | 2 |
-| **8.3.2** | **Verify that** memory can be reset for security reasons (quarantine, selective purge, full reset) through an operation that is separate and independent from the retention deletion process. | 2 |
-| **8.3.3** | **Verify that** quarantined content is retained for investigation but is excluded from all retrieval results while under quarantine. | 2 |
+| **8.3.2** | **Verify that** memory can be reset for security reasons through an operation independent from the retention deletion process. | 2 |
+| **8.3.3** | **Verify that** quarantined content is retained for investigation but excluded from all retrieval results while under quarantine. | 2 |
+| **8.3.4** | **Verify that** embedding leakage resistance targets are defined and measured, and that changes to embedding models or privacy transforms are gated by regression tests against those targets. | 3 |
 
 ---
 
-## C8.4 Prevent Embedding Inversion & Leakage
-
-Address inversion, membership inference, and attribute inference with explicit threat modeling, mitigations, and regression testing gates.
-
-| # | Description | Level |
-| :--: | --- | :---: |
-| **8.4.1** | **Verify that** privacy/utility targets for embedding leakage resistance are **defined and measured**, and that changes to embedding models, tokenizers, retrieval settings, or privacy transforms are gated by regression tests against those targets. | 3 |
-
----
-
-## C8.5 Scope Enforcement for User-Specific Memory
+## C8.4 Scope Enforcement for User-Specific Memory
 
 Prevent cross-tenant and cross-user leakage in retrieval and prompt assembly.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **8.5.1** | **Verify that** every retrieval operation enforces scope constraints (tenant/user/classification) **in the vector engine query** and verifies them again **before prompt assembly** (post-filter). | 2 |
-| **8.5.2** | **Verify that** vector identifiers, namespaces, and metadata indexing prevent cross-scope collisions and enforce uniqueness per tenant. | 1 |
-| **8.5.3** | **Verify that** retrieval results that match similarity criteria but fail scope checks are discarded. | 1 |
-| **8.5.4** | **Verify that** multi-tenant tests simulate adversarial retrieval attempts (prompt-based and query-based) and show that no out-of-scope documents appear in prompts or outputs. | 2 |
+| **8.4.1** | **Verify that** every retrieval operation enforces scope constraints in the vector engine query and verifies them again before prompt assembly. | 2 |
+| **8.4.2** | **Verify that** vector identifiers and namespaces enforce uniqueness per tenant and prevent cross-scope collisions. | 1 |
+| **8.4.3** | **Verify that** retrieval results that match similarity criteria but fail scope checks are discarded. | 1 |
+| **8.4.4** | **Verify that** multi-tenant tests simulate adversarial retrieval attempts and verify that no out-of-scope documents appear in prompts or outputs. | 2 |
 
 ---
 


### PR DESCRIPTION
## Summary

Applies the same structural editing pass as C1–C5 to chapters 6, 7, and 8.

**C06 Supply Chain** (5 sections → 3):
- C6.2 merged into C6.1 → "Model Artifact Integrity & Source Trust"
- C6.4 merged into C6.3 → "AI BOM & Supply Chain Monitoring"
- Item descriptions simplified; key-pinning item and lineage/license item dropped as covered elsewhere

**C07 Model Behavior** (5 sections → 4; numbering bugs fixed):
- C7.4 merged into C7.3 → "Output Safety, Privacy & Explainability"
- Encoding smuggling item split into three independently testable items: encoding/obfuscation (7.3.4), alternate representations (7.3.5), and remediation (7.3.6)
- Fixed missing 7.3.4 and duplicate 7.4.1 numbering bugs
- C7.5 renumbered to C7.4

**C08 Memory, Embeddings & Vector DB** (5 sections → 4):
- C8.4 merged into C8.3 → "Memory Expiry, Revocation & Leakage Prevention"
- C8.5 renumbered to C8.4
- Jargon simplified throughout: "retrieval geometry", "embedding density outliers", "retrieval bias distribution" replaced with plain language equivalents

## Test plan

- [ ] All item numbers are sequential with no gaps or duplicates within each section
- [ ] Section count: C6 has 3, C7 has 4, C8 has 4
- [ ] References sections unchanged
