### PR TITLE
Clarify C12.4.2 incident response audit evidence

### DIFF
--- a/1.01-dev/en/0x10-C12-Monitoring-and-Logging.md
+++ b/1.01-dev/en/0x10-C12-Monitoring-and-Logging.md
@@ -54,7 +54,7 @@ Security threats arising from proactive (agent-initiated) behavior must be detec
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.4.1** | **Verify that** autonomous action triggers include proactive behavior-pattern analysis, security evaluation, and threat-landscape assessment. | 2 |
-| **12.4.2** | **Verify that** audit logs capture security-critical proactive actions, including approver identity, timestamp, action parameters, and decision outcomes. | 2 |
+| **12.4.2** | **Verify that** structured, tamper-evident audit records capture authorization, denial, and execution of security-critical proactive actions with enough context for incident response, including initiating agent or model identity, approver identity when applicable, timestamp, action parameters or scope, policy decision and policy version at decision time, a correlation identifier linking the decision record to the execution outcome, and the actual execution outcome. | 2 |
 | **12.4.3** | **Verify that** kill-switch activations and override commands are logged. | 2 |
 
 ---

--- a/2.0-dev/en/0x10-C12-Monitoring-and-Logging.md
+++ b/2.0-dev/en/0x10-C12-Monitoring-and-Logging.md
@@ -54,7 +54,7 @@ Security threats arising from proactive (agent-initiated) behavior must be detec
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.4.1** | **Verify that** autonomous action triggers include proactive behavior-pattern analysis, security evaluation, and threat-landscape assessment. | 2 |
-| **12.4.2** | **Verify that** audit logs capture security-critical proactive actions, including approver identity, timestamp, action parameters, and decision outcomes. | 2 |
+| **12.4.2** | **Verify that** structured, tamper-evident audit records capture authorization, denial, and execution of security-critical proactive actions with enough context for incident response, including initiating agent or model identity, approver identity when applicable, timestamp, action parameters or scope, policy decision and policy version at decision time, a correlation identifier linking the decision record to the execution outcome, and the actual execution outcome. | 2 |
 | **12.4.3** | **Verify that** kill-switch activations and override commands are logged. | 2 |
 
 ---


### PR DESCRIPTION
## Summary

This updates C12.4.2 in the active development folders to make the audit evidence more useful for AI incident response while keeping the change scoped to a single existing requirement.

The previous wording required logs for security-critical proactive actions, but only named approver identity, timestamp, action parameters, and decision outcomes. This PR clarifies that incident response needs enough AI-specific context to reconstruct why an agent action was allowed, denied, or executed.

The revised wording adds:

- denied action attempts, not only executed actions;
- initiating agent or model identity;
- policy decision and policy version at decision time;
- a correlation identifier linking the decision to the execution outcome.

This relates to #1083 and stays within the issue's request for AI-specific IR requirements. It does not add a broad IR framework or alter the locked `1.0/` release snapshot.

## Files changed

- `1.01-dev/en/0x10-C12-Monitoring-and-Logging.md`
- `2.0-dev/en/0x10-C12-Monitoring-and-Logging.md`

## Verification

```bash
npx --yes markdownlint-cli@0.45.0 --config .github/workflows/config/markdownlint.jsonc \
  1.01-dev/en/0x10-C12-Monitoring-and-Logging.md \
  2.0-dev/en/0x10-C12-Monitoring-and-Logging.md
```

```text
1/2 1.01-dev/en/0x10-C12-Monitoring-and-Logging.md
2/2 2.0-dev/en/0x10-C12-Monitoring-and-Logging.md
```

```bash
npx --yes cspell@8.17.5 --config .github/workflows/config/cspell.json \
  1.01-dev/en/0x10-C12-Monitoring-and-Logging.md \
  2.0-dev/en/0x10-C12-Monitoring-and-Logging.md
```

```text
CSpell: Files checked: 2, Issues found: 0 in 0 files.
```

```bash
git diff --check
```

```text
passed
```