### PR TITLE
docs(readme): add Research Wiki section linking to research/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ Organizations should select a target level based on the risk profile of their AI
 * [Appendix B: AI Security Controls Inventory](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x91-Appendix-B_AI_Security_Controls_Inventory.md)
 * [Appendix C: AI-Assisted Secure Coding](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x92-Appendix-C_AI_for_Code_Generation.md)
 
+## Research Wiki
+
+For every requirement in the standard, the [Research Wiki](https://github.com/OWASP/AISVS/blob/main/research/README.md) provides implementation context beyond the requirement text:
+
+| Column | What it tells you |
+|--------|-------------------|
+| **Threat Mitigated** | Specific attack techniques, CVEs, and real-world incidents the control defends against |
+| **Verification Approach** | Concrete audit steps, tools, and evidence to collect |
+| **Gaps & Notes** | Tool maturity ratings, open research questions, and implementation caveats |
+
+The wiki covers all 195 requirements across 60 pages, with per-section threat landscape summaries, tooling recommendations, and references to current standards and research literature.
+
 ---
 
 ## How to Reference AISVS Requirements


### PR DESCRIPTION
Closes #1075

## What

Adds a **Research Wiki** section to the main README, placed between the existing Appendices and the "How to Reference AISVS Requirements" section.

## Why

The `research/` directory is a well-structured wiki covering all 195 requirements across 60 pages, but is currently undiscoverable from the repository homepage. Only `CONTRIBUTING.md` references it.

## Preview

The new section explains what the research wiki provides using a three-column table that mirrors the wiki's own structure:

| Column | What it tells you |
|--------|-------------------|
| Threat Mitigated | Specific attack techniques, CVEs, and real-world incidents |
| Verification Approach | Concrete audit steps, tools, and evidence to collect |
| Gaps & Notes | Tool maturity ratings, open research questions, and implementation caveats |

The link uses `https://github.com/OWASP/AISVS/blob/main/research/README.md`, consistent with existing chapter links that point to `main`.

## Related

Also see #1074 for a broader discussion about extending CI coverage to the research/ directory.