### PR TITLE
C03: renumber C3.5 Pipeline Fine-Tuning requirements (3.6.x -> 3.5.x)

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -59,10 +59,10 @@ Fine-tuning pipelines are high-privilege operations that can alter deployed mode
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **3.6.1** | **Verify that** models used in RLHF fine-tuning are versioned and integrity-verified before use in a training run. | 2 |
-| **3.6.2** | **Verify that** RLHF training stages include automated detection of reward hacking or reward model over-optimization. | 3 |
-| **3.6.3** | **Verify that** in multi-stage fine-tuning pipelines, each stage's output is integrity-verified before the next stage is consumed. | 3 |
-| **3.6.4** | **Verify that** fine-tuning checkpoints are registered as distinct artifacts. | 3 |
+| **3.5.1** | **Verify that** models used in RLHF fine-tuning are versioned and integrity-verified before use in a training run. | 2 |
+| **3.5.2** | **Verify that** RLHF training stages include automated detection of reward hacking or reward model over-optimization. | 3 |
+| **3.5.3** | **Verify that** in multi-stage fine-tuning pipelines, each stage's output is integrity-verified before the next stage is consumed. | 3 |
+| **3.5.4** | **Verify that** fine-tuning checkpoints are registered as distinct artifacts. | 3 |
 
 ---
 

--- a/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x93-Appendix-D_AI_Security_Controls_Inventory.md
@@ -262,10 +262,10 @@ Manage model validation, deployment, rollback, and fine-tuning pipeline integrit
 | Rollout mechanisms with automated rollback triggers | C3.3.1 |
 | Complete model-state restoration on rollback | C3.3.2 |
 | Isolated runtime state for model versions running in parallel | C3.3.3 |
-| Versioned, integrity-verified RLHF reward models before a training run | C3.6.1 |
-| Detection of reward hacking or reward-model over-optimization in RLHF stages | C3.6.2 |
-| Stage-by-stage integrity verification in multi-stage fine-tuning pipelines | C3.6.3 |
-| Fine-tuning checkpoints registered as distinct artifacts | C3.6.4 |
+| Versioned, integrity-verified RLHF reward models before a training run | C3.5.1 |
+| Detection of reward hacking or reward-model over-optimization in RLHF stages | C3.5.2 |
+| Stage-by-stage integrity verification in multi-stage fine-tuning pipelines | C3.5.3 |
+| Fine-tuning checkpoints registered as distinct artifacts | C3.5.4 |
 
 **Common pitfalls:** not testing rollback before it is needed; leaving retired model artifacts in serving caches; treating reward models as static infrastructure rather than versioned, validated artifacts.
 


### PR DESCRIPTION
## What

Section **C3.5 Pipeline Fine-Tuning** contained requirements numbered **3.6.1–3.6.4** with no corresponding C3.6 section. This renumbers them to **3.5.1–3.5.4** to match the section heading, and updates the matching entries in Appendix D (`C3.6.x` → `C3.5.x`).

This was the only numbering inconsistency found in a full review of all 12 chapters in `1.0/en/`.

## Scope

Numbering correction only. No change to requirement scope, level, or intent. Markdownlint passes on both changed files.

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)