### PR TITLE
Clarify C9.2 reversibility approval wording

### DIFF
--- a/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -20,11 +20,11 @@ Runtime expansion (recursion, concurrency, cost) must be bounded, with safe halt
 
 ## C9.2 High-Impact Action Approval and Irreversibility Controls
 
-Privileged, high-impact, or hard-to-reverse agent actions must require trusted approval checkpoints.
+Privileged, high-impact, or hard-to-reverse agent actions must be blocked, restricted, or routed through trusted approval checkpoints based on their impact and reversibility.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.2.1** | **Verify that** the agent runtime blocks execution of privileged, high-impact, or irreversible actions until explicit human approval is received and verified. | 1 |
+| **9.2.1** | **Verify that** the agent runtime blocks execution of privileged or irreversible actions until explicit human approval is received and verified. | 1 |
 | **9.2.2** | **Verify that** approval requests display canonicalized and complete action parameters, such as diffs, commands, recipients, amounts, resources, and scopes, without truncation or unsafe transformation. | 2 |
 | **9.2.3** | **Verify that** each high-impact action has a trusted reversibility classification, such as read-only, reversible, externally reversible, or irreversible. | 2 |
 | **9.2.4** | **Verify that** the agent runtime enforces reversibility classifications by blocking, requiring approval, or restricting actions based on their impact and ability to be reversed. | 2 |

--- a/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -24,7 +24,7 @@ Privileged, high-impact, or hard-to-reverse agent actions must require trusted a
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.2.1** | **Verify that** the agent runtime blocks execution of high impact actions until explicit human approval is received and verified. | 1 |
+| **9.2.1** | **Verify that** the agent runtime blocks execution of privileged or irreversible actions until explicit human approval is received and verified. | 1 |
 | **9.2.2** | **Verify that** approval requests display canonicalized and complete action parameters, such as diffs, commands, recipients, amounts, resources, and scopes, without truncation or unsafe transformation. | 2 |
 | **9.2.3** | **Verify that** each high-impact action has a trusted reversibility classification, such as read-only, reversible, externally reversible, or irreversible. | 2 |
 | **9.2.4** | **Verify that** the agent runtime enforces reversibility classifications by blocking, requiring approval, or restricting actions based on their impact and ability to be reversed. | 2 |

--- a/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -20,11 +20,11 @@ Runtime expansion (recursion, concurrency, cost) must be bounded, with safe halt
 
 ## C9.2 High-Impact Action Approval and Irreversibility Controls
 
-Privileged, high-impact, or hard-to-reverse agent actions must be blocked, restricted, or routed through trusted approval checkpoints based on their impact and reversibility.
+Privileged, high-impact, or hard-to-reverse agent actions must require trusted approval checkpoints.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.2.1** | **Verify that** the agent runtime blocks execution of privileged or irreversible actions until explicit human approval is received and verified. | 1 |
+| **9.2.1** | **Verify that** the agent runtime blocks execution of high impact actions until explicit human approval is received and verified. | 1 |
 | **9.2.2** | **Verify that** approval requests display canonicalized and complete action parameters, such as diffs, commands, recipients, amounts, resources, and scopes, without truncation or unsafe transformation. | 2 |
 | **9.2.3** | **Verify that** each high-impact action has a trusted reversibility classification, such as read-only, reversible, externally reversible, or irreversible. | 2 |
 | **9.2.4** | **Verify that** the agent runtime enforces reversibility classifications by blocking, requiring approval, or restricting actions based on their impact and ability to be reversed. | 2 |

--- a/2.0-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/2.0-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -24,7 +24,7 @@ Privileged, high-impact, or hard-to-reverse agent actions must require trusted a
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.2.1** | **Verify that** the agent runtime blocks execution of privileged or irreversible actions until explicit human approval is received and verified. | 1 |
+| **9.2.1** | **Verify that** the agent runtime blocks execution of privileged, high-impact, or irreversible actions until explicit human approval is received and verified. | 1 |
 | **9.2.2** | **Verify that** approval requests display canonicalized and complete action parameters, such as diffs, commands, recipients, amounts, resources, and scopes, without truncation or unsafe transformation. | 2 |
 | **9.2.3** | **Verify that** each high-impact action has a trusted reversibility classification, such as read-only, reversible, externally reversible, or irreversible. | 2 |
 | **9.2.4** | **Verify that** the agent runtime enforces reversibility classifications by blocking, requiring approval, or restricting actions based on their impact and ability to be reversed. | 2 |

