### PR TITLE
Extend C12.4.2 to log reversibility class and gate path

### DIFF
--- a/1.01-dev/en/0x10-C12-Monitoring-and-Logging.md
+++ b/1.01-dev/en/0x10-C12-Monitoring-and-Logging.md
@@ -54,7 +54,7 @@ Security threats arising from proactive (agent-initiated) behavior must be detec
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.4.1** | **Verify that** autonomous action triggers include proactive behavior-pattern analysis, security evaluation, and threat-landscape assessment. | 2 |
-| **12.4.2** | **Verify that** audit logs capture security-critical proactive actions, including approver identity, timestamp, action parameters, decision outcomes, the action's reversibility classification (per C9.2.3), and the gate path taken (auto-executed, approval-gated, or blocked). | 2 |
+| **12.4.2** | **Verify that** audit logs capture security-critical proactive actions, including approver identity, timestamp, action parameters, decision outcomes, the action's reversibility classification, and the gate path taken (auto-executed, approval-gated, or blocked). | 2 |
 | **12.4.3** | **Verify that** kill-switch activations and override commands are logged. | 2 |
 
 ---

--- a/1.01-dev/en/0x10-C12-Monitoring-and-Logging.md
+++ b/1.01-dev/en/0x10-C12-Monitoring-and-Logging.md
@@ -54,7 +54,7 @@ Security threats arising from proactive (agent-initiated) behavior must be detec
 | # | Description | Level |
 | :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
 | **12.4.1** | **Verify that** autonomous action triggers include proactive behavior-pattern analysis, security evaluation, and threat-landscape assessment. | 2 |
-| **12.4.2** | **Verify that** audit logs capture security-critical proactive actions, including approver identity, timestamp, action parameters, and decision outcomes. | 2 |
+| **12.4.2** | **Verify that** audit logs capture security-critical proactive actions, including approver identity, timestamp, action parameters, decision outcomes, the action's reversibility classification (per C9.2.3), and the gate path taken (auto-executed, approval-gated, or blocked). | 2 |
 | **12.4.3** | **Verify that** kill-switch activations and override commands are logged. | 2 |
 
 ---


### PR DESCRIPTION
Closes #1105.

12.4.2 records who approved, when, the parameters, and the outcome, but not whether the action was reversible or which path it took. Without those two fields an auditor cannot tell an action that auto-ran because it was genuinely reversible from one that auto-ran because an approval gate failed.

This adds two fields to the existing 12.4.2 record: the action's reversibility classification (per C9.2.3) and the gate path taken (auto-executed, approval-gated, or blocked). Additive to the field list, same L2 level. Targets 1.01.