### PR TITLE
Appendix A & C: fix broken control cross-references

### DIFF
--- a/1.0/en/0x90-Appendix-A_Glossary.md
+++ b/1.0/en/0x90-Appendix-A_Glossary.md
@@ -200,7 +200,7 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 
 * **OPA (Open Policy Agent)** – An open-source, general-purpose policy engine that evaluates authorization and admission control policies written in Rego, enabling unified policy enforcement across applications, APIs, and infrastructure.
 
-* **PDP (Policy Decision Point)** – A component in a policy enforcement architecture that evaluates authorization requests against defined policies and returns an allow or deny decision. In agentic AI systems, the PDP is isolated from the agent's execution environment to prevent a compromised agent from influencing its own authorization decisions. See also C9.7, C5.5.
+* **PDP (Policy Decision Point)** – A component in a policy enforcement architecture that evaluates authorization requests against defined policies and returns an allow or deny decision. In agentic AI systems, the PDP is isolated from the agent's execution environment to prevent a compromised agent from influencing its own authorization decisions. See also C5.2.5, C9.5.
 
 * **PII (Personally Identifiable Information)** – Any information that can be used to identify, contact, or locate a specific individual, either alone or combined with other data.
 
@@ -288,7 +288,7 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 
 * **Transfer Learning** – A technique where a model developed for one task is reused as the starting point for a model on a second task.
 
-* **Trust Boundary** – A point where data or control passes between zones that hold different levels of trust, such as from untrusted external input to a more privileged internal component. Flows crossing a trust boundary should be validated, authorized, and monitored, and content entering a higher-trust zone should be treated as untrusted until checked. See also: Appendix F.
+* **Trust Boundary** – A point where data or control passes between zones that hold different levels of trust, such as from untrusted external input to a more privileged internal component. Flows crossing a trust boundary should be validated, authorized, and monitored, and content entering a higher-trust zone should be treated as untrusted until checked.
 
 * **Vector Database** – A specialized database designed to store high-dimensional vectors (embeddings) and perform efficient similarity searches.
 

--- a/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
+++ b/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
@@ -46,7 +46,7 @@ Do not adopt an AI coding tool until it has been evaluated. Three areas in parti
 
 * **AC.2.1:** OWASP LLM Top 10 (2025) LLM01, LLM06; OWASP Agentic Top 10 (2026) ASI01, ASI02, ASI03; AISVS C9; MITRE ATLAS (Threat modeling).
 * **AC.2.2:** OWASP LLM Top 10 (2025) LLM03; OWASP Agentic Top 10 (2026) ASI04; NIST SSDF PO.1, PO.5; ISO/IEC 42001 Clause 8.
-* **AC.2.3:** MITRE ATLAS (Adversarial ML testing); AISVS C2.3; NIST AI 600-1 MEASURE.
+* **AC.2.3:** MITRE ATLAS (Adversarial ML testing); AISVS C2.1, C11.1; NIST AI 600-1 MEASURE.
 * **AC.2.4:** ISO/IEC 42001 Clause 9.2; NIST AI RMF GOVERN.
 
 ---
@@ -70,8 +70,8 @@ Two goals in this family. First: stop secrets, proprietary code, and personal da
 **Mappings & References:**
 
 * **AC.3.1:** OWASP LLM Top 10 (2025) LLM02 (Sensitive Information Disclosure); OWASP ASVS v5 V14 (Data Protection); ISO/IEC 27001:2022 A.8.12 (Data Leakage Prevention).
-* **AC.3.2:** AISVS C2.4; OWASP LLM Top 10 (2025) LLM02; NIST SSDF PW.3.
-* **AC.3.3:** AISVS C2.1, C2.4; OWASP LLM Top 10 (2025) LLM01; OWASP Agentic Top 10 (2026) ASI06; MITRE ATLAS (Indirect prompt injection).
+* **AC.3.2:** AISVS C2.2; OWASP LLM Top 10 (2025) LLM02; NIST SSDF PW.3.
+* **AC.3.3:** AISVS C2.1; OWASP LLM Top 10 (2025) LLM01; OWASP Agentic Top 10 (2026) ASI06; MITRE ATLAS (Indirect prompt injection).
 * **AC.3.4:** AISVS C2.1.2; OWASP LLM Top 10 (2025) LLM01; CISA Secure by Design.
 * **AC.3.5:** OWASP LLM Top 10 (2025) LLM10; AISVS C2.1.4.
 * **AC.3.6:** OWASP ASVS v5 V6 (Cryptography), V14 (Data Protection); ISO/IEC 27001:2022 A.8.24 (Use of Cryptography).
