### PR TITLE
feat(C9): add 9.3.7 allowlist verification for model-named external resources

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -42,7 +42,8 @@ Constrain tool and plugin execution, loading, and outputs to prevent unauthorize
 | **9.3.4** | **Verify that** the runtime enforces that tool manifests define required privileges, resource limits, and output validation. | 2 |
 | **9.3.5** | **Verify that** components processing untrusted data are isolated from tool-calling capabilities, ensuring that compromised data processing cannot trigger unauthorized tool invocations. | 2 |
 | **9.3.6** | **Verify that** there is architectural separation between untrusted data processing from tool outputs and agent operations. | 2 |
-| **9.3.7** | **Verify that** policy violations trigger automated tool containment. | 3 |
+| **9.3.7** | **Verify that** external resources named in model output are verified against an approved allowlist or registry before the agent installs or invokes them. | 2 |
+| **9.3.8** | **Verify that** policy violations trigger automated tool containment. | 3 |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a new L2 requirement to C9.3 closing the slopsquatting gap: models confidently name packages or other external resources that don't exist, attackers pre-register those names with malware, and agents or AI-assisted workflows install them. Neither C7.2 (confidence/fallback) nor C6 (AI artifact supply chain) covers this case -C7.2 won't catch a confident hallucination and C6 covers model/dataset sourcing, not runtime resource invocation.

**9.3.7** (L2): Verify that external resources named in model output are verified against an approved allowlist or registry before the agent installs or invokes them.

Former 9.3.7 (policy violations trigger automated tool containment) renumbered to 9.3.8.

The scope is intentionally broad - packages, container images, API endpoints, or any external resource the model names - not just package names.