### PR TITLE
C05: align Control Objective wording (editorial, no scope change)

### DIFF
--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -2,13 +2,13 @@
 
 ## Control Objective
 
-AI systems introduce access control challenges beyond traditional application security: classification labels must follow data through AI-specific transformations (embeddings, caches, model outputs), multi-tenant inference infrastructure creates novel side channels, and retrieval-augmented pipelines must enforce caller entitlements at every stage. This chapter addresses AI-specific access control and identity concerns, including runtime isolation of the policy decision point from agent execution and authorization-aware output filtering where entitlements vary per caller.
+This chapter addresses access control challenges that AI systems introduce beyond traditional application security: classification labels must follow data through AI-specific transformations such as embeddings, caches, and model outputs; multi-tenant inference infrastructure creates novel side channels; and retrieval-augmented pipelines must enforce caller entitlements at every stage. It covers authentication, AI resource authorization and classification, and multi-tenant isolation, including runtime isolation of the policy decision point from agent execution and authorization-aware output filtering where entitlements vary per caller.
 
 ---
 
 ## C5.1 Authentication
 
-Ensure that AI agents and human users accessing resources are properly authenticated and authorized for that level of access.
+This section covers ensuring that AI agents and human users accessing resources are properly authenticated and authorized for that level of access.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
@@ -19,7 +19,7 @@ Ensure that AI agents and human users accessing resources are properly authentic
 
 ## C5.2 AI Resource Authorization & Classification
 
-Enforce the caller's authorization context through AI-specific query pipelines (RAG retrieval, embedding lookups, inference chains) so that the AI system does not return data that the caller is not entitled to access.
+This section covers enforcing the caller's authorization context in AI-specific query pipelines so that the AI system does not return data that the caller is not entitled to access.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
@@ -35,7 +35,7 @@ Enforce the caller's authorization context through AI-specific query pipelines (
 
 ## C5.3 Multi-Tenant Isolation
 
-Prevent cross-tenant information leakage through AI-specific shared infrastructure components such as inference caches and shared model state.
+This section covers preventing cross-tenant information leakage through AI-specific shared infrastructure components such as inference caches and shared model state.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -8,7 +8,7 @@ This chapter addresses access control challenges that AI systems introduce beyon
 
 ## C5.1 Authentication
 
-This section covers ensuring that AI agents and human users accessing resources are properly authenticated and authorized for that level of access.
+AI agents and human users accessing resources must be properly authenticated and authorized for their level of access.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
@@ -19,7 +19,7 @@ This section covers ensuring that AI agents and human users accessing resources 
 
 ## C5.2 AI Resource Authorization & Classification
 
-This section covers enforcing the caller's authorization context in AI-specific query pipelines so that the AI system does not return data that the caller is not entitled to access.
+The caller's authorization context must be enforced through AI-specific query pipelines (RAG retrieval, embedding lookups, inference chains) so the system does not return data the caller is not entitled to access.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |
@@ -35,7 +35,7 @@ This section covers enforcing the caller's authorization context in AI-specific 
 
 ## C5.3 Multi-Tenant Isolation
 
-This section covers preventing cross-tenant information leakage through AI-specific shared infrastructure components such as inference caches and shared model state.
+Cross-tenant information leakage through AI-specific shared infrastructure, such as inference caches and shared model state, must be prevented.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |


### PR DESCRIPTION
Part of #1046. Editorial alignment of the C05 Control Objective to the shared shape: declarative voice, with a 'This chapter covers …' scope sentence mapped to the section headings (authentication, AI resource authorization and classification, multi-tenant isolation). No requirement scope, level, or intent changes.