### PR TITLE
C9.3.6: clarity fix — "processing from tool outputs" → "processing of tool outputs"

### DIFF
--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -45,7 +45,7 @@ Constrain tool and plugin execution, loading, and outputs to prevent unauthorize
 | **9.3.3** | **Verify that** tool manifests declare required privileges, resource limits, and output validation requirements. | 2 |
 | **9.3.4** | **Verify that** the runtime enforces that tool manifests define required privileges, resource limits, and output validation. | 2 |
 | **9.3.5** | **Verify that** components processing untrusted data are isolated from tool-calling capabilities, ensuring that compromised data processing cannot trigger unauthorized tool invocations. | 2 |
-| **9.3.6** | **Verify that** there is architectural separation between untrusted data processing from tool outputs and agent operations. | 2 |
+| **9.3.6** | **Verify that** there is architectural separation between untrusted data processing of tool outputs and agent operations. | 2 |
 | **9.3.7** | **Verify that** external resources named in model output are verified against an approved allowlist or registry before the agent installs or invokes them. | 2 |
 | **9.3.8** | **Verify that** policy violations trigger automated tool containment. | 3 |
 


### PR DESCRIPTION
Tiny clarity fix for the final v1.0 pass, per @jmanico's last-pass call in #project-genai.

  9.3.6 currently reads "architectural separation between untrusted data processing from tool outputs and agent operations," where "between … from …  and" parses awkwardly. Changing "from" to "of" reads cleanly:

  "architectural separation between untrusted data processing of tool outputs and agent operations."