### PR TITLE
Clarify C2.1.7 special token neutralization

### DIFF
--- a/1.01-dev/en/0x10-C02-Input-Validation.md
+++ b/1.01-dev/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
-| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, or encoded as literal content before model-context assembly, so they cannot be interpreted as special tokens by the model or tokenizer. | 2 |
+| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, and encoded as literal content before model-context assembly, so they cannot be interpreted as special tokens by the model or tokenizer. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
 ---

--- a/1.01-dev/en/0x10-C02-Input-Validation.md
+++ b/1.01-dev/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
-| **2.1.7** | **Verify that** reserved chat-template or control tokens from user, tool, memory, and retrieval inputs are escaped or encoded as literal content before prompt assembly, so they cannot create or terminate model-context roles, messages, or instructions. | 2 |
+| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, or encoded as literal content before model-context assembly, so individual special tokens cannot be interpreted as model-context delimiters or metadata. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
 ---

--- a/1.01-dev/en/0x10-C02-Input-Validation.md
+++ b/1.01-dev/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
-| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, and encoded as literal content before model-context assembly, so they cannot be interpreted as special tokens by the model or tokenizer. | 2 |
+| **2.1.7** | **Verify that** reserved special tokens in untrusted input are handled as literal content before model-context assembly, so they cannot be interpreted as special tokens by the model or tokenizer. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
 ---

--- a/1.01-dev/en/0x10-C02-Input-Validation.md
+++ b/1.01-dev/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
-| **2.1.7** | **Verify that** reserved special tokens are encoded as literal characters and cannot be injected into the model context. | 2 |
+| **2.1.7** | **Verify that** reserved chat-template or control tokens from user, tool, memory, and retrieval inputs are escaped or encoded as literal content before prompt assembly, so they cannot create or terminate model-context roles, messages, or instructions. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
 ---

--- a/1.01-dev/en/0x10-C02-Input-Validation.md
+++ b/1.01-dev/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
-| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, or encoded as literal content before model-context assembly, so individual special tokens cannot be interpreted as model-context delimiters or metadata. | 2 |
+| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, or encoded as literal content before model-context assembly, so they cannot be interpreted as special tokens by the model or tokenizer. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
 ---

--- a/2.0-dev/en/0x10-C02-Input-Validation.md
+++ b/2.0-dev/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
-| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, or encoded as literal content before model-context assembly, so they cannot be interpreted as special tokens by the model or tokenizer. | 2 |
+| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, and encoded as literal content before model-context assembly, so they cannot be interpreted as special tokens by the model or tokenizer. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
 ---

--- a/2.0-dev/en/0x10-C02-Input-Validation.md
+++ b/2.0-dev/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
-| **2.1.7** | **Verify that** reserved chat-template or control tokens from user, tool, memory, and retrieval inputs are escaped or encoded as literal content before prompt assembly, so they cannot create or terminate model-context roles, messages, or instructions. | 2 |
+| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, or encoded as literal content before model-context assembly, so individual special tokens cannot be interpreted as model-context delimiters or metadata. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
 ---

--- a/2.0-dev/en/0x10-C02-Input-Validation.md
+++ b/2.0-dev/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
-| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, and encoded as literal content before model-context assembly, so they cannot be interpreted as special tokens by the model or tokenizer. | 2 |
+| **2.1.7** | **Verify that** reserved special tokens in untrusted input are handled as literal content before model-context assembly, so they cannot be interpreted as special tokens by the model or tokenizer. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
 ---

--- a/2.0-dev/en/0x10-C02-Input-Validation.md
+++ b/2.0-dev/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
-| **2.1.7** | **Verify that** reserved special tokens are encoded as literal characters and cannot be injected into the model context. | 2 |
+| **2.1.7** | **Verify that** reserved chat-template or control tokens from user, tool, memory, and retrieval inputs are escaped or encoded as literal content before prompt assembly, so they cannot create or terminate model-context roles, messages, or instructions. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
 ---

--- a/2.0-dev/en/0x10-C02-Input-Validation.md
+++ b/2.0-dev/en/0x10-C02-Input-Validation.md
@@ -18,7 +18,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
-| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, or encoded as literal content before model-context assembly, so individual special tokens cannot be interpreted as model-context delimiters or metadata. | 2 |
+| **2.1.7** | **Verify that** reserved special tokens are canonicalized, escaped, or encoded as literal content before model-context assembly, so they cannot be interpreted as special tokens by the model or tokenizer. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 
 ---


### PR DESCRIPTION
## Summary

This clarifies C2.1.7 in the active development folders so the requirement is easier to verify against reserved special-token injection without overlapping C2.1.6 instruction-hierarchy wording or the existing C2.1.1/C2.1.2 normalization/encoding controls.

The previous wording said reserved special tokens must be encoded as literal characters and cannot be injected into the model context. The updated wording keeps the existing `special tokens` terminology and makes the verification target more explicit:

- individual reserved special tokens in untrusted input are the object of the check;
- the check happens before model-context assembly;
- the expected security property is that untrusted content is handled as literal content, not as model- or tokenizer-interpretable special tokens.

This is related to #1086. The frozen 1.0 research snapshot under `1.0/research/` was not modified because `1.0/LOCKED.md` says CI rejects changes there; instead, this applies a surgical requirement clarification to the active `1.01-dev` and `2.0-dev` requirement text.

## Files changed

- `1.01-dev/en/0x10-C02-Input-Validation.md`
- `2.0-dev/en/0x10-C02-Input-Validation.md`

## Verification

```bash
npx --yes markdownlint-cli@0.45.0 --config .github/workflows/config/markdownlint.jsonc \
  1.01-dev/en/0x10-C02-Input-Validation.md \
  2.0-dev/en/0x10-C02-Input-Validation.md
```

```text
1/2 1.01-dev/en/0x10-C02-Input-Validation.md
2/2 2.0-dev/en/0x10-C02-Input-Validation.md
```

```bash
npx --yes cspell@8.17.5 --config .github/workflows/config/cspell.json \
  1.01-dev/en/0x10-C02-Input-Validation.md \
  2.0-dev/en/0x10-C02-Input-Validation.md
```

```text
CSpell: Files checked: 2, Issues found: 0 in 0 files.
```

```bash
git diff --check
```

```text
passed
```
