### PR TITLE
Move Acknowledgments from Preface to Frontispiece and de-duplicate contributor text

### DIFF
--- a/1.0/en/0x01-Frontispiece.md
+++ b/1.0/en/0x01-Frontispiece.md
@@ -17,6 +17,10 @@ Copyright &copy; 2025-2026 The AISVS Project.
 Released under the [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
 For any reuse or distribution, you must clearly communicate the license terms of this work to others.
 
+## Acknowledgments
+
+AISVS v1.0 is the result of a collaborative effort by its project leads, working group members, and community contributors. We thank everyone who has contributed requirements, reviews, and feedback to make this standard possible.
+
 ## Project Leads
 
 * Jim Manico ([jmanico](https://github.com/jmanico))
@@ -27,7 +31,7 @@ For any reuse or distribution, you must clearly communicate the license terms of
 
 ## Contributors and Reviewers
 
-We gratefully acknowledge everyone who has helped build AISVS through pull requests, commits, issues, and reviews. This list reflects authored and edited content. It does not fully capture contributors whose impact came mainly through reviews and issue discussion, and we thank them as well.
+The list below reflects authored and edited content. It does not fully capture contributors whose impact came mainly through reviews and issue discussion, and we thank them as well.
 
 * b1oo ([b1oo](https://github.com/b1oo))
 * Jim Schwoebel ([jim-schwoebel](https://github.com/jim-schwoebel))

--- a/1.0/en/0x02-Preface.md
+++ b/1.0/en/0x02-Preface.md
@@ -2,6 +2,8 @@
 
 Welcome to the **Artificial Intelligence Security Verification Standard (AISVS) version 1.0**.
 
+By adopting AISVS, organizations can systematically evaluate and strengthen the security posture of their AI systems, building a foundation of secure AI engineering practices that evolves alongside the technology itself.
+
 ## Why AISVS Exists
 
 AI systems introduce security risks that traditional application security standards were not designed to address. Prompt injection allows attackers to override model instructions through crafted inputs, turning a language model into a tool for data exfiltration, unauthorized actions, or bypassing safety controls. Training data can be poisoned to install backdoors or degrade model behavior. Models can be extracted, inverted, or manipulated through adversarial inputs. Autonomous agents can take actions with real-world consequences, acting on prompt-injected instructions they cannot tell apart from legitimate ones. Retrieval pipelines can be exploited to leak sensitive information or to inject malicious content into model context. The supply chain for models, datasets, and frameworks presents novel integrity challenges that existing software composition analysis alone cannot solve.
@@ -52,9 +54,3 @@ AISVS focuses on security controls that are specific to AI and ML systems. It in
 * **General application security.** Requirements covered by the [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/) (such as session management, CSRF protection, or SQL injection prevention) are not repeated here. Organizations should apply ASVS alongside AISVS.
 * **AI governance and risk management.** Organizational governance, risk assessment methodology, and compliance processes are better addressed by frameworks such as the NIST AI RMF and ISO/IEC 42001.
 * **Vendor-specific guidance.** AISVS is vendor-neutral. It specifies what to verify, not which product to use.
-
-## Acknowledgments
-
-AISVS v1.0 is the result of a collaborative effort by its project leads, working group members, and community contributors. We thank everyone who has contributed requirements, reviews, and feedback to make this standard possible. A full list of contributors is available in the [Frontispiece](0x01-Frontispiece.md).
-
-By adopting AISVS, organizations can systematically evaluate and strengthen the security posture of their AI systems, building a foundation of secure AI engineering practices that evolves alongside the technology itself.


### PR DESCRIPTION
Closes #1068.

## What

Moves the **Acknowledgments** prose out of the Preface and into the Frontispiece, where the contributor lists already live, and removes the now-redundant cross-link.

## Why

All front-matter files print together in a single PDF. The Preface's "A full list of contributors is available in the [Frontispiece](0x01-Frontispiece.md)" link is meaningless in print (the Frontispiece is a few pages earlier) and split the gratitude prose from the names it refers to.

## Changes

- **Frontispiece:** add an `## Acknowledgments` section ("AISVS v1.0 is the result of a collaborative effort...") just above the contributor lists. Trim the **Contributors and Reviewers** intro so it no longer repeats the thanks now carried by the new section; it keeps the unique caveat that the list reflects authored/edited content and under-represents review-only contributors.
- **Preface:** drop the `## Acknowledgments` section and its cross-link. Keep the closing "By adopting AISVS..." sentence (it reads as a Preface framing statement, not an acknowledgment) by moving it up as the opening paragraph.

Editorial only: no requirement, level, or scope changes. Markdownlint and cspell pass on both files.
