### PR TITLE
Curate each chapter to 4-5 authoritative references; rebuild Appendix B

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -51,4 +51,5 @@ Training data quality and security assurance controls help detect corruption, po
 * [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
 * [EU AI Act: Article 10: Data & Data Governance](https://artificialintelligenceact.eu/article/10/)
 * [CISA Advisory: Securing Data for AI Systems](https://www.cisa.gov/news-events/cybersecurity-advisories/aa25-142a)
-* [OpenAI Privacy Center: Data Deletion Controls](https://privacy.openai.com/policies?modal=take-control)
+* [MITRE ATLAS: Poison Training Data (AML.T0020)](https://atlas.mitre.org/techniques/AML.T0020)
+* [ISO/IEC 42001:2023 Artificial Intelligence Management System](https://www.iso.org/standard/42001)

--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -43,4 +43,4 @@ Syntactically valid prompts may request disallowed content such as instructions 
 * [OWASP LLM01:2025 Prompt Injection](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)
 * [LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html)
 * [MITRE ATLAS: Adversarial Input Detection](https://atlas.mitre.org/mitigations/AML.M0015)
-* [Mitigate jailbreaks and prompt injections](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks)
+* [MITRE ATLAS: LLM Prompt Injection (AML.T0051)](https://atlas.mitre.org/techniques/AML.T0051)

--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -70,6 +70,6 @@ Fine-tuning pipelines are high-privilege operations that can alter deployed mode
 
 * [MITRE ATLAS](https://atlas.mitre.org/)
 * [OWASP AI Testing Guide](https://owasp.org/www-project-ai-testing-guide/)
-* [MLOps Principles](https://ml-ops.org/content/mlops-principles)
-* [Reinforcement fine-tuning](https://platform.openai.com/docs/guides/reinforcement-fine-tuning)
-* [What is AI adversarial robustness?: IBM Research](https://research.ibm.com/blog/securing-ai-workflows-with-adversarial-robustness)
+* [NIST SP 800-218A: Secure Software Development Practices for Generative AI](https://csrc.nist.gov/pubs/sp/800/218/a/final)
+* [ISO/IEC 42001:2023 Artificial Intelligence Management System](https://www.iso.org/standard/42001)
+* [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)

--- a/1.0/en/0x10-C04-Infrastructure.md
+++ b/1.0/en/0x10-C04-Infrastructure.md
@@ -50,6 +50,6 @@ Secure distributed AI deployments including edge computing, federated learning, 
 ## References
 
 * [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
-* [NVIDIA Multi-Instance GPU (MIG) Documentation](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/)
+* [NIST SP 800-190: Application Container Security Guide](https://csrc.nist.gov/pubs/sp/800/190/final)
+* [NSA/CISA Kubernetes Hardening Guidance](https://www.cisa.gov/news-events/alerts/2022/03/15/updated-kubernetes-hardening-guide)
 * [Confidential Computing Consortium](https://confidentialcomputing.io/)
-* [ARM TrustZone for AI](https://www.arm.com/technologies/trustzone-for-cortex-a)

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -48,4 +48,6 @@ Prevent cross-tenant information leakage through AI-specific shared infrastructu
 
 * [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)
 * [NIST SP 800-63-3: Digital Identity Guidelines](https://csrc.nist.gov/pubs/sp/800/63/3/final)
+* [OAuth 2.1 (IETF Draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-11)
+* [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)
 * [I Know What You Asked: Prompt Leakage via KV-Cache Sharing in Multi-Tenant LLM Serving (NDSS 2025)](https://www.ndss-symposium.org/ndss-paper/i-know-what-you-asked-prompt-leakage-via-kv-cache-sharing-in-multi-tenant-llm-serving/)

--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -59,3 +59,6 @@ Ensure RAG-grounded outputs are traceable to their source documents and that cit
 
 * [OWASP LLM05:2025 Improper Output Handling](https://genai.owasp.org/llmrisk/llm052025-improper-output-handling/)
 * [OWASP LLM06:2025 Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/)
+* [OWASP LLM09:2025 Misinformation](https://genai.owasp.org/llmrisk/llm092025-misinformation/)
+* [NIST AI 600-1: Generative AI Profile (AI RMF Companion)](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf)
+* [MITRE ATLAS](https://atlas.mitre.org/)

--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -50,6 +50,4 @@ Retention and revocation must be explicit and enforceable for memory and RAG ind
 * [OWASP LLM04:2025 Data and Model Poisoning](https://genai.owasp.org/llmrisk/llm042025-data-and-model-poisoning/)
 * [OWASP LLM02:2025 Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/)
 * [MITRE ATLAS: RAG Poisoning](https://atlas.mitre.org/techniques/AML.T0070)
-* [MITRE ATLAS: False RAG Entry Injection](https://atlas.mitre.org/techniques/AML.T0071)
 * [MITRE ATLAS: Infer Training Data Membership](https://atlas.mitre.org/techniques/AML.T0024.000)
-* [MITRE ATLAS: Invert AI Model](https://atlas.mitre.org/techniques/AML.T0024.001)

--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -96,16 +96,8 @@ Provide shutdown and graceful degradation paths under human control, with mechan
 
 ## References
 
-* [OWASP LLM06:2025 Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/)
-* [OWASP LLM10:2025 Unbounded Consumption](https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/)
 * [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
-* [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)
 * [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026)
-* [OpenAPI x-agent-trust Extension (OAI Extensions Registry)](https://spec.openapis.org/registry/extension/x-agent-trust.html)
-* [MITRE ATLAS: Human In-the-Loop for AI Agent Actions](https://atlas.mitre.org/mitigations/AML.M0029)
+* [OWASP LLM06:2025 Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/)
 * [NIST AI 100-1: AI Risk Management Framework (AI RMF 1.0)](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-1.pdf)
-* [NIST AI 600-1: Generative AI Profile (AI RMF Companion)](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf)
-* [ISO/IEC 42001:2023 Artificial Intelligence Management System](https://www.iso.org/standard/42001)
-* [ISO/IEC 23894:2023 Artificial Intelligence Risk Management Guidance](https://www.iso.org/standard/77304.html)
 * [Regulation (EU) 2024/1689 (EU AI Act), Article 14: Human Oversight](https://eur-lex.europa.eu/eli/reg/2024/1689/oj)
-* [OECD Recommendation on Artificial Intelligence](https://legalinstruments.oecd.org/en/instruments/OECD-LEGAL-0449)

--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -62,3 +62,5 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 * [Model Context Protocol (MCP) Specification](https://modelcontextprotocol.io/)
 * [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html)
 * [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)
+* [OAuth 2.1 (IETF Draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-11)
+* [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026)

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -61,13 +61,8 @@ Identify and neutralize manipulated, backdoored, or adversarial data entering th
 
 ## References
 
-* [OWASP LLM02:2025 Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/)
-* [OWASP LLM04:2025 Data and Model Poisoning](https://genai.owasp.org/llmrisk/llm042025-data-and-model-poisoning/)
-* [MITRE ATLAS: Infer Training Data Membership](https://atlas.mitre.org/techniques/AML.T0024.000)
-* [MITRE ATLAS: Invert ML Model](https://atlas.mitre.org/techniques/AML.T0024.001)
-* [MITRE ATLAS: Extract ML Model](https://atlas.mitre.org/techniques/AML.T0024.002)
-* [MITRE ATLAS: Backdoor ML Model](https://atlas.mitre.org/techniques/AML.T0018)
 * [NIST AI 100-2e2023 Adversarial Machine Learning: A Taxonomy and Terminology of Attacks and Mitigations](https://csrc.nist.gov/pubs/ai/100/2/e2023/final)
-* [MITRE ATLAS: Active Scanning (AML.T0006)](https://atlas.mitre.org/techniques/AML.T0006)
+* [OWASP LLM04:2025 Data and Model Poisoning](https://genai.owasp.org/llmrisk/llm042025-data-and-model-poisoning/)
 * [MITRE ATLAS: Evade ML Model (AML.T0015)](https://atlas.mitre.org/techniques/AML.T0015)
-* [MITRE ATLAS Case Study: Bypass Cylance's AI Malware Detection (AML.CS0003)](https://atlas.mitre.org/studies/AML.CS0003)
+* [MITRE ATLAS: Backdoor ML Model](https://atlas.mitre.org/techniques/AML.T0018)
+* [MITRE ATLAS: Extract ML Model](https://atlas.mitre.org/techniques/AML.T0024.002)

--- a/1.0/en/0x10-C12-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C12-Monitoring-and-Logging.md
@@ -118,7 +118,5 @@ Ensure that the provenance and change history of training data, model artifacts,
 * [OWASP Top 10 for LLM Applications 2025](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 * [MITRE ATLAS - Adversarial Threat Landscape for AI Systems](https://atlas.mitre.org/)
 * [NIST AI Risk Management Framework (AI RMF 1.0)](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-1.pdf)
-* [NIST AI 100-1 - Artificial Intelligence Risk Management Framework](https://doi.org/10.6028/NIST.AI.100-1)
-* [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
-* [Microsoft Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)
 * [NIST SP 800-207 Zero Trust Architecture](https://nvlpubs.nist.gov/nistpubs/specialpublications/NIST.SP.800-207.pdf)
+* [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)

--- a/1.0/en/0x91-Appendix-B_References.md
+++ b/1.0/en/0x91-Appendix-B_References.md
@@ -4,34 +4,45 @@ The following standards, frameworks, and publications are referenced throughout 
 
 ## Standards and Frameworks
 
-* [NIST AI Risk Management Framework 1.0](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf)
+* [NIST AI Risk Management Framework 1.0 (AI 100-1)](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf)
+* [NIST AI 600-1: Generative AI Profile](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf)
+* [NIST AI 100-2e2023: Adversarial Machine Learning Taxonomy and Terminology](https://csrc.nist.gov/pubs/ai/100/2/e2023/final)
 * [NIST SP 800-218A: Secure Software Development Practices for Generative AI](https://csrc.nist.gov/pubs/sp/800/218/a/final)
+* [NIST SP 800-190: Application Container Security Guide](https://csrc.nist.gov/pubs/sp/800/190/final)
+* [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)
+* [NIST SP 800-63-3: Digital Identity Guidelines](https://csrc.nist.gov/pubs/sp/800/63/3/final)
 * [ISO/IEC 42001:2023: AI Management Systems Requirements](https://www.iso.org/standard/42001)
+* [NSA/CISA Kubernetes Hardening Guidance](https://www.cisa.gov/news-events/alerts/2022/03/15/updated-kubernetes-hardening-guide)
+* [CISA Advisory: Securing Data for AI Systems](https://www.cisa.gov/news-events/cybersecurity-advisories/aa25-142a)
+* [CISA Software Bill of Materials (SBOM)](https://www.cisa.gov/sbom)
+* [Confidential Computing Consortium](https://confidentialcomputing.io/)
+
+## OWASP Resources
+
 * [OWASP Application Security Verification Standard (ASVS)](https://owasp.org/www-project-application-security-verification-standard/)
 * [OWASP Top 10 for Large Language Model Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
-* [OWASP Secure Coding Practices: Quick Reference Guide](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/)
+* [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026)
+* [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
+* [OWASP AI Testing Guide](https://owasp.org/www-project-ai-testing-guide/)
+* [OWASP AI Bill of Materials (AIBOM)](https://genai.owasp.org/owasp-aibom/)
+* [OWASP LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html)
+* [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html)
+
+## Threat Frameworks
+
 * [MITRE ATLAS: Adversarial Threat Landscape for AI Systems](https://atlas.mitre.org/)
 
 ## Specifications and Protocols
 
+* [Model Context Protocol (MCP) Specification](https://modelcontextprotocol.io/)
 * [OAuth 2.1 (IETF Draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-11)
 * [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)
-* [SPDX (Software Package Data Exchange)](https://spdx.dev/)
 * [CycloneDX Bill of Materials Standard](https://cyclonedx.org/)
-* [Model Context Protocol (MCP) Specification](https://modelcontextprotocol.io/)
 
-## Cryptographic Standards
+## Regulation
 
-* [FIPS 140-3: Security Requirements for Cryptographic Modules](https://csrc.nist.gov/publications/detail/fips/140/3/final)
-* [NIST Post-Quantum Cryptography Standards](https://csrc.nist.gov/projects/post-quantum-cryptography)
-
-## Privacy and Data Protection
-
-* [General Data Protection Regulation (GDPR)](https://gdpr-info.eu/)
 * [EU Artificial Intelligence Act](https://artificialintelligenceact.eu/)
-* [California Consumer Privacy Act (CCPA)](https://oag.ca.gov/privacy/ccpa)
 
-## Policy Engines
+## Academic Research
 
-* [Open Policy Agent (OPA)](https://www.openpolicyagent.org/)
-* [Cedar Policy Language](https://www.cedarpolicy.com/)
+* [Prompt Leakage via KV-Cache Sharing in Multi-Tenant LLM Serving (NDSS 2025)](https://www.ndss-symposium.org/ndss-paper/i-know-what-you-asked-prompt-leakage-via-kv-cache-sharing-in-multi-tenant-llm-serving/)


### PR DESCRIPTION
Closes #1010.

Standardizes the reference section of every requirement chapter on **4–5 authoritative references** and rebuilds Appendix B as the deduplicated roll-up of that set.

## What changed

- **Authoritative only.** Removed vendor product docs and blogs and substituted authoritative equivalents:
  - C1: dropped OpenAI Privacy Center → added MITRE ATLAS (Poison Training Data, AML.T0020) and ISO/IEC 42001.
  - C2: dropped Anthropic guardrails doc → added MITRE ATLAS (LLM Prompt Injection, AML.T0051).
  - C3: dropped OpenAI fine-tuning docs, IBM Research blog, ml-ops.org → added NIST SP 800-218A, ISO/IEC 42001, NIST AI RMF.
  - C4: dropped NVIDIA MIG and ARM TrustZone → added NIST SP 800-190 and NSA/CISA Kubernetes Hardening Guidance.
  - C12: removed the Microsoft Agent Governance Toolkit and a duplicate NIST AI 100-1 entry.
- **Filled out thin chapters.** C5 and C10 gained OAuth 2.1 / OpenID Connect; C7 gained OWASP LLM09, NIST AI 600-1, and MITRE ATLAS.
- **Trimmed over-long lists** to the most relevant authoritative sources: C8 (7→5), C9 (12→5), C11 (10→5).
- **Appendix B rebuilt** from the deduplicated union of the curated references, keeping the topical grouping (Standards & Frameworks, OWASP Resources, Threat Frameworks, Specifications & Protocols, Regulation, Academic Research). Entries no longer cited by any chapter were dropped.

Every chapter now lists 4–5 references; all new URLs were checked. Normative protocol specs (MCP, OAuth, OpenID Connect, CycloneDX) are kept as standards, not marketing.

This is an editorial/reference cleanup only — **no requirement text, level, scope, or intent changes**. Both CI gates (markdownlint, cspell) pass on all changed files.