### PR TITLE
Appendix C: align AC.11.5 mapping with C9.5 (no scope change)

### DIFF
--- a/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
+++ b/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md
@@ -247,7 +247,7 @@ AI code-review bots, PR-comment bots, MCP-driven assistants (Model Context Proto
 * **AC.11.2:** AISVS C2.1; OWASP LLM Top 10 (2025) LLM01; OWASP Agentic Top 10 (2026) ASI01.
 * **AC.11.3:** AISVS C7.1; OWASP LLM Top 10 (2025) LLM05; OWASP Agentic Top 10 (2026) ASI02, ASI05.
 * **AC.11.4:** AISVS C9.3; OWASP Agentic Top 10 (2026) ASI02, ASI03, ASI05; NIST SP 800-204D (Workload isolation).
-* **AC.11.5:** AISVS C9.2, C5.2.5; OWASP ASVS v5 V4 (Access Control); OWASP Agentic Top 10 (2026) ASI02, ASI03.
+* **AC.11.5:** AISVS C9.5, C5.2.5; OWASP ASVS v5 V4 (Access Control); OWASP Agentic Top 10 (2026) ASI02, ASI03.
 * **AC.11.6:** OWASP ASVS v5 V8 (Logging & Error Handling); OWASP LLM Top 10 (2025) LLM02; ISO/IEC 27001:2022 A.8.15, A.8.16.
 * **AC.11.7:** GitHub Security Lab "Preventing pwn requests" series (Parts 1-4); OWASP Agentic Top 10 (2026) ASI01, ASI03, ASI09; OWASP CI/CD Top 10 CICD-SEC-01.
 * **AC.11.8:** MITRE ATLAS (Indirect prompt injection); AISVS C2.1, C11.1; OWASP SAMM Security Testing (ST).


### PR DESCRIPTION
Follow-up to #1026. The AC.11 relationship note now names **C9.5 "Agent Authorization, Delegation, and Continuous Enforcement"** as the authorization control. This updates AC.11.5's mapping bullet to cite C9.5 instead of C9.2, so the row and the note agree. C5.2.5 (policy decision point isolated from the agent execution environment) is retained, since AC.11.5 requires the authorization path be "adjudicated by a policy engine, not by the LLM".

No requirement scope, level, or verifiable condition is changed. Passes markdownlint and cspell.
