### PR TITLE
Levels review C10

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -12,7 +12,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | :--: | --- | :---: |
 | **10.1.1** | **Verify that** MCP server and client components are obtained only from trusted sources and verified using signatures, checksums, or secure package metadata, rejecting tampered or unsigned builds. | 1 |
 | **10.1.2** | **Verify that** only allowlisted MCP server identifiers (name, version, and registry) are permitted in production and that the runtime rejects connections to unlisted or unregistered servers at load time. | 1 |
-| **10.1.3** | **Verify that** all MCP tool and resource schemas include cryptographically verifiable provenance metadata — including author, timestamp, version hash, signature, and approved‑by fields. | 2 |
+| **10.1.3** | **Verify that** all MCP tool and resource schemas record provenance metadata, including author, timestamp, version hash, and approved-by fields. | 2 |
 
 ---
 
@@ -30,7 +30,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | **10.2.8** | **Verify that** MCP servers do not pass through access tokens received from clients to downstream APIs and instead obtain a separate token scoped to the server's own identity (e.g., via on-behalf-of or client credentials flow). | 2 |
 | **10.2.9** | **Verify that** MCP clients request only the minimum scopes needed for the current operation and elevate progressively via step-up authorization for higher-privilege operations. | 2 |
 | **10.2.10** | **Verify that** MCP servers enforce deterministic session teardown, destroying cached tokens, in-memory state, temporary storage, and file handles when a session terminates, disconnects, or times out. | 2 |
-| **10.2.11** | **Verify that** autonomous agents authenticate using cryptographically bound identity credentials (e.g., key-based proof-of-possession) rather than bearer-only tokens, ensuring that agent identity cannot be transferred, replayed, or impersonated by forwarding a shared secret. | 2 |
+| **10.2.11** | **Verify that** autonomous agents authenticate using cryptographically bound identity credentials (e.g., key-based proof-of-possession) rather than bearer-only tokens, ensuring that agent identity cannot be transferred, replayed, or impersonated by forwarding a shared secret. | 3 |
 
 ---
 
@@ -77,7 +77,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | # | Description | Level |
 | :--: | --- | :---: |
 | **10.6.1** | **Verify that** MCP security controls enforce fail-closed semantics: if tool schema validation, MCP-Protocol-Version negotiation, authentication, or policy evaluation fails or cannot be completed, the default action is to deny the request rather than permit it. | 2 |
-| **10.6.2** | **Verify that** MCP servers expose only allow-listed functions and resources, and restrict function invocation to statically defined, pre-approved names that cannot be influenced by user or model-provided input. | 3 |
+| **10.6.2** | **Verify that** MCP servers expose only allow-listed functions and resources, and restrict function invocation to statically defined, pre-approved names that cannot be influenced by user or model-provided input. | 2 |
 
 ---
 


### PR DESCRIPTION
Implementability and level review for C10.

## Changes

**10.1.3** narrowed (drop cryptographic-signature element, level unchanged: L2): The original requirement conflated two different concerns: recording provenance metadata fields (author, timestamp, version hash, approved-by) and cryptographic signing plus signature verification of tool schemas. The signing concern is research-grade (the MCP spec is silent on schema signing, no SDK or ecosystem standard exists) and it duplicates 10.4.8 (L3), which already requires signature-based schema authenticity and integrity verification. This mirrors the C06 split where recording provenance metadata is cheap (C6.5.1 AI BOM fields at L1) while signing it is the separate harder tier (C6.5.2 sign BOM at L2). Narrowed 10.1.3 to declared provenance metadata, kept at L2.

**10.2.11** L2 -> L3: Proof-of-possession / sender-constrained agent credentials. The control requires cryptographically bound, non-bearer agent identity (key-based proof-of-possession). DPoP and mTLS sender-constraining are not in the MCP spec or official SDKs (only partial private_key_jwt client registration exists). This is the same aspirational capability that C5.1.2 places at L3 ("sender-constrained tokens for AI agents is aspirational; MCP has no sender-constrained token spec"). Keeping 10.2.11 at L2 contradicted that anchor. The L1/L2 auth floor remains intact via 10.2.1 (present a valid token) and 10.2.4 (validate the token); 10.2.11 is the sender-constrained hardening tier on top, so it belongs at L3.

**10.6.2** L3 -> L2: Static, pre-approved tool/function names that cannot be influenced by user or model input. Defining tools statically is the default in every MCP SDK; allowing function names to be chosen from user or model input would be an obvious RCE that no implementation does. Cross-chapter anchors support L2: 10.1.2 (allowlist servers) is L1, C9.6.1 (fine-grained tool authz) is L2, C9.6.3 (access decisions never by the model) is L2. Kept at L2 rather than L1 because the explicit "cannot be influenced by user or model input" guarantee (defending against dynamic registration and tools/list_changed rug-pulls) is a deliberate hardening step beyond the bare default.

