### PR TITLE
Fix glossary C07 reference and C02 section separator (no scope/intent change)

### DIFF
--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -23,6 +23,8 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | **2.1.7** | **Verify that** reserved special tokens are encoded as literal characters and cannot be injected into the model context. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
+---
+
 ## C2.2 Content & Policy Screening
 
 Syntactically valid prompts may request disallowed content such as instructions that violate policies, harmful content, or restricted material. Input-side content screening prevents such prompts from reaching the model.

--- a/1.0/en/0x90-Appendix-A_Glossary.md
+++ b/1.0/en/0x90-Appendix-A_Glossary.md
@@ -272,7 +272,7 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 
 * **Synthetic Data** – Artificially generated data that preserves the statistical properties of real data while containing no actual individual records, used to protect privacy during model training and testing.
 
-* **System Prompt** – Instructions supplied to a model by the application or developer that establish its role, constraints, and policies, separate from user input. System prompt content is sensitive: disclosure can reveal guardrails and aid evasion, so AISVS requires output filters to block its leakage (C07). See also: Prompt Template, Context Window.
+* **System Prompt** – Instructions supplied to a model by the application or developer that establish its role, constraints, and policies, separate from user input. System prompt content is sensitive: disclosure can reveal guardrails and aid evasion, so AISVS requires output filters to block its leakage (C7.3.2). See also: Prompt Template, Context Window.
 
 * **TEE (Trusted Execution Environment)** – A hardware-isolated processing environment that provides confidentiality and integrity guarantees for code and data, protecting them from the host operating system and other tenants.
 


### PR DESCRIPTION
Two patch-level fixes from the v1.0 release-readiness audit (#1006). Both are editorial with **no change to any requirement's scope, level, or intent**, and the CI markdownlint + cspell checks pass on both files.

### Changes

1. **Glossary cross-reference (`0x90-Appendix-A_Glossary.md`).** The "System Prompt" entry cited `(C07)`, which is not the citation convention and is imprecise. Repointed to the specific requirement **C7.3.2** ("output filters detect and block responses that disclose system prompt content"), which is exactly what the sentence describes.

2. **C02 section separator (`0x10-C02-Input-Validation.md`).** Added the missing `---` horizontal rule between section C2.1 and the `## C2.2` header, matching every other section transition in the standard.

Refs #1006
