### PR TITLE
Levels review for C09

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -26,7 +26,7 @@ Require explicit checkpoints for privileged or irreversible outcomes.
 | :--: | --- | :---: |
 | **9.2.1** | **Verify that** the agent runtime enforces an execution gate that blocks privileged or irreversible actions (e.g., code merges/deploys, financial transfers, user access changes, destructive deletes, external notifications) until an explicit human approval is received and verified. | 1 |
 | **9.2.2** | **Verify that** approval requests display canonicalized and complete action parameters (diff, command, recipient, amount, scope) without truncation or transformation. | 2 |
-| **9.2.3** | **Verify that** approvals are cryptographically bound (e.g., signed or MACed) to the exact action parameters, requester identity, and execution context, include a unique single-use nonce, and expire within a defined maximum time-to-live (TTL). | 2 |
+| **9.2.3** | **Verify that** approvals are cryptographically bound (e.g., signed or MACed) to the exact action parameters, requester identity, and execution context, include a unique single-use nonce, and expire within a defined maximum time-to-live (TTL). | 3 |
 | **9.2.4** | **Verify that** where rollback is feasible, compensating actions are defined and tested (transactional semantics), and failures trigger rollback or safe containment. | 3 |
 
 ---
@@ -78,7 +78,7 @@ Ensure every action is authorized at execution time and constrained by scope.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.6.1** | **Verify that** agent actions are authorized against fine-grained policies enforced by the runtime that restrict which tools an agent may invoke, which parameter values it may supply (e.g., allowed resources, data scopes, action types), and block policy violations. | 1 |
+| **9.6.1** | **Verify that** agent actions are authorized against fine-grained policies enforced by the runtime that restrict which tools an agent may invoke, which parameter values it may supply (e.g., allowed resources, data scopes, action types), and block policy violations. | 2 |
 | **9.6.2** | **Verify that** when an agent acts on a user's behalf, the runtime propagates an integrity-protected delegation context (user ID, tenant, session, scopes) and enforces that context at every downstream call without using the user's credentials. | 2 |
 | **9.6.3** | **Verify that** all access control decisions are enforced by application logic or a policy engine, never by the AI model itself, and that model-generated output (e.g., "the user is allowed to do this") cannot override or bypass access control checks. | 2 |
 | **9.6.4** | **Verify that** secrets and credentials required by an agent at runtime are not exposed within the model's observable context, including the context window, system prompts, or tool call parameters, and are instead provided via out-of-band mechanisms such as credential proxies, secrets manager injection, runtime sidecar authentication, or short-lived scoped tokens. | 2 |
@@ -98,7 +98,7 @@ Prevent "technically authorized but unintended" actions by binding execution to 
 | **9.7.2** | **Verify that** post-execution checks confirm the intended outcome was achieved and detect unintended side effects, and that any mismatch triggers containment and, where supported, compensating actions. | 2 |
 | **9.7.3** | **Verify that** all write operations to persistent external state are authorized by either explicit human approval or an independent policy-based authorization mechanism that evaluates the operation against the original user intent, and not solely on agent-generated output. | 2 |
 | **9.7.4** | **Verify that** when the policy decision point (PDP) used for governance evaluation is unavailable (e.g., timeout, network partition, service failure), agent execution fails closed by blocking the proposed action, and the unavailability event is logged with sufficient detail for incident investigation. | 2 |
-| **9.7.5** | **Verify that** prompt templates and agent policy configurations retrieved from a remote source are integrity-verified at load time against their approved versions (e.g., via hashes or signatures). | 3 |
+| **9.7.5** | **Verify that** prompt templates and agent policy configurations retrieved from a remote source are integrity-verified at load time against their approved versions (e.g., via hashes or signatures). | 2 |
 
 ---
 
