### PR TITLE
Editorial: 9 mechanical fixes pre-release (no scope/intent change)

### DIFF
--- a/1.0/en/0x03-Using-AISVS.md
+++ b/1.0/en/0x03-Using-AISVS.md
@@ -63,4 +63,4 @@ Individual chapters and sections do not enumerate which other AISVS chapters cov
 
 When using AISVS to assess security of a system, often the organization developing the system is not in full control of the supply chain. AISVS does not prescribe a certain way to approach these situations.
 
-One option is to get this information from the vendors used in the supply chain. Often the requirements can be assessed using a combination of technical testing and referencing vendor documentation (e.g., model cards for AI models). Another option is to just mark requirements not in organization's control as out of scope.
+One option is to get this information from the vendors used in the supply chain. Often the requirements can be assessed using a combination of technical testing and referencing vendor documentation (e.g., model cards for AI models). Another option is to just mark requirements not in the organization's control as out of scope.

--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -55,7 +55,7 @@ Model development must follow secure practices to prevent compromise.
 
 ## C3.5 Pipeline Fine-Tuning
 
-Fine-tuning pipelines are high-privilege operations that can alter deployed model behavior at scale. Multi-stage pipelines compound this risk because a compromise at any intermediate stage produces a subtly altered artifact that subsequent stages accept. Reward models used in Reinforcement Learning from Human Feedback (RLHF) are ML artifacts subject to tampering yet they are often treated as static infrastructure rather than versioned, validated components.
+Fine-tuning pipelines are high-privilege operations that can alter deployed model behavior at scale. Multi-stage pipelines compound this risk because a compromise at any intermediate stage produces a subtly altered artifact that subsequent stages accept. Reward models used in Reinforcement Learning from Human Feedback (RLHF) are ML artifacts subject to tampering, yet they are often treated as static infrastructure rather than versioned, validated components.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -14,7 +14,7 @@ Enforce fine-grained access controls and query-time scope enforcement for every 
 | :--: | --- | :---: |
 | **8.1.1** | **Verify that** vector identifiers and namespaces enforce uniqueness per tenant and prevent cross-tenant collisions. | 1 |
 | **8.1.2** | **Verify that** document metadata tags are immutable after the initial write. | 2 |
-| **8.1.3** | **Verify that** retrieval operations enforces scope constraints. | 2 |
+| **8.1.3** | **Verify that** retrieval operations enforce scope constraints. | 2 |
 
 ---
 

--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -74,7 +74,7 @@ Ensure every action is authorized at execution time and constrained by scope.
 | # | Description | Level |
 | :--: | --- | :---: |
 | **9.5.1** | **Verify that** agent actions are authorized against fine-grained policies enforced by the runtime that restrict which tools an agent may invoke, and which parameter values it may supply. | 2 |
-| **9.5.2** | **Verify that** when an agent acts on a user's behalf, the runtime propagates an integrity-protected and scope limited token that enforces that context at every downstream call. | 2 |
+| **9.5.2** | **Verify that** when an agent acts on a user's behalf, the runtime propagates an integrity-protected and scope-limited token that enforces that context at every downstream call. | 2 |
 | **9.5.3** | **Verify that** all access control decisions are enforced by application logic or a policy engine, never by the AI model itself. | 2 |
 | **9.5.4** | **Verify that** secrets and credentials required by an agent at runtime are not exposed within the model's observable context, including the context window, system prompts, or tool call parameters. | 2 |
 | **9.5.5** | **Verify that** inter-agent task delegation is restricted by an explicit authorization policy. | 2 |

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -12,7 +12,7 @@ Increase resilience to manipulated inputs designed to cause misclassification or
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **11.1.1** | **Verify that** model has been alignment and safety trained or fine-tuned to prevent the model from generating disallowed content categories. | 1 |
+| **11.1.1** | **Verify that** the model has been alignment and safety trained or fine-tuned to prevent the model from generating disallowed content categories. | 1 |
 | **11.1.2** | **Verify that** a version-controlled alignment test suite is run on every model update or release. | 1 |
 | **11.1.3** | **Verify that** models are evaluated against known adversarial attack techniques relevant to their modality. | 1 |
 | **11.1.4** | **Verify that** models are hardened against adversarial inputs. | 2 |
@@ -22,7 +22,7 @@ Increase resilience to manipulated inputs designed to cause misclassification or
 
 ## C11.2 Membership-Inference and Model-Inversion Mitigation
 