--- a/2.0-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/2.0-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -20,11 +20,11 @@ Runtime expansion (recursion, concurrency, cost) must be bounded, with safe halt
 
 ## C9.2 High-Impact Action Approval and Irreversibility Controls
 
-Privileged, high-impact, or hard-to-reverse agent actions must require trusted approval checkpoints.
+Privileged, high-impact, or hard-to-reverse agent actions must be blocked, restricted, or routed through trusted approval checkpoints based on their impact and reversibility.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.2.1** | **Verify that** the agent runtime blocks execution of privileged, high-impact, or irreversible actions until explicit human approval is received and verified. | 1 |
+| **9.2.1** | **Verify that** the agent runtime blocks execution of privileged or irreversible actions until explicit human approval is received and verified. | 1 |
 | **9.2.2** | **Verify that** approval requests display canonicalized and complete action parameters, such as diffs, commands, recipients, amounts, resources, and scopes, without truncation or unsafe transformation. | 2 |
 | **9.2.3** | **Verify that** each high-impact action has a trusted reversibility classification, such as read-only, reversible, externally reversible, or irreversible. | 2 |
 | **9.2.4** | **Verify that** the agent runtime enforces reversibility classifications by blocking, requiring approval, or restricting actions based on their impact and ability to be reversed. | 2 |

--- a/2.0-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/2.0-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -24,7 +24,7 @@ Privileged, high-impact, or hard-to-reverse agent actions must require trusted a
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.2.1** | **Verify that** the agent runtime blocks execution of high impact actions until explicit human approval is received and verified. | 1 |
+| **9.2.1** | **Verify that** the agent runtime blocks execution of privileged or irreversible actions until explicit human approval is received and verified. | 1 |
 | **9.2.2** | **Verify that** approval requests display canonicalized and complete action parameters, such as diffs, commands, recipients, amounts, resources, and scopes, without truncation or unsafe transformation. | 2 |
 | **9.2.3** | **Verify that** each high-impact action has a trusted reversibility classification, such as read-only, reversible, externally reversible, or irreversible. | 2 |
 | **9.2.4** | **Verify that** the agent runtime enforces reversibility classifications by blocking, requiring approval, or restricting actions based on their impact and ability to be reversed. | 2 |

--- a/2.0-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/2.0-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -20,11 +20,11 @@ Runtime expansion (recursion, concurrency, cost) must be bounded, with safe halt
 
 ## C9.2 High-Impact Action Approval and Irreversibility Controls
 
-Privileged, high-impact, or hard-to-reverse agent actions must be blocked, restricted, or routed through trusted approval checkpoints based on their impact and reversibility.
+Privileged, high-impact, or hard-to-reverse agent actions must require trusted approval checkpoints.
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.2.1** | **Verify that** the agent runtime blocks execution of privileged or irreversible actions until explicit human approval is received and verified. | 1 |
+| **9.2.1** | **Verify that** the agent runtime blocks execution of high impact actions until explicit human approval is received and verified. | 1 |
 | **9.2.2** | **Verify that** approval requests display canonicalized and complete action parameters, such as diffs, commands, recipients, amounts, resources, and scopes, without truncation or unsafe transformation. | 2 |
 | **9.2.3** | **Verify that** each high-impact action has a trusted reversibility classification, such as read-only, reversible, externally reversible, or irreversible. | 2 |
 | **9.2.4** | **Verify that** the agent runtime enforces reversibility classifications by blocking, requiring approval, or restricting actions based on their impact and ability to be reversed. | 2 |


### PR DESCRIPTION
## Summary

This is a small wording clarification for #1085 in the active `1.01-dev` branch.

The current C9.2.1 text makes explicit human approval mandatory for every `high-impact` action at Level 1. Because AISVS levels are cumulative, that can make the Level 2 reversibility classification in C9.2.3/C9.2.4 unable to distinguish between high-impact actions that must be approved and high-impact actions that can be safely restricted or allowed according to a trusted reversibility classification.

This PR keeps mandatory human approval for privileged or irreversible actions, while leaving other high-impact handling to the reversibility classification model in C9.2.3/C9.2.4.

## Scope

Changed only C9.2.1 in:

- `1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md`

No changes to the locked `1.0/` release folder or the removed `2.0-dev/` development folder.

## Verification

```bash
npx --yes markdownlint-cli@0.45.0 --config .github/workflows/config/markdownlint.jsonc \
  1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md

npx --yes cspell@8.17.5 --config .github/workflows/config/cspell.json \
  1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md

# CSpell: Files checked: 1, Issues found: 0 in 0 files.

git diff --check
```

Closes #1085.
