### PR TITLE
Align Control Objective wording across chapters

### DIFF
--- a/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
+++ b/1.0/en/0x10-C01-Training-Data-Integrity-and-Traceability.md
@@ -2,7 +2,7 @@
 
 ## Control Objective
 
-This chapter addresses how training data is sourced, handled, and maintained.
+This chapter addresses protecting the integrity and traceability of training data as it is sourced, handled, and maintained.
 
 ---
 

--- a/1.0/en/0x10-C06-Supply-Chain.md
+++ b/1.0/en/0x10-C06-Supply-Chain.md
@@ -2,7 +2,7 @@
 
 ## Control Objective
 
-This chapter addresses AI supply chain attacks that exploit third-party models, frameworks, or datasets to embed backdoors, bias, or exploitable code.
+This chapter addresses defending against AI supply chain attacks that exploit third-party models, frameworks, or datasets to embed backdoors, bias, or exploitable code.
 
 ---
 

--- a/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.0/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -2,7 +2,7 @@
 
 ## Control Objective
 
-This chapter addresses embeddings and vector stores that act as semi-persistent and persistent "memory" for AI systems through Retrieval-Augmented Generation (RAG).
+This chapter addresses securing the embeddings and vector stores that act as semi-persistent and persistent "memory" for AI systems through Retrieval-Augmented Generation (RAG).
 
 ---
 


### PR DESCRIPTION
## What

Double-checks the **Control Objective** block at the top of all 12 chapters and aligns the three that broke the shared pattern. Every chapter's Control Objective is now a single sentence that opens with "This chapter addresses…" and names what is being protected.

## Why

Nine of the twelve Control Objectives already state a protective goal (harden, constrain, ensure, secure visibility, etc.). Three described only the chapter's subject:

| Chapter | Before | After |
|---|---|---|
| C01 | …addresses **how training data is sourced, handled, and maintained.** | …addresses **protecting the integrity and traceability of training data as it is sourced, handled, and maintained.** |
| C06 | …addresses **AI supply chain attacks that exploit…** | …addresses **defending against AI supply chain attacks that exploit…** |
| C08 | …addresses **embeddings and vector stores that act as…** | …addresses **securing the embeddings and vector stores that act as…** |

## Scope

Editorial only. No change to any requirement, level, scope, or intent. The other nine Control Objectives were reviewed and left unchanged. markdownlint and cspell pass on all three files.