### PR TITLE
C10: align Control Objective wording (editorial, no scope change)

### DIFF
--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -2,11 +2,13 @@
 
 ## Control Objective
 
-Ensure secure discovery, authentication, authorization, transport, and use of MCP-based tool and resource integrations to prevent context confusion, unauthorized tool invocation, or cross-tenant data exposure. This chapter covers MCP-specific controls.
+This chapter addresses secure discovery, authentication, authorization, transport, and use of MCP-based tool and resource integrations to prevent context confusion, unauthorized tool invocation, and cross-tenant data exposure. It covers MCP component integrity, authentication and authorization, secure transport, and schema, message, and input validation.
 
 ---
 
 ## C10.1 Component Integrity
+
+This section covers ensuring that only trusted MCP components are used and that local servers are secured.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -17,6 +19,8 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ---
 
 ## C10.2 Authentication & Authorization
+
+This section covers authenticating callers and authorizing access to MCP servers following protocol best practices.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -32,6 +36,8 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 
 ## C10.3 Secure Transport
 
+This section covers securing MCP communications following protocol best practices.
+
 | # | Description | Level |
 | :--: | --- | :---: |
 | **10.3.1** | **Verify that** authenticated, encrypted streamable HTTP is used for MCP transport for remote services. | 1 |
@@ -43,6 +49,8 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ---
 
 ## C10.4 Schema, Message, and Input Validation
+
+This section covers schema, message, and input validation in both MCP servers and clients.
 
 | # | Description | Level |
 | :--: | --- | :---: |

--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -8,7 +8,7 @@ This chapter addresses secure discovery, authentication, authorization, transpor
 
 ## C10.1 Component Integrity
 
-This section covers ensuring that only trusted MCP components are used and that local servers are secured.
+Only trusted MCP components must be used, and locally launched servers must be secured.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -20,7 +20,7 @@ This section covers ensuring that only trusted MCP components are used and that 
 
 ## C10.2 Authentication & Authorization
 
-This section covers authenticating callers and authorizing access to MCP servers following protocol best practices.
+Callers must be authenticated and access to MCP servers authorized, following protocol best practices.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -36,7 +36,7 @@ This section covers authenticating callers and authorizing access to MCP servers
 
 ## C10.3 Secure Transport
 
-This section covers securing MCP communications following protocol best practices.
+MCP communications must be secured following protocol best practices.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -50,7 +50,7 @@ This section covers securing MCP communications following protocol best practice
 
 ## C10.4 Schema, Message, and Input Validation
 
-This section covers schema, message, and input validation in both MCP servers and clients.
+Schema, message, and input validation must be enforced in both MCP servers and clients.
 
 | # | Description | Level |
 | :--: | --- | :---: |


### PR DESCRIPTION
Part of #1046. Editorial alignment of the C10 Control Objective to the shared shape: declarative voice (rather than imperative), with a 'This chapter covers …' scope sentence mapped to the section headings. No requirement scope, level, or intent changes.