## Reviewed and kept

| Req | Level | Why kept |
|---|---|---|
| C10.1.1 | L1 | Trusted-source components verified via signatures/checksums/secure-package-metadata. The checksum/package-metadata path is trivially universal. Verifies components, not self-signed artifacts (cf. C6.2.1 L1). |
| C10.1.2 | L1 | Allowlist MCP server IDs, reject unlisted at load. Trivial allowlisting; matches C6.2.1 (L1). |
| C10.2.1 | L1 | Present a valid access token per request. Foundational auth baseline. |
| C10.2.2 | L1 | Controlled server onboarding; unregistered not callable in prod. Standard registry discipline. |
| C10.2.3 | L1 | Session IDs as state not identity (CSPRNG, user-bound, never used for authn/authz). Standard session hygiene. |
| C10.2.4 | L1 | Validate token issuer/audience/expiration/scope per OAuth 2.1. Spec-MUST; mature OAuth libs. Foundational. |
| C10.2.5 | L1 | Resource servers do not store/persist tokens or creds. Spec-MUST; standard practice. |
| C10.2.6 | L2 | Scope-filtered tools/list and resource discovery. Spec silent; custom server logic. Aligns with C5.2.2 (L2). |
| C10.2.7 | L2 | Access control on every tool invocation incl. argument values. Custom server logic; anchors C9.6.1 (L2). |
| C10.2.8 | L2 | No token passthrough; obtain own-identity token. Spec-MUST (prose), architectural, not SDK-enforced. |
| C10.2.9 | L2 | Minimum scopes plus step-up authorization. Spec SHOULD; Python SDK implements, TS custom. |
| C10.2.10 | L2 | Deterministic session teardown. SDKs lack lifecycle hooks; custom. |
| C10.3.1 | L1 | Authenticated encrypted Streamable HTTP. TLS is standard HTTPS. Current standard transport. |
| C10.3.2 | L1 | stdio local-only, low-privilege, no network bind. Spec SHOULD; trivial local hardening. |
| C10.3.3 | L2 | SSE on private authenticated channels plus TLS/schema/payload-limits/rate-limiting. Payload-limit and rate-limit are infra-layer engineering. |
| C10.3.4 | L2 | Origin plus Host validation (DNS rebinding). Spec mandates Origin; Host is added hardening. Standard web-security engineering. |
| C10.3.5 | L2 | Mcp-Protocol-Version header not altered/stripped (downgrade prevention). Server validates mismatch (spec-native); intermediary protection needs deployment care. |
| C10.3.6 | L2 | Client enforces minimum protocol version. Version negotiation in spec; minimum-version enforcement is custom client logic. |
| C10.4.1 | L1 | Validate tool responses before model context (prompt injection). Same control as C2.1.3 (L1) and C9.3.3 (L1). |
| C10.4.2 | L1 | Error responses do not leak internals. Standard JSON-RPC error hygiene; trivial. |
| C10.4.3 | L2 | Message-framing integrity plus strict schema validation. SDK JSON-RPC validation helps; framing/desync hardening is L2. |
| C10.4.4 | L2 | Strict input validation (type/boundary/enum). Defining bounds is per-tool engineering. |
| C10.4.5 | L2 | Tool-definition change re-approval (hash snapshot plus list_changed). Notification is spec-native; re-approval logic is custom. Aligns with C9.3.5/3.6 (L2). |
| C10.4.6 | L2 | Max payload size limits; reject malformed/truncated/interleaved frames. Infra/server config. |
| C10.4.7 | L2 | Reject unrecognized/oversized parameters. Bounds are per-tool. |
| C10.4.8 | L3 | Signature-based schema authenticity/integrity verification. Research-grade (MCP silent, no ecosystem standard). Sole owner of schema signing after the 10.1.3 narrowing. |
| C10.4.9 | L3 | Canonicalization / parser-differential defense. MCP silent; no production solutions; research-grade. |
| C10.4.10 | L3 | Sign tool responses with nonce plus timestamp plus freshness. Only in draft MCPS spec; zero SDK support. Research-grade. |
| C10.5.1 | L2 | Least-privilege egress, default-deny. MCP silent; OS/container network-policy engineering. |
| C10.6.1 | L2 | Fail-closed semantics across schema/version/auth/policy failures. Schema+version+auth fail-closed is spec-native; policy fail-closed is operator work. Aligns with C9.7.4 (L2). |