### PR TITLE
docs: Minor changes to the wording of the MCP Security chapter

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -2,7 +2,7 @@
 
 ## Control Objective
 
-Ensure secure discovery, authentication, authorization, transport, and use of MCP-based tool and resource integrations to prevent context confusion, unauthorized tool invocation, or cross-tenant data exposure. This chapter covers MCP protocol-specific controls.
+Ensure secure discovery, authentication, authorization, transport, and use of MCP-based tool and resource integrations to prevent context confusion, unauthorized tool invocation, or cross-tenant data exposure. This chapter covers MCP-specific controls.
 
 ---
 
@@ -46,8 +46,8 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **10.4.1** | **Verify that** MCP tools/list and tool responses are validated via a prompt injection guardrail system to prevent indirect prompt injection. | 1 |
-| **10.4.2** | **Verify that** MCP tools/list and tool responses are schema validated before being injected into the model context. | 1 |
+| **10.4.1** | **Verify that** MCP tools/list requests and tool responses are validated via a prompt injection guardrail system to prevent indirect prompt injection. | 1 |
+| **10.4.2** | **Verify that** MCP tools/list requests and tool responses are schema validated before being injected into the model context. | 1 |
 | **10.4.3** | **Verify that** MCP servers reject unrecognized or oversized parameters in function calls. | 1 |
 | **10.4.4** | **Verify that** all MCP servers enforce strict schema validation. | 2 |
 | **10.4.5** | **Verify that** all MCP transports enforce maximum payload size limits. | 2 |


### PR DESCRIPTION
1. Removed "protocol" from the Control Objective section.  I felt that it was redundant, since MCP is Model Context Protocol

2. Change "tools/list" to "tools/list" requests to get more specific