@@ -109,8 +109,8 @@ Reduce cross-domain interference and emergent unsafe collective behavior.
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.8.1** | **Verify that** agents in different tenants, security domains, or environments (dev/test/prod) run in isolated runtimes and network segments, with default-deny controls that prevent cross-domain discovery and calls. | 1 |
-| **9.8.2** | **Verify that** each agent is restricted to its own memory namespace and is technically prevented from reading or modifying peer agent state, preventing unauthorized cross-agent access within the same swarm. | 2 |
-| **9.8.3** | **Verify that** each agent operates with an isolated context window that peer agents cannot read or influence, preventing unauthorized cross-agent context access within the same swarm. | 3 |
+| **9.8.2** | **Verify that** each agent is restricted to its own memory namespace and is technically prevented from reading or modifying peer agent state, preventing unauthorized cross-agent access within the same swarm. | 3 |
+| **9.8.3** | **Verify that** each agent operates with an isolated context window that peer agents cannot read or influence, preventing unauthorized cross-agent context access within the same swarm. | 2 |
 | **9.8.4** | **Verify that** runtime monitoring detects unsafe emergent behavior (oscillation, deadlocks, uncontrolled broadcast, abnormal call graphs) and automatically applies corrective actions (throttle, isolate, terminate). | 3 |
 | **9.8.5** | **Verify that** swarm-level aggregate action rate limits (e.g., total external API calls, file writes, or network requests per time window across all agents) are enforced to prevent bursts that cause denial-of-service or abuse of external systems. | 3 |
 | **9.8.6** | **Verify that** a swarm-level shutdown capability exists that can halt all active agent instances or selected problematic instances in an organized fashion and prevents new agent spawning, with shutdown completable within a pre-defined response time. | 3 |
@@ -123,7 +123,7 @@ Prevent data-flow attacks that exploit agentic tool-calling pipelines by manipul
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.9.1** | **Verify that** the system architecturally separates, or applies an equivalent isolation mechanism to separate, plan generation (control flow) from untrusted data processing, such that the component determining which tools to call and in what sequence does not directly process untrusted content (e.g., tool outputs, retrieved documents, external messages). | 2 |
+| **9.9.1** | **Verify that** the system architecturally separates, or applies an equivalent isolation mechanism to separate, plan generation (control flow) from untrusted data processing, such that the component determining which tools to call and in what sequence does not directly process untrusted content (e.g., tool outputs, retrieved documents, external messages). | 3 |
 | **9.9.2** | **Verify that** components processing untrusted data (e.g., for extraction, summarization, or parsing) are isolated, or equivalently constrained, from tool-calling capabilities, ensuring that compromised data processing cannot trigger unauthorized tool invocations. | 2 |
 | **9.9.3** | **Verify that** security policies for tool execution are expressed as auditable, versioned, machine-interpretable code or configuration, not solely as natural language instructions within prompts. | 2 |
 | **9.9.4** | **Verify that** values passed to tools carry origin metadata tracking their source (user input, specific tool, external source). | 3 |


### PR DESCRIPTION
Implementability and levels review for C09.

## Changes

**C9.6.1** L1 -> L2: Fine-grained per-tool and per-parameter agent authorization. This is functionally the same control as C10.2.7 (L2): "enforce access control on every tool invocation, validating that the user's access token authorizes both the requested tool and the specific argument values supplied." C9.6.1 restricts "which tools an agent may invoke, which parameter values it may supply." Same control at two levels. Even the coarser resource-level access control in C5.2.1 is L2.

Per-parameter-value policy authorization is production-with-engineering (OPA/Cedar policy authoring plus PDP integration), not the L1 trivial/universal bar. The L1 baseline gate is preserved by C9.7.1 (L1), which already covers allow-list and deny-rule gating, so C9.6 keeps an L1 floor while the fine-grained per-parameter policy moves to L2.

**C9.8.3** L3 -> L2: Per-agent isolated context window. Per-agent context-window isolation is trivial and is the default behavior across all agent frameworks (separate LLM API calls do not share context). The harder sibling is C9.8.2 (per-agent memory namespace isolation), now moved to L3 below.

