### PR TITLE
[codex] Polish C2-C5 requirement text

### DIFF
--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | **2.1.2** | **Verify that** encoding and representation smuggling in inputs is detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 1 |
 | **2.1.3** | **Verify that** all inputs that could steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier, with flagged inputs blocked. | 1 |
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
-| **2.1.5** | **Verify that** the system implements a character-set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
+| **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
 | **2.1.7** | **Verify that** reserved special tokens are encoded as literal characters and cannot be injected into the model context. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |

--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -10,15 +10,15 @@ In agentic and multi-step systems, input from tools, retrieved documents, MCP se
 
 ## C2.1 Prompt Injection Defenses
 
-Prompt injection is one of the top risks for AI systems. Defenses against this tactic require a combination of pattern filters, data classifiers and instruction hierarchy enforcement.
+Prompt injection is one of the top risks for AI systems. Defenses against this tactic require a combination of pattern filters, data classifiers, and instruction hierarchy enforcement.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.1.1** | **Verify that** input normalization is applied before tokenization or embedding. | 1 |
 | **2.1.2** | **Verify that** encoding and representation smuggling in inputs is detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 1 |
-| **2.1.3** | **Verify that** all inputs that could steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier and blocked. | 1 |
+| **2.1.3** | **Verify that** all inputs that could steer model behavior are treated as untrusted and screened by a prompt-injection detection ruleset or classifier, with flagged inputs blocked. | 1 |
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
-| **2.1.5** | **Verify that** the system implements a character set limitation for all inputs. The limitation must use an allow-list approach which only permits characters that are explicitly required. | 1 |
+| **2.1.5** | **Verify that** the system implements a character-set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
 | **2.1.7** | **Verify that** reserved special tokens are encoded as literal characters and cannot be injected into the model context. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
@@ -31,8 +31,8 @@ Syntactically valid prompts may request disallowed content such as instructions 
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **2.2.1** | **Verify that** every prompt is scored by a content classifier for violence, self-harm, hate, and sexual content against configurable thresholds. Prompts that exceed those thresholds are rejected or sanitized before reaching model context. | 1 |
-| **2.2.2** | **Verify that** prompt content classification is evaluated for languages that are not supported. | 1 |
+| **2.2.1** | **Verify that** every prompt is scored by a content classifier for violence, self-harm, hate, and sexual content against configurable thresholds. Prompts that exceed those thresholds are rejected or sanitized before reaching the model context. | 1 |
+| **2.2.2** | **Verify that** prompt content classification is evaluated for unsupported languages. | 1 |
 | **2.2.3** | **Verify that** non-text inputs (image/video/audio) are checked for adversarial perturbations, steganographic payloads, hidden or embedded content, or known attack patterns. | 2 |
 | **2.2.4** | **Verify that** coordinated attacks spanning multiple input types (e.g., steganographic payloads in images combined with prompt injection in text) are detected and blocked. | 3 |
 

--- a/1.0/en/0x10-C02-Input-Validation.md
+++ b/1.0/en/0x10-C02-Input-Validation.md
@@ -16,7 +16,7 @@ Prompt injection is one of the top risks for AI systems. Defenses against this t
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **2.1.1** | **Verify that** input normalization is applied before tokenization or embedding. | 1 |
 | **2.1.2** | **Verify that** encoding and representation smuggling in inputs is detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 1 |
-| **2.1.3** | **Verify that** all inputs that could steer model behavior are treated as untrusted and screened by a prompt-injection detection ruleset or classifier, with flagged inputs blocked. | 1 |
+| **2.1.3** | **Verify that** all inputs that could steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier, with flagged inputs blocked. | 1 |
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character-set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |

--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -2,7 +2,7 @@
 
 ## Control Objective
 
