### PR TITLE
Levels review for C12

### DIFF
--- a/1.0/en/0x10-C12-Privacy.md
+++ b/1.0/en/0x10-C12-Privacy.md
@@ -25,7 +25,7 @@ Ensure data-subject deletion requests propagate across all AI artifacts and that
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.2.1** | **Verify that** data-subject deletion requests propagate to AI-derived artifacts including training and fine-tuning datasets, model checkpoints, evaluation sets, derived caches, and feature stores within a service-level agreement window of less than 30 days. | 1 |
+| **12.2.1** | **Verify that** data-subject deletion requests propagate to AI data artifacts including training and fine-tuning datasets, evaluation sets, derived caches, feature stores, and vector/embedding stores within a service-level agreement window of less than 30 days. | 1 |
 | **12.2.2** | **Verify that** shadow-model or membership-inference evaluation demonstrates that forgotten records influence less than a documented policy threshold of model outputs after unlearning. | 2 |
 | **12.2.3** | **Verify that** machine-unlearning routines, when claimed, either physically retrain the affected model on the retained data or apply a certified unlearning algorithm with documented (ε, δ) guarantees. | 3 |
 
@@ -50,8 +50,8 @@ Prevent models and datasets from being used beyond their originally consented pu
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.4.1** | **Verify that** every dataset and model checkpoint carries a machine-readable purpose tag aligned to the original consent and lawful basis under which the source data was collected. | 1 |
-| **12.4.2** | **Verify that** runtime monitors detect queries inconsistent with the declared purpose of the dataset or model, and that detected queries trigger a soft refusal or are blocked pending review. | 1 |
-| **12.4.3** | **Verify that** policy-as-code gates block redeployment of a model to a purpose or domain not covered by its purpose tag (12.4.1). | 3 |
+| **12.4.2** | **Verify that** runtime monitors detect queries inconsistent with the declared purpose of the dataset or model, and that detected queries trigger a soft refusal or are blocked pending review. | 2 |
+| **12.4.3** | **Verify that** policy-as-code gates block redeployment of a model to a purpose or domain not covered by its purpose tag (12.4.1). | 2 |
 
 ---
 


### PR DESCRIPTION
Implementability and level review for C12.

## Changes

**12.2.1** narrowed (kept L1): Dropped "model checkpoints" from the L1 deletion-propagation list. Deleting a record from trained weights needs unlearning or retraining, which are the harder controls 12.2.2 (L2) and 12.2.3 (L3); requiring it at L1 demanded an L3 capability. Scoped 12.2.1 to data artifacts where deletion is real data-engineering (datasets, eval sets, caches, feature stores, vector/embedding stores).

**12.4.2** L1 -> L2: Runtime purpose monitoring + block. Detecting "queries inconsistent with declared purpose" is intent-classification engineering (and largely vacuous for general-purpose LLMs), not an L1 trivial/universal control. (12.4.1, carrying the tag, stays L1; the runtime detection is the L2 work.)

**12.4.3** L3 -> L2: Policy-as-code redeployment gate. OPA/Cedar gating in CI/CD is standard production-with-engineering, not research-grade. Consistent with the standard's other policy-gate controls at L2.

## For discussion

**12.5.1 testability**: "data subjects whose data materially influences the response" is only computable for RAG/retrieval, not for parametric model knowledge, so an auditor cannot verify it for a parametric LLM even at L3. Consider scoping the clause to RAG contexts.

**Governance vs technical scope**: 12.4.1 and 12.5.x are a bit on the governance side. The technical parts (carry the tag, gate at inference, propagate withdrawal) were leveled on technical difficulty; the lawful-basis determination is governance and outside AISVS technical scope.

## Reviewed and kept (notable calls)

| Req | Level | Why kept |
|---|---|---|
| 12.1.1 | L1 | PII/identifier removal before training. Presidio/Cloud DLP mature for direct identifiers; same tooling base as C1.2.4 (L2 labels) and C8.2.1 (L1 pre-embedding). Foundational baseline. |
| 12.1.2 | L2 | k-anonymity/l-diversity audits. Well-defined and tooled (ARX/sdcMicro) for tabular data; not meaningfully computable for unstructured/LLM corpora. L2 for the tabular case. |
| 12.1.3 | L2 | Feature-importance to detect reconstructed identifiers. SHAP/captum production for tabular/small models; unreliable for LLMs. L2 for the tabular case. |
| 12.1.4 | L3 | Re-identification formal proofs / synthetic-data certification under linkage attacks. Similarity-based metrics are broken; only DP-synthesis is sound and expensive. Research-grade. |
| 12.2.2 | L2 | MIA/shadow-model unlearning verification. Production-with-engineering for small/fine-tuned models; shadow models infeasible for foundation models. Threshold verification, lower bar than C11.3.3 (L3). |
| 12.2.3 | L3 | Certified unlearning with (epsilon, delta) or physical retrain. Certified unlearning research-grade for non-convex/LLMs; retrain infeasible at scale. |
| 12.3.1 | L2 | DP budget tracking per round. Trivial if doing DP-SGD (Opacus accountant); L2 engineering within DP training. Matches C11.3.2 (L2). |
| 12.3.2 | L2 | Black-box DP audit (empirical epsilon-hat). Production-with-engineering for small DP models; research for LLMs. L2 for the DP-trained case. |
| 12.3.3 | L3 | Formal DP proofs across fine-tunes and embedding generation. No integrated production implementation. Research-grade. |
| 12.4.1 | L1 | Machine-readable purpose tag. Trivial metadata (BOM-field class). The consent/lawful-basis alignment is governance; carrying the tag is trivial. |
| 12.5.1 | L3 | Consent-scope validation at inference including data subjects whose data materially influences the response. Tractable for RAG; research-grade/infeasible for parametric knowledge. See testability flag below. |
| 12.5.2 | L2 | Refuse/downgrade when consent scope not covered (considered L3, kept L2). Enforcement action is standard L2 (cf. C5.2.4, C5.2.2); coupling it to its hardest-case input (12.5.1 L3) would over-level it. |
| 12.5.3 | L2 | Consent-withdrawal propagation (same pipeline as 12.2.1). Same data-store-vs-weights caveat. |
| 12.6.1 | L1 | FL local/central DP (considered L2, kept L1). C12.6 is scoped to federated-learning systems; within FL, DP is the foundational floor, with 12.6.2-4 the harder tiers. |
| 12.6.2 | L2 | DP training metrics / no single-client gradient leakage (secure aggregation). Production-with-engineering. |
| 12.6.3 | L3 | Canary-based FL privacy auditing. Research-grade; not operationalized in production FL platforms. |
| 12.6.4 | L3 | Formal FL epsilon proofs plus utility loss. Formal utility bounds are instance-dependent/research. |
