### PR TITLE
C08: align Control Objective wording (editorial, no scope change)

### DIFF
--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -2,13 +2,13 @@
 
 ## Control Objective
 
-Embeddings and vector stores act as semi-persistent and persistent "memory" for AI systems via Retrieval-Augmented Generation (RAG). This memory can become a high-risk data sink and data exfiltration path. This control family hardens memory pipelines and vector databases so that access is least-privilege, data is sanitized before vectorization, retention is explicit, and systems are resilient to embedding inversion, membership inference, and cross-tenant leakage.
+This chapter addresses the embeddings and vector stores that act as semi-persistent and persistent "memory" for AI systems through Retrieval-Augmented Generation (RAG), which makes them a high-risk data sink and exfiltration path. It covers access controls on memory and RAG indices, embedding sanitization and validation, and memory expiry and revocation, so that access is least-privilege, data is sanitized before vectorization, retention is explicit, and systems resist embedding inversion, membership inference, and cross-tenant leakage.
 
 ---
 
 ## C8.1 Access Controls on Memory & RAG Indices
 
-Enforce fine-grained access controls and query-time scope enforcement for every vector collection.
+This section covers enforcing fine-grained access controls and query-time scope enforcement for every vector collection.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -20,7 +20,7 @@ Enforce fine-grained access controls and query-time scope enforcement for every 
 
 ## C8.2 Embedding Sanitization & Validation
 
-Pre-screen content before vectorization and treat memory writes as untrusted inputs to prevent ingestion of unsafe payloads.
+This section covers pre-screening content before vectorization and treating memory writes as untrusted inputs to prevent ingestion of unsafe payloads.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -32,9 +32,9 @@ Pre-screen content before vectorization and treat memory writes as untrusted inp
 
 ---
 
-## C8.3 Memory Expiry, Revocation & Leakage Prevention
+## C8.3 Memory Expiry & Revocation
 
-Retention and revocation must be explicit and enforceable for memory and RAG indices, and systems must address embedding inversion and attribute inference risks.
+This section covers making retention and revocation explicit and enforceable for memory and RAG indices.
 
 | # | Description | Level |
 | :--: | --- | :---: |

--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -8,7 +8,7 @@ This chapter addresses the embeddings and vector stores that act as semi-persist
 
 ## C8.1 Access Controls on Memory & RAG Indices
 
-This section covers enforcing fine-grained access controls and query-time scope enforcement for every vector collection.
+Fine-grained access controls and query-time scope enforcement must be applied to every vector collection.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -20,7 +20,7 @@ This section covers enforcing fine-grained access controls and query-time scope 
 
 ## C8.2 Embedding Sanitization & Validation
 
-This section covers pre-screening content before vectorization and treating memory writes as untrusted inputs to prevent ingestion of unsafe payloads.
+Content must be pre-screened before vectorization, and memory writes treated as untrusted input, to prevent ingestion of unsafe payloads.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -34,7 +34,7 @@ This section covers pre-screening content before vectorization and treating memo
 
 ## C8.3 Memory Expiry & Revocation
 
-This section covers making retention and revocation explicit and enforceable for memory and RAG indices.
+Retention and revocation must be explicit and enforceable for memory and RAG indices.
 
 | # | Description | Level |
 | :--: | --- | :---: |


### PR DESCRIPTION
Part of #1046. Editorial alignment of the C08 Control Objective to the shared shape: consistent noun ('this chapter' rather than 'this control family'), with a 'This chapter covers …' scope sentence mapped to the section headings. No requirement scope, level, or intent changes.