**C9.2.3** L2 -> L3: Crypto-bound approvals (signed or MACed to exact parameters, requester identity, and execution context, with single-use nonce and TTL). The crypto primitives are standard, but no agent framework provides this as built-in functionality and it is very much a defense-in-depth control layered on top of the L1 approval gate (C9.2.1). L3 fits a control that must be hand-built per deployment and applies only to the most security-sensitive systems.

**C9.8.2** L3: Per-agent memory namespace isolation. The requirement demands that an agent be *technically prevented* from reading or modifying peer agent state, a stronger guarantee than application-layer namespacing. Logical separation (e.g., CrewAI memory scopes) does not stop a compromised or injected agent runtime that shares a process or store; true technical prevention requires runtime/process/VM-level isolation or per-agent isolated state stores, the same class of work as C9.8.1 runtime isolation and C5.3.2 (L3 tenant compute isolation). This also makes the section gradient coherent: context-window isolation (C9.8.3, L2, default in separate LLM calls) is genuinely easier than technically enforced memory-state isolation against a compromised peer (C9.8.2, L3).

**C9.9.1** L2 -> L3: Architectural plan/data separation (dual-LLM / CaMeL). Formal plan/data separation (CaMeL) is a research artifact with no native framework support. The earlier L2 rationale rested on the requirement's "or applies an equivalent isolation mechanism" hedge, but read strictly the control requires the formal guarantee that the planner never ingests untrusted content. That is not built-in functionality and is defense-in-depth, so it belongs at L3 alongside the data-flow taint-tracking tier (9.9.4-9.9.7).

## Reviewed and kept