-Limit the ability to determine whether a specific record was in the training data, and prevent reconstruction of private training data or sensitive attributes from model outputs.. Differential privacy and output calibration are the most effective known defenses.
+Limit the ability to determine whether a specific record was in the training data, and prevent reconstruction of private training data or sensitive attributes from model outputs. Differential privacy and output calibration are the most effective known defenses.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x10-C12-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C12-Monitoring-and-Logging.md
@@ -12,7 +12,7 @@ This chapter focuses on controls unique to AI systems for monitoring, logging, a
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.1.1** | **Verify that** AI interactions are logged with session context and AI-specific telemetry | 1 |
+| **12.1.1** | **Verify that** AI interactions are logged with session context and AI-specific telemetry. | 1 |
 | **12.1.2** | **Verify that** safety filtering and policy decisions are logged with sufficient detail to support audit, debugging, and forensic analysis of content moderation systems. | 2 |
 | **12.1.3** | **Verify that** log entries for AI inference events follow a structured, interoperable schema that includes at least the model identifier, token usage (input and output), provider name, and operation type. | 2 |
 | **12.1.4** | **Verify that** RAG pipeline retrieval events are logged, including the query, documents retrieved, and knowledge source. | 2 |

--- a/1.0/en/0x90-Appendix-A_Glossary.md
+++ b/1.0/en/0x90-Appendix-A_Glossary.md
@@ -140,7 +140,7 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 
 * **k-anonymity** – A privacy property where each record in a dataset is indistinguishable from at least k-1 other records with respect to certain identifying attributes.
 
-* **Kill-Switch** – A mechanism to immediately halt AI model inference, agent execution, or system outputs on command or in response to a safety trigger. Kill-switches for autonomous agents must be delivered through a channel the agent runtime cannot access or suppress, so that a compromised agent cannot block its own shutdown. See also C9.6.
+* **Kill-Switch** – A mechanism to immediately halt AI model inference, agent execution, or system outputs on command or in response to a safety trigger. Kill-switches for autonomous agents must be delivered through a channel the agent runtime cannot access or suppress, so that a compromised agent cannot block its own shutdown. See also: C9.6.
 
 * **KMS (Key Management Service)** – A managed service for creating, storing, rotating, and controlling access to cryptographic keys used to protect data and artifacts.
 
@@ -194,7 +194,7 @@ This comprehensive glossary provides definitions of key AI, ML, and security ter
 
 * **OPA (Open Policy Agent)** – An open-source, general-purpose policy engine that evaluates authorization and admission control policies written in Rego, enabling unified policy enforcement across applications, APIs, and infrastructure.
 
-* **PDP (Policy Decision Point)** – A component in a policy enforcement architecture that evaluates authorization requests against defined policies and returns an allow or deny decision. In agentic AI systems, the PDP is isolated from the agent's execution environment to prevent a compromised agent from influencing its own authorization decisions. See also C5.2.5, C9.5.
+* **PDP (Policy Decision Point)** – A component in a policy enforcement architecture that evaluates authorization requests against defined policies and returns an allow or deny decision. In agentic AI systems, the PDP is isolated from the agent's execution environment to prevent a compromised agent from influencing its own authorization decisions. See also: C5.2.5, C9.5.
 
 * **PII (Personally Identifiable Information)** – Any information that can be used to identify, contact, or locate a specific individual, either alone or combined with other data.
 


### PR DESCRIPTION
Mechanical/editorial fixes from a pre-release sweep of `1.0/en/`. Grammar and formatting only — no requirement wording, scope, or level changes. Each was verified against the source text; `markdownlint` and `cspell` pass on all changed files.

Addresses #1034.

| File | Fix |
| --- | --- |
| C8.1.3 | subject-verb agreement: "operations **enforces**" → **enforce** |
| C11.2 (prose) | doubled period after "model outputs" |
| C3 Using-AISVS | missing article: "not in **the** organization's control" |
| C11.1.1 | missing article: "Verify that **the** model has been" |
| C3.5 (prose) | comma before "yet" joining two independent clauses |
| C9.5.2 | hyphenate "**scope-limited**" to match "integrity-protected" |
| C12.1.1 | missing terminal period |
| Appendix A | "See also**:**" colon consistency (2 glossary entries) |

9 single-token edits, 9 insertions / 9 deletions across 7 files.
