### PR TITLE
Appendix E: generate contributor list from repo history

### DIFF
--- a/.github/workflows/config/local-custom.txt
+++ b/.github/workflows/config/local-custom.txt
@@ -151,3 +151,12 @@ Pearson
 f-DP
 reconstructable
 homoglyphs
+Mohamad
+Khalil
+Yossif
+Sandhya
+Andalis
+Mayur
+Agnihotri
+Braiterman
+Treyrob

--- a/1.0/en/0x94-Appendix-E_Contributors.md
+++ b/1.0/en/0x94-Appendix-E_Contributors.md
@@ -1,23 +1,72 @@
 # Appendix E: Contributors
 
-We gratefully acknowledge the contributions of everyone who has submitted pull
-requests, opened issues, or provided reviews since the start of the AISVS
-project.
+We gratefully acknowledge everyone who has helped build AISVS through pull
+requests, commits, issues, and reviews.
 
-If you are aware of any mistakes or would like your name to appear differently,
+The lists below are ordered by the volume of content each person authored in the
+standard, measured as bytes added across all non-merge commits to `1.0/` and the
+project's root documents, consolidated across each contributor's Git identities.
+Automation-generated material (the `research/` wiki) and build artifacts are
+excluded. This measure reflects authored and edited text; it does not fully
+capture contributors whose impact came mainly through reviews and issue
+discussion, and we thank them as well.
+
+If a name or handle is wrong or missing, or you would like it shown differently,
 please open an issue or pull request.
 
 ---
 
 ## Project Leads
 
-* Jim Manico ([jmanico](https://github.com/jmanico))
-* Rico Komenda ([RicoKomenda](https://github.com/RicoKomenda))
-* Otto Sulin ([ottosulin](https://github.com/ottosulin))
-* Russ Memisyazici ([vtknightmare](https://github.com/vtknightmare))
+| Contributor | Bytes added |
+| --- | --: |
+| Jim Manico ([jmanico](https://github.com/jmanico)) | 6,800,541 |
+| Otto Sulin ([ottosulin](https://github.com/ottosulin)) | 1,038,370 |
+| Rico Komenda ([RicoKomenda](https://github.com/RicoKomenda)) | 188,704 |
+| Russ Memisyazici ([vtknightmare](https://github.com/vtknightmare)) | 90,146 |
+| Raza Sharif ([razashariff](https://github.com/razashariff)) | 15,262 |
 
 ---
 
 ## Contributors
 
-We will generate the contributor list from automation (based on GitHub history) before we release 1.0 the end of June 2026!
+_Ordered by contribution to the standard._
+
+| Contributor | Bytes added |
+| --- | --: |
+| b1oo ([b1oo](https://github.com/b1oo)) | 78,264 |
+| Jim Schwoebel | 47,185 |
+| Vineeth Sai Narajala | 21,200 |
+| RL Thornton | 19,926 |
+| Almog Langleben ([almogbhl](https://github.com/almogbhl)) | 16,977 |
+| Khalid Al-Amri ([khalidwalidalamri](https://github.com/khalidwalidalamri)) | 13,648 |
+| Barno Kaharova | 10,717 |
+| Joshua Beck ([Josh-Beck](https://github.com/Josh-Beck)) | 10,156 |
+| Vishal Jindal ([vishaljindal1990](https://github.com/vishaljindal1990)) | 5,765 |
+| Stefan Aeschbacher | 4,021 |
+| DotDotSlash ([DotDotSlash](https://github.com/DotDotSlash)) | 3,259 |
+| Tetsuo Seto | 3,231 |
+| Tametomo | 3,116 |
+| Martin Bjerke | 2,953 |
+| Deepak Pandey ([deepakrpandey12](https://github.com/deepakrpandey12)) | 2,748 |
+| RogueValley ([RogueValley](https://github.com/RogueValley)) | 2,676 |
+| emmanuelgjr ([emmanuelgjr](https://github.com/emmanuelgjr)) | 2,235 |
+| Cyril Mathew | 1,919 |
+| mattijs moens | 1,735 |
+| Jerry Hoff ([jerryhoff](https://github.com/jerryhoff)) | 1,554 |
+| Ronald Robertson ([Treyrob3](https://github.com/Treyrob3)) | 1,414 |
+| Vatsal Gupta | 1,301 |
+| Zoe Braiterman | 1,118 |
+| Ralph Andalis | 932 |
+| Uncle Joe ([sydseter](https://github.com/sydseter)) | 607 |
+| Stuart Small | 479 |
+| Boone Carlson | 450 |
+| kattn ([kattn](https://github.com/kattn)) | 408 |
+| Joe-B-Security ([Joe-B-Security](https://github.com/Joe-B-Security)) | 389 |
+| hackwither ([hackwither](https://github.com/hackwither)) | 332 |
+| Mayur Agnihotri | 296 |
+| Mohamad Khalil Yossif ([MohamadKhalilYossif](https://github.com/MohamadKhalilYossif)) | 294 |
+| William Jawad ([wiljav](https://github.com/wiljav)) | 192 |
+| Hari Mukundhan | 137 |
+| Sandhya | 43 |
+| Starr Brown ([mamicidal](https://github.com/mamicidal)) | 7 |


### PR DESCRIPTION
## What

Replaces the placeholder in Appendix E with the real contributor list, generated from repository history. This addresses the empty-contributor-list release blocker tracked in #1008.

## How the list was built (fair-method)

- **Identities consolidated.** Many contributors committed under 2–4 different name/email combos (Rico, Otto, Russ, Khalid, Raza, Vishal, Deepak, Boone, Almog, Vatsal). A mailmap merges each person into a single entry.
- **Generated content excluded.** The automation-generated `research/` wiki and bot-produced build artifacts are left out; counting their large bulk commits would distort the picture.
- **Scope = the standard.** Bytes added across all non-merge commits to `1.0/**` and the project's root documents.
- **Gross additions, not net.** Editors and contributors whose text was later revised still receive credit; a net measure would penalize valuable deletion/restructuring work.

The appendix note states the methodology and explicitly thanks contributors whose impact came mainly through reviews and issue discussion, which commit metrics cannot capture.

## Notes for reviewers

- Project Leads and Contributors are each ordered by bytes added, with the count shown.
- GitHub handles are linked only where they could be derived with confidence (GitHub noreply emails plus well-known accounts). Entries without a confident handle are listed by name only; contributors are invited in the appendix text to open a PR to correct their entry.
- New contributor surnames were added to `.github/workflows/config/local-custom.txt` so spell-check passes.

## Checks

- `markdownlint` clean on the changed file.
- `cspell` clean on the changed file.

This branch intentionally contains **only** the two contributor-related files and none of the unrelated in-progress chapter edits.
