### PR TITLE
Header: drop Working Draft label from PDF subtitle (no scope/intent change)

### DIFF
--- a/1.0/en/0x00-Header.yaml
+++ b/1.0/en/0x00-Header.yaml
@@ -1,6 +1,6 @@
 ---
     title: "Artificial Intelligence Security Verification Standard 1.0"
-    subtitle: "Working Draft Pre-Release"
+    subtitle: "Version 1.0"
     date: June 2026
     titlepage: true
     titlepage-rule-height: 0


### PR DESCRIPTION
Replaces the PDF title-page subtitle `Working Draft Pre-Release` with `Version 1.0` in `1.0/en/0x00-Header.yaml`.

This is the last "Working Draft" self-label in the standard. The Frontispiece equivalent was already fixed in #1009 (`Version 1.0, 2026`); this matches that wording on the PDF cover. Clears the remaining part of release blocker #1008.

No requirement text, level, scope, or intent change.