@@ -243,14 +243,14 @@ AI code-review bots, PR-comment bots, MCP-driven assistants (Model Context Proto
 
 **Mappings & References:**
 
-* **AC.11.1:** AISVS C2.1, C2.4; OWASP LLM Top 10 (2025) LLM01; OWASP Agentic Top 10 (2026) ASI01, ASI06.
-* **AC.11.2:** AISVS C9.7; OWASP LLM Top 10 (2025) LLM01; OWASP Agentic Top 10 (2026) ASI01.
-* **AC.11.3:** AISVS C9.6.4; OWASP LLM Top 10 (2025) LLM05; OWASP Agentic Top 10 (2026) ASI02, ASI05.
+* **AC.11.1:** AISVS C2.1; OWASP LLM Top 10 (2025) LLM01; OWASP Agentic Top 10 (2026) ASI01, ASI06.
+* **AC.11.2:** AISVS C2.1; OWASP LLM Top 10 (2025) LLM01; OWASP Agentic Top 10 (2026) ASI01.
+* **AC.11.3:** AISVS C7.1; OWASP LLM Top 10 (2025) LLM05; OWASP Agentic Top 10 (2026) ASI02, ASI05.
 * **AC.11.4:** AISVS C9.3; OWASP Agentic Top 10 (2026) ASI02, ASI03, ASI05; NIST SP 800-204D (Workload isolation).
-* **AC.11.5:** AISVS C9.6.4; OWASP ASVS v5 V4 (Access Control); OWASP Agentic Top 10 (2026) ASI02, ASI03.
+* **AC.11.5:** AISVS C9.2, C5.2.5; OWASP ASVS v5 V4 (Access Control); OWASP Agentic Top 10 (2026) ASI02, ASI03.
 * **AC.11.6:** OWASP ASVS v5 V8 (Logging & Error Handling); OWASP LLM Top 10 (2025) LLM02; ISO/IEC 27001:2022 A.8.15, A.8.16.
 * **AC.11.7:** GitHub Security Lab "Preventing pwn requests" series (Parts 1-4); OWASP Agentic Top 10 (2026) ASI01, ASI03, ASI09; OWASP CI/CD Top 10 CICD-SEC-01.
-* **AC.11.8:** MITRE ATLAS (Indirect prompt injection); AISVS C2.3; OWASP SAMM Security Testing (ST).
+* **AC.11.8:** MITRE ATLAS (Indirect prompt injection); AISVS C2.1, C11.1; OWASP SAMM Security Testing (ST).
 
 ---
 


### PR DESCRIPTION
Addresses the Glossary and Appendix C items in #999. Several cross-references pointed at requirement IDs that do not exist (left over from the old chapter taxonomy). Each is repointed to the existing control that matches the intent. No control text, scope, level, or intent changes.

### Appendix A (Glossary)
- **PDP entry:** `See also C9.7, C5.5.` → `See also C5.2.5, C9.5.` — C5.2.5 is the control "the policy decision point for agent authorization is isolated from the agent's execution environment," which is exactly what the entry describes; C9.5 is the agent-authorization section.
- **Trust Boundary entry:** removed the dangling `See also: Appendix F.` (appendices only go A–E; there is no clear replacement target).

### Appendix C (AISVS mapping column)
Repointed each broken `AISVS …` reference to the control matching the AC item's text:

| AC item | Was | Now | Rationale |
|---|---|---|---|
| AC.2.3 (adversarial robustness testing of tools) | C2.3 | C2.1, C11.1 | prompt-injection defenses + robustness testing |
| AC.3.2 (strip sensitive material from context) | C2.4 | C2.2 | content & policy screening |
| AC.3.3 (external context screened for injection) | C2.1, C2.4 | C2.1 | prompt-injection defenses (incl. indirect) |
| AC.11.1 (PR content untrusted; apply C2.1) | C2.1, C2.4 | C2.1 | item text already names C2.1 |
| AC.11.2 (bot prompts can't be modified by input) | C9.7 | C2.1 | instruction-hierarchy / injection defenses |
| AC.11.3 (structured, schema-validated output) | C9.6.4 | C7.1 | output format enforcement |
| AC.11.5 (privileged action via policy engine, not LLM) | C9.6.4 | C9.2, C5.2.5 | high-impact action approval + PDP isolation |
| AC.11.8 (continuous adversarial testing) | C2.3 | C2.1, C11.1 | prompt-injection defenses + robustness testing |

A few of these (notably AC.11.2) had no single perfect target; I chose the closest existing control and am happy to adjust on review.

### Note on #999
The issue also flagged the glossary's Sender-Constrained Token reference to C10.3.5 as broken. That was a false positive — C10.3.5 does exist ("access tokens between the MCP client and server are sender-constrained using mTLS or DPoP"). It is left unchanged. I'll correct the issue.

markdownlint and cspell both pass.
