### PR TITLE
Adding 10.4.9 for verifying that a MCP proxy server not is vulnerable to Confused Deputy Vulnerability and sharpen 10.2.7 to prevent blocking legitimate use of specifc token flows (#1100)

### DIFF
--- a/1.01-dev/en/0x10-C10-MCP-Security.md
+++ b/1.01-dev/en/0x10-C10-MCP-Security.md
@@ -30,7 +30,7 @@ Callers must be authenticated and access to MCP servers authorized, following pr
 | **10.2.4** | **Verify that** MCP tools/list returns only tools permitted by resource owners' authorized scopes. | 2 |
 | **10.2.5** | **Verify that** MCP servers enforce access control on every tool invocation, validating that the user's access token authorizes both the requested tool and the specific argument values supplied. | 2 |
 | **10.2.6** | **Verify that** MCP servers ensure all session artifacts are removed when a session terminates. | 2 |
-| **10.2.7** | **Verify that** MCP servers not accept any tokens that were not explicitly issued for them. | 2 |
+| **10.2.7** | **Verify that** MCP servers only accept tokens explicitly issued for them. | 2 |
 
 ---
 

--- a/1.01-dev/en/0x10-C10-MCP-Security.md
+++ b/1.01-dev/en/0x10-C10-MCP-Security.md
@@ -30,7 +30,7 @@ Callers must be authenticated and access to MCP servers authorized, following pr
 | **10.2.4** | **Verify that** MCP tools/list returns only tools permitted by resource owners' authorized scopes. | 2 |
 | **10.2.5** | **Verify that** MCP servers enforce access control on every tool invocation, validating that the user's access token authorizes both the requested tool and the specific argument values supplied. | 2 |
 | **10.2.6** | **Verify that** MCP servers ensure all session artifacts are removed when a session terminates. | 2 |
-| **10.2.7** | **Verify that** the MCP server not accept any tokens that were not explicitly issued for the MCP server. | 2 |
+| **10.2.7** | **Verify that** MCP servers not accept any tokens that were not explicitly issued for them. | 2 |
 
 ---
 

--- a/1.01-dev/en/0x10-C10-MCP-Security.md
+++ b/1.01-dev/en/0x10-C10-MCP-Security.md
@@ -30,7 +30,7 @@ Callers must be authenticated and access to MCP servers authorized, following pr
 | **10.2.4** | **Verify that** MCP tools/list returns only tools permitted by resource owners' authorized scopes. | 2 |
 | **10.2.5** | **Verify that** MCP servers enforce access control on every tool invocation, validating that the user's access token authorizes both the requested tool and the specific argument values supplied. | 2 |
 | **10.2.6** | **Verify that** MCP servers ensure all session artifacts are removed when a session terminates. | 2 |
-| **10.2.7** | **Verify that** MCP servers do not pass through access tokens received from clients to downstream APIs. | 2 |
+| **10.2.7** | **Verify that** the MCP server not accept any tokens that were not explicitly issued for the MCP server. | 2 |
 
 ---
 
@@ -62,6 +62,7 @@ Schema, message, and input validation must be enforced in both MCP servers and c
 | **10.4.6** | **Verify that** MCP servers sign tool responses with a unique nonce and timestamp so MCP clients can detect replay attempts. | 2 |
 | **10.4.7** | **Verify that** MCP clients present users with explicit consent dialogue and cancellation options upon installation of a local MCP server. | 2 |
 | **10.4.8** | **Verify that** MCP clients maintain a snapshot of tool definitions and that any change to a tool definition triggers re-approval before the modified tool can be invoked. | 3 |
+| **10.4.9** | **Verify that** MCP proxy servers using a shared upstream OAuth client identity do not allow a requesting MCP client to inherit authorization established for a different MCP client. | 2 |
 
 ---
 


### PR DESCRIPTION
Closes #1100

## Summary

This PR updates 10.2.7 and adds 10.4.9 to address two different problems that were conflated in the discussion around 10.2.7:

1. token passthrough / token audience misuse
2. OAuth proxy confused-deputy authorization inheritance

The result is a narrower and more accurate 10.2.7, plus a new requirement that directly addresses the shared-upstream-client confused-deputy case.

## Changes

In [1.01-dev/en/0x10-C10-MCP-Security.md](1.01-dev/en/0x10-C10-MCP-Security.md):

- 10.2.7 is changed from:
  - "Verify that MCP servers do not pass through access tokens received from clients to downstream APIs."
- to:
  - "Verify that MCP servers only accept tokens explicitly issued for them."

- 10.4.9 is added:
  - "Verify that MCP proxy servers using a shared upstream OAuth client identity do not allow a requesting MCP client to inherit authorization established for a different MCP client."

## Background

Issue #1100 correctly pointed out that the previous 10.2.7 wording was too broad and could be read as blocking legitimate delegated token flows, while still not clearly expressing the actual MCP requirement.

The MCP authorization and security guidance distinguishes these concerns:

- For token passthrough, MCP guidance says servers must only accept tokens explicitly issued for the MCP server.
- For confused deputy in proxy architectures, MCP guidance focuses on preventing one MCP client from inheriting authorization established for another client when a shared upstream OAuth client identity is in use.

This PR aligns AISVS with that distinction.

## Rationale

The revised 10.2.7 keeps the requirement centred on the verifiable security property that matters: the MCP server must reject tokens not explicitly issued for it. That preserves legitimate architectures where downstream access may use separate, properly issued tokens, without weakening the control against audience confusion and token misuse.

The new 10.4.9 captures the MCP proxy confused-deputy condition at the AISVS level without over-specifying one implementation pattern. It stays testable: two different requesting MCP clients should not be able to share or inherit upstream authorization state.

## Scope

This PR is intentionally limited to the 1.01-dev. It does not attempt to duplicate all lower-level OAuth consent, redirect URI, CSRF, or state-handling details already covered by MCP documentation and related standards.

## References

- MCP Authorization Specification:
  https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
- MCP Security Best Practices, Token Passthrough:
  https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices#token-passthrough
- MCP Security Best Practices, Confused Deputy Problem:
  https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices#confused-deputy-problem