### PR TITLE
Language fixes and missing section descriptions

### DIFF
--- a/1.0/en/0x10-C03-Model-Lifecycle-Management.md
+++ b/1.0/en/0x10-C03-Model-Lifecycle-Management.md
@@ -44,7 +44,7 @@ Model deployments must be controlled, monitored, and reversible to support model
 
 ## C3.4 Secure Development Practices
 
-Model development must follow secure practices to prevent compromise.
+Model development environments must be separated from production environments.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
@@ -55,7 +55,7 @@ Model development must follow secure practices to prevent compromise.
 
 ## C3.5 Pipeline Fine-Tuning
 
-Fine-tuning pipelines are high-privilege operations that can alter deployed model behavior at scale. Multi-stage pipelines compound this risk because a compromise at any intermediate stage produces a subtly altered artifact that subsequent stages accept. Reward models used in Reinforcement Learning from Human Feedback (RLHF) are ML artifacts subject to tampering, yet they are often treated as static infrastructure rather than versioned, validated components.
+Fine-tuning pipelines are high-privilege operations that can alter deployed model behavior at scale. Multi-stage pipelines compound this risk because a compromise at any intermediate stage produces a subtly altered artifact that subsequent stages accept.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x10-C05-Access-Control-and-Identity.md
+++ b/1.0/en/0x10-C05-Access-Control-and-Identity.md
@@ -19,7 +19,7 @@ Ensure that AI agents and human users accessing resources are properly authentic
 
 ## C5.2 AI Resource Authorization & Classification
 
-Enforce the caller's authorization context through AI-specific query pipelines (RAG retrieval, embedding lookups, inference chains) so that the AI system does not return data that the caller is not entitled to access.
+Enforce the caller's authorization context in AI-specific query pipelines so that the AI system does not return data that the caller is not entitled to access.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -8,7 +8,7 @@ AI supply-chain attacks exploit third-party models, frameworks, or datasets to e
 
 ## C6.1 Model Artifact Integrity
 
-Authenticate third-party model origins and check for hidden behavior before fine-tuning or deployment. Download AI artifacts only from approved sources.
+Authenticate third-party model origins and check for hidden behavior before fine-tuning or deployment. Ensure AI artifacts are only downloaded from approved sources.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x10-C07-Model-Behavior.md
+++ b/1.0/en/0x10-C07-Model-Behavior.md
@@ -29,9 +29,9 @@ Detect when the model produces potentially inaccurate or fabricated content and 
 
 ---
 
-## C7.3 Output Safety, Privacy & Explainability
+## C7.3 Output Safety
 
-Technical controls detect and scrub unsafe content before it is shown to the user and ensure AI decisions are interpretable.
+Technical controls detect and remove unsafe content before it is shown to the user.
 
 | # | Description | Level |
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -32,9 +32,9 @@ Pre-screen content before vectorization and treat memory writes as untrusted inp
 
 ---
 
-## C8.3 Memory Expiry, Revocation & Leakage Prevention
+## C8.3 Memory Expiry & Revocation
 
-Retention and revocation must be explicit and enforceable for memory and RAG indices, and systems must address embedding inversion and attribute inference risks.
+Retention and revocation must be explicit and enforceable for memory and RAG indices.
 
 | # | Description | Level |
 | :--: | --- | :---: |

--- a/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -84,7 +84,7 @@ Ensure every action is authorized at execution time and constrained by scope.
 
 ## C9.6 Shutdown and Graceful Degradation
 
-Provide shutdown and graceful degradation paths under human control, with mechanisms that remain reliable and exercised over time.
+Provide shutdown and graceful degradation paths under human control, with mechanisms that remain reliable.
 
 | # | Description | Level |
 | :--: | --- | :---: |

--- a/1.0/en/0x10-C10-MCP-Security.md
+++ b/1.0/en/0x10-C10-MCP-Security.md
@@ -8,6 +8,8 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 
 ## C10.1 Component Integrity
 
+Ensure that only trusted MCP components are used and local servers are secured.
+
 | # | Description | Level |
 | :--: | --- | :---: |
 | **10.1.1** | **Verify that** MCP components are obtained only from trusted sources and cryptographically verified. | 1 |
@@ -17,6 +19,8 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ---
 
 ## C10.2 Authentication & Authorization
+
+Implement authentication and authorization to MCP servers following protocol recommended practices.
 
 | # | Description | Level |
 | :--: | --- | :---: |
@@ -32,6 +36,8 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 
 ## C10.3 Secure Transport
 
+Ensure that MCP communications are secure following protocol best practices.
+
 | # | Description | Level |
 | :--: | --- | :---: |
 | **10.3.1** | **Verify that** authenticated, encrypted streamable HTTP is used for MCP transport for remote services. | 1 |
@@ -43,6 +49,8 @@ Ensure secure discovery, authentication, authorization, transport, and use of MC
 ---
 
 ## C10.4 Schema, Message, and Input Validation
+
+Implement schema, message and input validation to in both MCP servers and clients.
 
 | # | Description | Level |
 | :--: | --- | :---: |

--- a/1.0/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.0/en/0x10-C11-Adversarial-Robustness.md
@@ -8,7 +8,7 @@ Ensure that AI systems remain reliable, privacy-preserving, and abuse-resistant 
 
 ## C11.1 Model Alignment, Safety, and Robustness Testing and Training
 
-Increase resilience to manipulated inputs designed to cause misclassification or policy bypass. Adversarial testing and robustness benchmarking are the current best practices.
+Increase model resilience to manipulated inputs designed to cause misclassification or policy bypass.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
@@ -22,7 +22,7 @@ Increase resilience to manipulated inputs designed to cause misclassification or
 
 ## C11.2 Membership-Inference and Model-Inversion Mitigation
 
-Limit the ability to determine whether a specific record was in the training data, and prevent reconstruction of private training data or sensitive attributes from model outputs. Differential privacy and output calibration are the most effective known defenses.
+Limit the ability to determine whether a specific record was in the training data, and prevent reconstruction of private training data or sensitive attributes from model outputs.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
@@ -36,7 +36,7 @@ Limit the ability to determine whether a specific record was in the training dat
 
 ## C11.3 Model-Extraction Defense
 
-Detect and deter unauthorized model cloning through API abuse. Rate limiting, query-pattern analysis, and watermarking are recommended defenses.
+Detect and deter unauthorized model cloning through API abuse by implementing rate limiting, query-pattern analysis, and watermarking.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |

--- a/1.0/en/0x10-C12-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C12-Monitoring-and-Logging.md
@@ -10,6 +10,8 @@ This chapter focuses on controls unique to AI systems for monitoring, logging, a
 
 ## C12.1 Request & Response Logging
 
+AI specific components must include appropriate request and response logging to create audit trail and support incident response.
+
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.1.1** | **Verify that** AI interactions are logged with session context and AI-specific telemetry. | 1 |


### PR DESCRIPTION
Some of the chapter descriptions and names had content that was referring to requirements that were removed earlier.

Also, ensure that chapter section descriptions are uniform describing only on high-level intention and key methods included in requirements.