### PR TITLE
C10.2: add client-side OAuth iss validation (RFC 9207)

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -26,6 +26,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | **10.2.5** | **Verify that** MCP servers enforce access control on every tool invocation, validating that the user's access token authorizes both the requested tool and the specific argument values supplied. | 2 |
 | **10.2.6** | **Verify that** MCP servers ensure that all session artifacts are removed when a session terminates. | 2 |
 | **10.2.7** | **Verify that** MCP servers do not pass through access tokens received from clients to downstream APIs. | 2 |
+| **10.2.8** | **Verify that** MCP clients validate the `iss` parameter on OAuth authorization responses in accordance with RFC 9207 to prevent mix-up attacks across multiple authorization servers. | 2 |
 
 ---
 
@@ -60,3 +61,4 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 * [Model Context Protocol (MCP) Specification](https://modelcontextprotocol.io/)
 * [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html)
 * [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)
+* [RFC 9207: OAuth 2.0 Authorization Server Issuer Identification](https://www.rfc-editor.org/rfc/rfc9207)

--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -36,7 +36,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | :--: | --- | :---: |
 | **10.3.1** | **Verify that** authenticated, encrypted streamable-HTTP is used for MCP transport for remote services. | 1 |
 | **10.3.2** | **Verify that** stdio transport is permitted only in controlled local environments. | 1 |
-| **10.3.3** | **Verify that** MCP servers validate both the Origin header and the Host header independently on all HTTP-based transports to prevent DNS rebinding attacks.| 2 |
+| **10.3.3** | **Verify that** MCP servers validate both the Origin header and the Host header independently on all HTTP-based transports to prevent DNS rebinding attacks. | 2 |
 | **10.3.4** | **Verify that** MCP clients enforce a minimum acceptable protocol version and reject initialize responses that propose a version below that minimum. | 2 |
 | **10.3.5** | **Verify that** access tokens between the MCP client and server are sender-constrained using mTLS or DPoP. | 3 |
 


### PR DESCRIPTION
Adds 10.2.8 covering the client-side half of OAuth validation. 
C10.2.2 already covers what an MCP server validates on incoming access tokens. 
RFC 9207 covers what an MCP client has to validate on authorization responses coming back from the authorization server, specifically the `iss` parameter identifying which server issued the response.

The reason this matters for MCP is the deployment pattern: one client commonly connects to multiple MCP servers, each potentially using a different authorization server. 
Without `iss` validation, a malicious or compromised authorization server can substitute its authorization response for one belonging to a different server, and the client uses the code at the wrong place. 
That's the OAuth mix-up attack RFC 9207 was written to mitigate.

RFC 9207 was published in 2022, so this is closing a current gap rather than addressing anything specific to the 2026-07-28 MCP release candidate. One row added to the C10.2 table and one line in References, no modifications to existing controls.

Submitting under @jmanico's invitation in #823 to consider PRs for 1.0. cc @ottosulin @RicoKomenda