### PR TITLE
C12/AppB: fix inventory IDs missed by C12.4 removal (#1077)

### DIFF
--- a/1.0/en/0x91-Appendix-B_AI_Security_Controls_Inventory.md
+++ b/1.0/en/0x91-Appendix-B_AI_Security_Controls_Inventory.md
@@ -283,9 +283,9 @@ Source, vet, and document training data so tampering, poisoning, and corruption 
 | Confidence thresholds and consistency checks on automatically generated labels | C1.3.2 |
 | Bias evaluation for models used in security-relevant decisions | C1.3.3 |
 | Defenses against clean-label poisoning attacks | C1.3.5 |
-| Dataset lineage recording (transformations, augmentations, merges) | C12.6.1 |
-| Logging of all labeling activities | C12.6.2 |
-| Write-time tagging of every ingested document (source, writer identity, timestamp) | C12.6.4 |
+| Dataset lineage recording (transformations, augmentations, merges) | C12.5.1 |
+| Logging of all labeling activities | C12.5.2 |
+| Write-time tagging of every ingested document (source, writer identity, timestamp) | C12.5.4 |
 
 **Common pitfalls:** not scanning fine-tuning datasets for poisoning; collecting more attributes than the purpose requires; losing dataset lineage across transformations and merges.
 
@@ -349,9 +349,9 @@ Capture security-relevant events with sufficient context and integrity for foren
 | Logging of safety filtering and policy decisions in enough detail to audit content moderation | C12.1.2 |
 | Structured, interoperable log schema for inference events (model identifier, token usage, provider, operation type) | C12.1.3 |
 | Logging of RAG pipeline retrieval events (query, documents retrieved, knowledge source) | C12.1.4 |
-| Audit logs capturing the approval chain for security-critical proactive actions (approver identity, timestamp, parameters, outcome) | C12.5.2 |
-| Logging of kill-switch activations and override commands | C12.5.3 |
-| Immutable audit records for all model changes | C12.6.3 |
+| Audit logs capturing the approval chain for security-critical proactive actions (approver identity, timestamp, parameters, outcome) | C12.4.2 |
+| Logging of kill-switch activations and override commands | C12.4.3 |
+| Immutable audit records for all model changes | C12.5.3 |
 
 **Common pitfalls:** logging prompts without redaction; using mutable log storage without integrity protection; logging agent actions and approvals but not human-initiated overrides such as kill-switch activations.
 


### PR DESCRIPTION
PR #1077 removed section C12.4 (AI Incident Response) and renumbered the sections below it (old C12.5 → C12.4, old C12.6 → C12.5), and updated the Controls Inventory in Appendix B.

However, the inventory groups each control into several `AD.xx` categories, so C12 controls appear in more than one place. The original PR only updated the rows under **AD.18 (Monitoring, Detection & Incident Response)**. Six rows in other categories still cited the old IDs:

| Description | Was | Now |
|---|---|---|
| Dataset lineage recording | C12.6.1 | C12.5.1 |
| Logging of all labeling activities | C12.6.2 | C12.5.2 |
| Write-time tagging of ingested documents | C12.6.4 | C12.5.4 |
| Audit logs for proactive-action approval chain | C12.5.2 | C12.4.2 |
| Kill-switch / override logging | C12.5.3 | C12.4.3 |
| Immutable audit records for model changes | C12.6.3 | C12.5.3 |

Each row was realigned by matching its description to the renumbered chapter requirement (two of them, C12.5.2/C12.5.3, pointed at still-existing but now-wrong IDs, so an ID-only check wouldn't have caught them).

After the fix, Appendix B references exactly the 191 current requirement IDs with no dangling or missing entries, and markdownlint/cspell pass. Editorial only, no scope or intent change.