### PR TITLE
C2.1.5 Add usecase and multilingual condition (#1099)

### DIFF
--- a/1.01-dev/en/0x10-C02-Input-Validation.md
+++ b/1.01-dev/en/0x10-C02-Input-Validation.md
@@ -16,7 +16,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.2** | **Verify that** encoding and representation smuggling in inputs is detected and mitigated. Approved mitigations include canonicalization, strict schema validation, policy-based rejection, or explicit marking. | 1 |
 | **2.1.3** | **Verify that** all inputs that could steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier, with flagged inputs blocked. | 1 |
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
-| **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach that permits only characters that are explicitly required. | 1 |
+| **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach derived from the languages and use cases the system supports, permitting only characters that are explicitly required. | 1 |
 | **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
 | **2.1.7** | **Verify that** reserved special tokens are encoded as literal characters and cannot be injected into the model context. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |


### PR DESCRIPTION
closes #1099 

### Background

The previous phrasing of requirement 2.1.5 mandated a strict allow-list approach for all inputs. While effective in narrow, security-sensitive contexts (such as URL or domain name validation), enforcing a rigid, universal allow-list on broad, multilingual AI chat inputs is practically difficult to implement. 
Aggressive normalization techniques (such as NFKC) applied to unrestricted text can be destructive to legitimate internationalized inputs.

### Rationale

To address the operational limitations of the original requirement while maintaining its Level 1 security baseline, this PR updates the requirement to make the allow-list context-dependent.
By tying the allow-list explicitly to the languages and use cases the system supports, systems can still defend against prompt injection vectors that rely on out-of-band data (such as unexpected invisible, control, bidirectional-override, tag, or variation-selector characters) without breaking core user functionality.
The updated text provides the flexibility needed for modern AI implementations while maintaining a default-deny philosophy for unsupported Unicode scripts.

### Proposed Change

| # | Description | Level |
| :--------: | ------------------------------------------------------------------------------------------------------------------- | :---: |
| **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach derived from the languages and use cases the system supports, permitting only characters that are explicitly required. | 1 |

### References

- Issue discussion: #1099 - C2.1 white-list approach - difficult to implement in multilingual systems
- Research context: [C02-01 Prompt Injection Defense - Requirements](https://github.com/OWASP/AISVS/blob/main/1.0/research/chapters/C02-User-Input-Validation/C02-01-Prompt-Injection-Defense.md#requirements)
