### PR TITLE
C10.1: add least-privilege sandboxing requirement for local MCP servers

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -12,6 +12,7 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 | :--: | --- | :---: |
 | **10.1.1** | **Verify that** MCP components are obtained only from trusted sources and cryptographically verified. | 1 |
 | **10.1.2** | **Verify that** only allow-listed MCP servers are permitted. | 2 |
+| **10.1.3** | **Verify that** locally launched MCP servers run in a least-privilege sandbox with restricted file system, network, and system access. | 2 |
 
 ---
 


### PR DESCRIPTION
Per your review on #974, splitting it into single requirements. This is the sandboxing control you flagged.

  Adds C10.1.3: locally launched MCP servers run in a least-privilege sandbox with restricted file system, network, and system access. Grounded in the MCP spec Security Best Practices (Local MCP Server Compromise, sandboxing).

  Note: the 10.3.3 spacing fix you asked for already landed in main via the editorial pass, so it isn't here. Passing on the pre-execution-consent one per your note.