### PR TITLE
Pre-release editorial pass: typo, grammar, link, and label fixes (no scope/intent change)

### DIFF
--- a/1.0/en/0x03-Using-AISVS.md
+++ b/1.0/en/0x03-Using-AISVS.md
@@ -55,7 +55,7 @@ If an AISVS requirement appears to overlap with an ASVS requirement, the AISVS v
 
 ## Cross-References Inside AISVS
 
-AISVS chapters are organized by control family rather than by attack or component. As a result, defending against a given AI threat usually requires applying requirements from several chapters together. For example, defending against prompt injection in an agentic application combines requirements from C2 (input validation), C7 (model behavior), C9 (orchestration and agentic action), C10 (MCP-specific controls), C11 (adversarial robustness), and C12 (detection and logging).
+AISVS chapters are organized by control family rather than by attack or component. As a result, defending against a given AI threat usually requires applying requirements from several chapters together. For example, defending against prompt injection in an agentic application combines requirements from C2 (input validation), C7 (model behavior), C9 (orchestration and agentic security), C10 (MCP-specific controls), C11 (adversarial robustness), and C12 (detection and logging).
 
 Individual chapters and sections do not enumerate which other AISVS chapters cover related concerns. When applying AISVS, treat the standard as a whole and consult Appendix D (AI Security Controls Inventory) for a cross-cutting view of where each defense technique appears.
 


### PR DESCRIPTION
Pre-release cleanup across chapters and appendices, found during a full sweep of the standard ahead of the v1.0 release. No requirement scope, level, or verifiable condition is changed.

## Grammar / typos
- **C5.1**: fix ungrammatical section intro (meaning unchanged).
- **C12.3.4**: "identified from" → "distinguished from"; clarify drift wording.
- **C12.2.6**: remove stray comma ("identify, malware" → "identify malware").
- **C12.4.4**: remove stray comma in a two-item list.
- **C3.5.3**: fix dangling clause ("before it is consumed by the next stage").

## Links / references
- **C12 references**: drop the duplicate NIST AI RMF entry (listed twice).
- **Preface**: point the contributor list to Appendix E (the Frontispiece only lists the leads).
- **Appendix C**: correct stale section-title glosses for C2.1, C9.3, and C9.4.
- **0x03 Using-AISVS**: align the C9 cross-reference label with the chapter title ("orchestration and agentic security").

## Consistency
- **C4.1.2, C9.3.7**: normalize "allowlist" → "allow-list".
- **Appendix A**: fix two alphabetical-ordering slips (Embedding*, seccomp/Secure*).

All changes pass markdownlint and cspell.

### Deliberately not included (need discussion / decision)
- Appendix C cites `C9.6 (Action Authorization)`, but C9.6 is "Shutdown and Graceful Degradation" and action authorization is C9.5. Left for a maintainer to confirm the intended target.
- Material verifiability tightening (e.g. C2.1.8, C2.2.2, C5.2.3, C7.4.4) is governed by the release/freeze policy and should be discussed separately.