-AI systems must implement change control processes that prevent unauthorized or unsafe model modifications from reaching production. These controls enable rapid incident response and maintain accountability for all changes by ensuring model integrity through the entire lifecycle, from development through deployment to decommissioning. By employing controlled processes that maintain integrity, traceability, and recoverability, only authorized and validated models will reach production.
+AI systems must implement change control processes that prevent unauthorized or unsafe model modifications from reaching production. These controls enable rapid incident response and maintain accountability for all changes by ensuring model integrity through the entire lifecycle, from development through deployment to decommissioning. Controlled processes that maintain integrity, traceability, and recoverability ensure that only authorized and validated models reach production.
 
 ---
 
@@ -24,15 +24,15 @@ Models must pass defined security and safety validations before deployment.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------- | :---: |
-| **3.2.1** | **Verify that** models undergo automated input validation testing, safety evaluation testing and output sanitization testing before deployment. | 1 |
-| **3.2.2** | **Verify that** models that are subjected to post-training quantization will be re-evaluated against the same safety and alignment test suite on the compressed artifact before deployment. | 2 |
+| **3.2.1** | **Verify that** models undergo automated input-validation, safety-evaluation, and output-sanitization testing before deployment. | 1 |
+| **3.2.2** | **Verify that** models subjected to post-training quantization are re-evaluated against the same safety and alignment test suite on the compressed artifact before deployment. | 2 |
 | **3.2.3** | **Verify that** provider model, version, or routing changes trigger security re-evaluation before continued use. | 3 |
 
 ---
 
 ## C3.3 Controlled Deployment & Rollback
 
-Model deployments must be controlled, monitored, and reversible for ease of managing model lifecycle.
+Model deployments must be controlled, monitored, and reversible to support model lifecycle management.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -24,7 +24,7 @@ Models must pass defined security and safety validations before deployment.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------- | :---: |
-| **3.2.1** | **Verify that** models undergo automated input-validation, safety-evaluation, and output-sanitization testing before deployment. | 1 |
+| **3.2.1** | **Verify that** models undergo automated input validation testing, safety evaluation testing, and output sanitization testing before deployment. | 1 |
 | **3.2.2** | **Verify that** models subjected to post-training quantization are re-evaluated against the same safety and alignment test suite on the compressed artifact before deployment. | 2 |
 | **3.2.3** | **Verify that** provider model, version, or routing changes trigger security re-evaluation before continued use. | 3 |
 

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -26,7 +26,7 @@ Enforce the caller's authorization context through AI-specific query pipelines (
 | **5.2.1** | **Verify that** every AI resource (datasets, endpoints, vector collections, embedding indices, compute instances) enforces access controls with explicit allow-lists and default-deny policies. | 2 |
 | **5.2.2** | **Verify that** retrieval pipelines (e.g., RAG queries, embedding lookups) enforce the end-user's authorization context at each retrieval and assembly stage, rather than relying solely on the service account's permissions. | 2 |
 | **5.2.3** | **Verify that** sensitive data is retrieved via retrieval pipelines (e.g., RAG queries, embedding lookups) to prevent permanent storage in models. | 2 |
-| **5.2.4** | **Verify that** post-inference filtering mechanisms prevent responses from including data that the requestor is not authorized to receive. | 2 |
+| **5.2.4** | **Verify that** post-inference filtering mechanisms prevent responses from including data that the requester is not authorized to receive. | 2 |
 | **5.2.5** | **Verify that** the policy decision point for agent authorization is isolated from the agent's execution environment. | 2 |
 | **5.2.6** | **Verify that** privileged access to model weights, training pipelines, and production AI configuration is granted just in time, with a defined maximum session duration and automatic expiry. Zero Standing Privilege (ZSP) to these resources is encouraged. | 3 |
 | **5.2.7** | **Verify that** data classification labels propagate to downstream resources (embeddings, prompt caches, model outputs). | 3 |


### PR DESCRIPTION
## Summary
- Clarify grammar and testability wording in C2 input validation requirements
- Polish C3 lifecycle wording without changing requirement IDs or levels
- Standardize requester terminology in C5

## Validation
- git diff --check on this split branch
- Original combined review passed markdownlint, cspell, local link checks, requirement/reference checks, and pandoc HTML rendering

## Notes
- Split out from draft PR #1039.
- Draft PR only; do not merge yet.