### PR TITLE
Fix all four v1.0 release blockers (lint, PDF version, security link, titlepage logo)

### DIFF
--- a/1.0/en/0x00-Header.yaml
+++ b/1.0/en/0x00-Header.yaml
@@ -1,5 +1,5 @@
 ---
-    title: "Artificial Intelligence Security Verification Standard .9"
+    title: "Artificial Intelligence Security Verification Standard 1.0"
     subtitle: "Working Draft Pre-Release"
     date: June 2026
     titlepage: true

--- a/1.0/en/0x10-C04-Infrastructure.md
+++ b/1.0/en/0x10-C04-Infrastructure.md
@@ -13,7 +13,7 @@ Isolate untrusted AI models in secure sandboxes and protect sensitive AI workloa
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------ | :---: |
 | **4.1.1** | **Verify that** AI models execute in isolated sandboxes. | 1 |
-| **4.1.2** | **Verify that** model artifact loading enforces an explicit allowlist of serialization formats that do not permit arbitrary code execution during deserialization.| 1 |
+| **4.1.2** | **Verify that** model artifact loading enforces an explicit allowlist of serialization formats that do not permit arbitrary code execution during deserialization. | 1 |
 | **4.1.3** | **Verify that** workload attestation is performed before model loading to provide proof that the execution environment has not been tampered with. | 3 |
 | **4.1.4** | **Verify that** confidential inference services protect model weights during runtime through isolated execution environments. | 3 |
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Each stable release of AISVS is published as a numbered folder in this repositor
 
 We welcome contributions from the community. Please [open an issue](https://github.com/OWASP/AISVS/issues) to report bugs or suggest improvements. We may ask you to [submit a pull request](https://github.com/OWASP/AISVS/pulls) based on the discussion.
 
-To report a security issue with the AISVS project itself, please follow the [Security Policy](Security.md).
+To report a security issue with the AISVS project itself, please follow the [Security Policy](SECURITY.md).
 
 ## License
 


### PR DESCRIPTION
Fixes all four release blockers from #1004. All changes are correctness/whitespace/asset only — no scope, level, or intent change to any control.

1. **markdownlint CI failure** — `1.0/en/0x10-C04-Infrastructure.md` req 4.1.2 was missing the space before the trailing pipe (`deserialization.| 1 |`), tripping `MD060/table-column-style`. The lint gate was red on `main`; it now passes. Added one space.
2. **PDF version string** — `1.0/en/0x00-Header.yaml` title read `…Standard .9`; corrected to `…Standard 1.0` so the release PDF cover is branded correctly.
3. **Broken README link** — `README.md` linked `[Security Policy](Security.md)`; the file is `SECURITY.md`. Fixed (was broken on case-sensitive GitHub).
4. **Missing PDF titlepage logo** — `0x00-Header.yaml` references `images/owasp_logo_1c_notext.png`, which did not exist. Added the file, sourced from the sibling OWASP/ASVS project (`5.0/images/owasp_logo_1c_notext.png`) — the same asset ASVS uses on its PDF cover. Valid PNG, 2667×817.

Verification: `npx markdownlint-cli` and `npx cspell` both pass on the touched files (markdownlint was exit 1 before this change, now exit 0).

### Not in this PR (need maintainer input — see #1004)
- Missing `tools/` build pipeline / no PDF-release workflow.
- The release-day "Working Draft" flips and pending artifact links (tracked in #1003).
