### PR TITLE
Appendix A: restore alphabetical order of four glossary entries

### DIFF
--- a/1.0/en/0x90-Appendix-A_Glossary.md
+++ b/1.0/en/0x90-Appendix-A_Glossary.md
@@ -2,14 +2,6 @@
 
 This comprehensive glossary provides definitions of key AI, ML, and security terms used throughout the AISVS to ensure clarity and common understanding.
 
-* **Labeling** – The process of assigning classification tags, annotations, or ground-truth values to training data records or fields, performed by human annotators, automated systems, or a combination of both. Labeling encompasses the full annotation pipeline including annotator identity tracking, label integrity verification, and preference data collection for RLHF.
-
-* **Scanned** – Subjected to automated security analysis by a tool, integrated into a pipeline or controlled process (as opposed to an ad-hoc or manual check).
-
-* **Sensitive Fields** – Individual data attributes, columns, or record elements within a dataset that contain personal, regulated, or otherwise protected information (e.g., names, identifiers, health data, financial data, or biometric data). Sensitive fields require access controls, minimization, redaction, or encryption. In AI systems, sensitive field detection is required before data is used for training, embedding, or inference to prevent unintentional leakage or memorization.
-
-* **Zero Standing Privilege (ZSP)** – A security principle requiring that no user, service account, or agent holds persistent elevated permissions. All privileged access is granted just in time for a specific task, scoped to the minimum necessary rights, and automatically revoked after a defined maximum session duration or upon task completion.
-
 * **Adapter** – A lightweight module (e.g., LoRA, QLoRA) added to a pre-trained model to specialize its behavior on a specific task without modifying the original weights.
 
 * **Adversarial Example** – An input deliberately crafted to cause an AI model to make a mistake, often by adding subtle perturbations imperceptible to humans.
@@ -152,6 +144,8 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 
 * **KMS (Key Management Service)** – A managed service for creating, storing, rotating, and controlling access to cryptographic keys used to protect data and artifacts.
 
+* **Labeling** – The process of assigning classification tags, annotations, or ground-truth values to training data records or fields, performed by human annotators, automated systems, or a combination of both. Labeling encompasses the full annotation pipeline including annotator identity tracking, label integrity verification, and preference data collection for RLHF.
+
 * **l-diversity** – A privacy property extending k-anonymity that requires each equivalence class to contain at least l distinct values for sensitive attributes, preventing attribute disclosure.
 
 * **Least Privilege** – The security principle of granting only the minimum necessary access rights for users and processes.
@@ -234,6 +228,8 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 
 * **SBOM (Software Bill of Materials)** – A formal record containing the details and supply chain relationships of software components used in building an application. See also AI BOM for model-specific artifacts.
 
+* **Scanned** – Subjected to automated security analysis by a tool, integrated into a pipeline or controlled process (as opposed to an ad-hoc or manual check).
+
 * **SCVS (Software Component Verification Standard)** – An OWASP framework for verifying the security properties of software components, referenced by AISVS for supply chain integrity controls applicable to AI frameworks, libraries, and model dependencies.
 
 * **Secure Boot** – A firmware security feature that verifies the cryptographic signature of each component in the boot chain before execution, preventing unauthorized or tampered software from loading.
@@ -245,6 +241,8 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 * **SELinux (Security-Enhanced Linux)** – A Linux kernel security module that provides mandatory access controls using security policies, used to enforce fine-grained process isolation for AI workloads.
 
 * **Sender-Constrained Token** – An access token cryptographically bound to the legitimate client so it cannot be used by another party if stolen, through mechanisms such as mTLS or DPoP. AISVS requires sender-constrained tokens between MCP clients and servers (C10.3.5). See also: DPoP, mTLS.
+
+* **Sensitive Fields** – Individual data attributes, columns, or record elements within a dataset that contain personal, regulated, or otherwise protected information (e.g., names, identifiers, health data, financial data, or biometric data). Sensitive fields require access controls, minimization, redaction, or encryption. In AI systems, sensitive field detection is required before data is used for training, embedding, or inference to prevent unintentional leakage or memorization.
 
 * **Shadow Deployment** – A deployment pattern in which a new model version receives a copy of live production traffic alongside the current version without serving responses to end users, enabling behavioral comparison and safety validation before promotion.
 
@@ -303,5 +301,7 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 * **WORM (Write-Once-Read-Many)** – A storage technology that prevents modification or deletion of data after it is written, used for tamper-evident audit logs and backup protection.
 
 * **Zero-Day Vulnerability** – A previously unknown vulnerability that attackers can exploit before developers create and deploy a patch.
+
+* **Zero Standing Privilege (ZSP)** – A security principle requiring that no user, service account, or agent holds persistent elevated permissions. All privileged access is granted just in time for a specific task, scoped to the minimum necessary rights, and automatically revoked after a defined maximum session duration or upon task completion.
 
 * **Zero-Trust** – A security model that assumes no implicit trust for any user, device, or network, requiring continuous verification of identity and authorization for every access request.


### PR DESCRIPTION
Addresses the remaining MINOR glossary item from #999.

Four entries had been prepended to the top of the glossary instead of inserted in alphabetical position. This moves each to its correct spot; the definition text is unchanged (pure relocation, 8 insertions / 8 deletions):

- **Labeling** → between *KMS* and *l-diversity*
- **Scanned** → between *SBOM* and *SCVS*
- **Sensitive Fields** → between *Sender-Constrained Token* and *Shadow Deployment*
- **Zero Standing Privilege (ZSP)** → between *Zero-Day Vulnerability* and *Zero-Trust*

The glossary now opens with *Adapter*. markdownlint and cspell pass.

### Scope notes (the other two MINOR items from #999)
- **Appendix C title:** left unchanged. The appendix's own H1, the README, and the Preface all already say "AI-Assisted Secure Coding"; only the filename slug differs (`AI_for_Code_Generation`), and renaming a published file would break inbound links for no reader benefit.
- **"Working Draft" label** (`0x01-Frontispiece.md`): left unchanged. It is still accurate pre-release; this is a status flip to make at the actual 1.0 release, not a consistency cleanup.

A few other glossary entries sit in debatable order due to punctuation/case (e.g. *Embedding Inversion* vs *Embeddings*, the *Sec…* cluster, *stdio*); these are pre-existing, were not flagged in the audit, and are left as-is to keep this change tightly scoped.
