### PR TITLE
README: fix stale chapter titles and the C9.4.3 reference example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ Organizations should select a target level based on the risk profile of their AI
 2. [Input Validation](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C02-Input-Validation.md)
 3. [Model Lifecycle Management & Change Control](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C03-Model-Lifecycle-Management.md)
 4. [Infrastructure, Configuration & Deployment Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C04-Infrastructure.md)
-5. [Access Control & Identity](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C05-Access-Control-and-Identity.md)
-6. [Supply Chain Security for Models, Frameworks & Data](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C06-Supply-Chain.md)
+5. [Access Control & Identity for AI Components & Users](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C05-Access-Control-and-Identity.md)
+6. [Supply Chain Security for Models](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C06-Supply-Chain.md)
 7. [Model Behavior, Output Control & Safety Assurance](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C07-Model-Behavior.md)
 8. [Memory, Embeddings & Vector Database Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md)
-9. [Autonomous Orchestration & Agentic Action Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md)
+9. [Orchestration & Agentic Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md)
 10. [Model Context Protocol (MCP) Security](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C10-MCP-Security.md)
-11. [Adversarial Robustness & Attack Resistance](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C11-Adversarial-Robustness.md)
+11. [Adversarial Robustness](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C11-Adversarial-Robustness.md)
 12. [Monitoring, Logging & Anomaly Detection](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C12-Monitoring-and-Logging.md)
 
 ## Appendices
@@ -109,11 +109,11 @@ Organizations should select a target level based on the risk profile of their AI
 
 Each requirement has an identifier in the format `C<chapter>.<section>.<requirement>`, where each element is a number, for example `C9.4.3`.
 
-- The `C<chapter>` value corresponds to the chapter from which the requirement comes; for example, all `C9.#.#` requirements are from the 'Autonomous Orchestration & Agentic Action Security' chapter.
-- The `<section>` value corresponds to the section within that chapter where the requirement appears; for example, all `C9.4.#` requirements are in the 'Identity & Audit' section.
+- The `C<chapter>` value corresponds to the chapter from which the requirement comes; for example, all `C9.#.#` requirements are from the 'Orchestration & Agentic Security' chapter.
+- The `<section>` value corresponds to the section within that chapter where the requirement appears; for example, all `C9.4.#` requirements are in the 'Agent and Orchestrator Identity' section.
 - The `<requirement>` value identifies the specific requirement within the chapter and section; for example, `C9.4.3` which as of version 1.0 of this standard is:
 
-> Verify that audit logs are tamper-evident via append-only/WORM/immutable log store, cryptographic hash chaining where each record includes the hash of the prior record, or equivalent integrity guarantees that can be independently verified.
+> Verify that agent identity credentials rotate on a defined schedule.
 
 Since identifiers may change between versions of the standard, it is preferable for other documents, reports, or tools to use the following format: `v<version>-C<chapter>.<section>.<requirement>`, where 'version' is the AISVS version tag. For example: `v1.0-C9.4.3`.
 


### PR DESCRIPTION
Addresses the README items in #999. These are pure consistency fixes against the canonical chapter files in `1.0/en/`; no control scope, level, or intent changes.

### Chapter titles (Requirement Chapters list)
The list had four titles that no longer match the canonical chapter H1 headings:

| # | Was | Now (matches canonical H1) |
|---|---|---|
| 5 | Access Control & Identity | Access Control & Identity for AI Components & Users |
| 6 | Supply Chain Security for Models, Frameworks & Data | Supply Chain Security for Models |
| 9 | Autonomous Orchestration & Agentic Action Security | Orchestration & Agentic Security |
| 11 | Adversarial Robustness & Attack Resistance | Adversarial Robustness |

### "How to Reference" worked example
The single example that teaches the citation convention was stale end to end:
- chapter title corrected to "Orchestration & Agentic Security"
- C9.4 section name corrected from "Identity & Audit" to "Agent and Orchestrator Identity"
- C9.4.3 quote replaced with the actual text. The previous quote ("audit logs are tamper-evident via append-only/WORM…") exists nowhere in the standard; the real C9.4.3 is "Verify that agent identity credentials rotate on a defined schedule."

markdownlint passes.