### PR TITLE
fix: drop Working Draft label from Frontispiece (closes #1003)

### DIFF
--- a/1.0/en/0x01-Frontispiece.md
+++ b/1.0/en/0x01-Frontispiece.md
@@ -8,7 +8,7 @@ Every requirement in AISVS has been developed from the ground up to reflect the 
 
 ## Copyright and License
 
-Version 1.0 (Working Draft), 2026
+Version 1.0, 2026
 
 [![CC BY-SA 4.0](https://licensebuttons.net/l/by-sa/4.0/88x31.png)](https://creativecommons.org/licenses/by-sa/4.0/)
 


### PR DESCRIPTION
## Summary

This PR implements the release-day action tracked in #1003 by removing the **"(Working Draft)"** label from the AISVS 1.0 frontispiece.

The frontispiece currently states:

> Version 1.0 (Working Draft), 2026

This change updates it to:

> Version 1.0, 2026

to reflect the final 1.0 release status.

## Changes

* Updated `1.0/en/0x01-Frontispiece.md`
* Removed the `(Working Draft)` designation from the version line

## Related Issue

Closes #1003

## Notes

This change only addresses the frontispiece release-status update described in the release-day checklist. No normative requirements, control text, numbering, references, or appendices were modified.
