### PR TITLE
Remove C12.4

### DIFF
--- a/1.0/en/0x10-C12-Monitoring-and-Logging.md
+++ b/1.0/en/0x10-C12-Monitoring-and-Logging.md
@@ -47,41 +47,28 @@ Drift and degradation across model outputs, input distributions, and data schema
 
 ---
 
-## C12.4 AI Incident Response Planning & Execution
-
-Incident response must be planned and executed for AI-specific security events.
-
-| # | Description | Level |
-| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.4.1** | **Verify that** incident response plans address AI-related security events with containment and investigation steps for each scenario. | 1 |
-| **12.4.2** | **Verify that** incident response teams have access to forensic AI-specific capabilities. | 2 |
-| **12.4.3** | **Verify that** automated incident response workflows can isolate compromised models and block malicious users. | 2 |
-| **12.4.4** | **Verify that** post-incident analysis includes model retraining and safety filter updates. | 3 |
-
----
-
-## C12.5 Proactive Security Behavior Monitoring
+## C12.4 Proactive Security Behavior Monitoring
 
 Security threats arising from proactive (agent-initiated) behavior must be detected and prevented, including pre-execution validation, behavior pattern analysis, and audit trails for approval of security-critical actions.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.5.1** | **Verify that** autonomous action triggers include proactive behavior-pattern analysis, security evaluation, and threat-landscape assessment. | 2 |
-| **12.5.2** | **Verify that** audit logs capture security-critical proactive actions, including approver identity, timestamp, action parameters, and decision outcomes. | 2 |
-| **12.5.3** | **Verify that** kill-switch activations and override commands are logged. | 2 |
+| **12.4.1** | **Verify that** autonomous action triggers include proactive behavior-pattern analysis, security evaluation, and threat-landscape assessment. | 2 |
+| **12.4.2** | **Verify that** audit logs capture security-critical proactive actions, including approver identity, timestamp, action parameters, and decision outcomes. | 2 |
+| **12.4.3** | **Verify that** kill-switch activations and override commands are logged. | 2 |
 
 ---
 
-## C12.6 Training Data & Model Lifecycle Audit
+## C12.5 Training Data & Model Lifecycle Audit
 
 The provenance and change history of training data, model artifacts, and knowledge sources must be auditable throughout the AI development lifecycle.
 
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
-| **12.6.1** | **Verify that** dataset lineage records each dataset and its components, including all transformations, augmentations, and merges. | 1 |
-| **12.6.2** | **Verify that** all labeling activities are recorded in logs. | 1 |
-| **12.6.3** | **Verify that** all model changes generate immutable audit records. | 2 |
-| **12.6.4** | **Verify that** every ingested document is tagged at write time with source, writer identity, and timestamp. | 2 |
+| **12.5.1** | **Verify that** dataset lineage records each dataset and its components, including all transformations, augmentations, and merges. | 1 |
+| **12.5.2** | **Verify that** all labeling activities are recorded in logs. | 1 |
+| **12.5.3** | **Verify that** all model changes generate immutable audit records. | 2 |
+| **12.5.4** | **Verify that** every ingested document is tagged at write time with source, writer identity, and timestamp. | 2 |
 
 ---
 

--- a/1.0/en/0x91-Appendix-B_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x91-Appendix-B_AI_Security_Controls_Inventory.md
@@ -376,11 +376,7 @@ Detect AI-specific abuse, drift, and anomalies, and respond to incidents.
 | Hallucination detection monitoring of model outputs | C12.3.2 |
 | Hallucination rates tracked as continuous time-series metrics | C12.3.3 |
 | Distinction of unexplained behavioral shifts from gradual operational drift | C12.3.4 |
-| AI-specific incident response plans with per-scenario containment and investigation steps | C12.4.1 |
-| AI-specific forensic tools and expertise for investigating model behavior | C12.4.2 |
-| Automated incident-response workflows that isolate compromised models and block malicious users | C12.4.3 |
-| Post-incident analysis feeding model retraining and safety filter updates | C12.4.4 |
-| Security evaluation and threat-landscape assessment for autonomous action triggers | C12.5.1 |
+| Security evaluation and threat-landscape assessment for autonomous action triggers | C12.4.1 |
 
 **Common pitfalls:** not correlating AI-specific events with broader SIEM alerts; treating drift as a scheduled check rather than continuous monitoring; lacking AI-specific forensic tooling during an incident.
 


### PR DESCRIPTION
Remove C12.4. requirements because they concern documentation and systems outside of an AI system itself.

Incident response is a topic that should be explored further, will open an issue with the removed requirements to discuss how to address this better in a future release.