### PR TITLE
C10.1: add pre-execution consent and sandboxing controls for local MCP servers

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -12,6 +12,8 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | :--: | --- | :---: |
 | **10.1.1** | **Verify that** MCP components are obtained only from trusted sources and cryptographically verified. | 1 |
 | **10.1.2** | **Verify that** only allowlisted MCP servers are permitted. | 2 |
+| **10.1.3** | **Verify that** before a local MCP server is configured or launched (including one-click install flows), the MCP client displays the exact command and arguments to be executed without truncation and requires explicit human approval before execution. | 1 |
+| **10.1.4** | **Verify that** locally launched MCP servers run in a least-privilege sandbox with restricted file system, network, and system access. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -37,7 +37,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | :--: | --- | :---: |
 | **10.3.1** | **Verify that** authenticated, encrypted streamable-HTTP is used for MCP transport for remote services. | 1 |
 | **10.3.2** | **Verify that** stdio transport is permitted only in controlled local environments. | 1 |
-| **10.3.3** | **Verify that** MCP servers validate both the Origin header and the Host header independently on all HTTP-based transports to prevent DNS rebinding attacks.| 2 |
+| **10.3.3** | **Verify that** MCP servers validate both the Origin header and the Host header independently on all HTTP-based transports to prevent DNS rebinding attacks. | 2 |
 | **10.3.4** | **Verify that** MCP clients enforce a minimum acceptable protocol version and reject initialize responses that propose a version below that minimum. | 2 |
 | **10.3.5** | **Verify that** access tokens between the MCP client and server are sender-constrained using mTLS or DPoP. | 3 |
 


### PR DESCRIPTION
Mapping C10 against the MCP spec's Security Best Practices, the **Local MCP Server Compromise** section specifies controls C10 doesn't currently cover.

  The spec requires (MUST) that an MCP client supporting one-click local server configuration implement consent before executing commands: show the exact command without truncation, identify it as a code-execution operation, and require explicit approval. It also recommends (SHOULD) sandboxing local servers with least privilege.

  C10 today covers local-server integrity and transport — 10.1.1 (trusted sources + cryptographic verification), 10.1.2 (allowlisted servers), 10.3.2 (stdio in controlled local environments) — but none require pre-execution consent with full command display, or sandboxing of the launched server. These address arbitrary code execution from a malicious startup command.

  Reference: MCP Specification — Security Best Practices, "Local MCP Server Compromise" (Pre-Configuration Consent; sandboxing).