| Req | Level | Why kept |
|---|---|---|
| C9.1.1 | L1 | Execution budgets. recursion_limit is native (LangGraph); the full bundle needs engineering, but bounding consumption is a foundational baseline (LLM10 Unbounded Consumption) every agent system should set. |
| C9.1.2 | L2 | Cumulative per-chain counters plus circuit-breaker hard-stop. Production-with-engineering, not native. |
| C9.1.3 | L3 | Security testing of runaway loops, budget exhaustion, partial-failure with safe termination. Advanced adversarial QA. |
| C9.2.1 | L1 | Human-approval gate for privileged/irreversible actions. Foundational; aligns with C14.1.1 (L1), C14.2.1 (L1). |
| C9.2.2 | L2 | Canonicalized complete approval parameters without truncation. UI/serialization engineering. |
| C9.2.4 | L3 | Compensating actions / transactional rollback for agentic actions. Genuinely hard and situational. |
| C9.3.1 | L1 | Per-tool sandbox (container/VM/WASM). gVisor/Kata/Firecracker production-ready; aligns with C4.1.1 (L1). |
| C9.3.2 | L1 | Per-tool quotas/timeouts, fail-closed. Standard runtime limits. |
| C9.3.3 | L1 | Tool output schema/policy validation before downstream use. Aligns with C10.4.1 (L1), C2.1.3 (L1). |
| C9.3.4 | L1 | Logging quota/timeout breaches. Trivial. |
| C9.3.5 | L2 | Tool manifests declare privileges/side-effects/limits. MCP spec lacks side-effect fields; needs a declaration schema. Aligns with C10.1.3 (L2). |
| C9.3.6 | L2 | Runtime enforces manifest declarations. OPA/Cedar can enforce, but policies are authored per tool. |
| C9.3.7 | L3 | Automated containment on sandbox-escape indicators. Detection plus auto-quarantine is advanced. |
| C9.4.1 | L1 | Unique agent crypto identity authenticating as first-class principal. SPIFFE/SPIRE plus OAuth client-credentials make this trivial. Distinct from C10.2.11 (L2 proof-of-possession) and C5.1.2 (L3 federated short-lived), which are the harder increments. |
| C9.4.2 | L2 | Bind actions to execution chain ID. Production-with-engineering (middleware, not native). |
| C9.4.3 | L2 | Rich audit context (who/what, delegation scope, authz decision, params, outcomes). Aligns with C13 logging at L2. |
| C9.4.4 | L2 | Sign and timestamp actions for non-repudiation. C10.4.10 (L3) is the stricter nonce-plus-freshness variant. |
| C9.4.5 | L3 | Credential rotation plus rapid revocation plus quarantine on compromise indicators. Full lifecycle is advanced. |
| C9.4.6 | L3 | Persisted agent-state integrity protection (MAC/signature) plus reject-on-failure. Higher integrity bar than C8.2.4 (L2). |
| C9.5.1 | L2 | Semantic-constraint validation of agent-to-agent outputs beyond schema. Non-trivial domain logic. |
| C9.6.2 | L2 | Integrity-protected delegation-context propagation without user creds. RFC 8693 token exchange plus enforcement. Aligns with C10.2.8 (L2). |
| C9.6.3 | L2 | Access decisions by policy engine, never the model. Aligns with C5.2.5 (L2). |
| C9.6.4 | L2 | Secrets kept out of model-observable context. Aligns with C10.2.5 (L1) / C10.2.8 (L2). |
| C9.6.5 | L2 | Dual-constraint PDP (agent perms AND delegated scope). Trivial to author in OPA/Cedar but depends on the L2 delegation plumbing in C9.6.2. |
| C9.6.6 | L2 | Peer authorization via approved-agent registry/allowlist. The bar is allowlisting (explicit in text), not research-grade trust-scoring. Needs registry plus enforcement. |
| C9.6.7 | L3 | Continuous re-evaluation of backend authz on every privileged action. CAEP final but receivers experimental. Aligns with C5.1.1 (L3). |
| C9.7.1 | L1 | Pre-execution hard-constraint gates (deny rules, allow-lists, side-effect budgets). The L1 authorization floor (anchors the C9.6.1 move to L2). |
| C9.7.2 | L2 | Post-execution outcome verification plus side-effect detection plus containment. Non-trivial. |
| C9.7.3 | L2 | Writes to persistent external state authorized by human approval or policy engine vs original intent. Aligns with C8.2.4 (L2). |
| C9.7.4 | L2 | Fail-closed when PDP unavailable. Aligns with C10.6.1 (L2), C14.2.2 (L2). |
| C9.8.1 | L1 | Tenant/domain/env runtime plus network isolation, default-deny. Standard segmentation. |
| C9.8.4 | L3 | Detect emergent unsafe behavior plus auto-remediation. Monitoring exists; detection plus auto-remediation has no standardized tooling. |
| C9.8.5 | L3 | Swarm-level aggregate rate limits across all agents. Cross-swarm distributed coordination is harder than per-principal limits; no native support. |
| C9.8.6 | L3 | Swarm kill switch with bounded response time. Infra-layer, no standardized open-source; orchestrator-level shutdown does not propagate to sub-agents. |
| C9.9.2 | L2 | Data processors isolated from tool-calling. Tool denial is trivial; the isolation guarantee is the L2 work. Pairs with 9.9.1. |
| C9.9.3 | L2 | Policy-as-code for tool execution (OPA/Cedar/Cerbos). Mature engines; integration custom. |
| C9.9.4 | L3 | Origin metadata on tool-argument values (taint source labeling). Research-grade; no framework native. |
| C9.9.5 | L3 | Policy evaluation against value origin before tool call. Research-grade; depends on 9.9.4. |
| C9.9.6 | L3 | Block tool calls on origin-policy violation. Research-grade. |
| C9.9.7 | L3 | Data-flow integrity even when control flow is intended. Research-grade; current research is incomplete. |
| C9.9.8 | L3 | Per-session data-flow dependency graph for audit. Depends on the research-grade origin-tracking layer. Coherent at L3. |
