### PR TITLE
README: update requirement count 195 -> 191 after C12.4 removal (#1077)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Organizations should select a target level based on the risk profile of their AI
 For every requirement in the standard, the [Research Wiki](https://github.com/OWASP/AISVS/blob/main/research/README.md) provides implementation context beyond the requirement text:
 
 | Column | What it tells you |
-|--------|-------------------|
+| --- | --- |
 | **Threat Mitigated** | Specific attack techniques, CVEs, and real-world incidents the control defends against |
 | **Verification Approach** | Concrete audit steps, tools, and evidence to collect |
 | **Gaps & Notes** | Tool maturity ratings, open research questions, and implementation caveats |

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For every requirement in the standard, the [Research Wiki](https://github.com/OW
 | **Verification Approach** | Concrete audit steps, tools, and evidence to collect |
 | **Gaps & Notes** | Tool maturity ratings, open research questions, and implementation caveats |
 
-The wiki covers all 195 requirements across 60 pages, with per-section threat landscape summaries, tooling recommendations, and references to current standards and research literature.
+The wiki covers all 191 requirements across 60 pages, with per-section threat landscape summaries, tooling recommendations, and references to current standards and research literature.
 
 ---
 


### PR DESCRIPTION
PR #1077 removed section C12.4 (4 requirements), bringing the standard's total from 195 to **191** requirements.

The README's Research Wiki section still stated "all 195 requirements." This updates it to 191 to match the current standard.

This was the only hardcoded requirement total in the docs; the front matter and other docs describe structure ("12 chapters", "three verification levels") without a fixed count. Editorial only.