### PR TITLE
C9.5: add 9.5.7 requiring delegated authority to be a subset of the delegator (#1104)

### DIFF
--- a/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -79,6 +79,7 @@ Every action must be authorized at execution time and constrained by scope.
 | **9.5.4** | **Verify that** secrets and credentials required by an agent at runtime are not exposed within the model's observable context, including the context window, system prompts, or tool call parameters. | 2 |
 | **9.5.5** | **Verify that** inter-agent task delegation is restricted by an explicit authorization policy. | 2 |
 | **9.5.6** | **Verify that** long-running agent sessions re-evaluate current backend authorization policy on every privileged action. | 3 |
+| **9.5.7** | **Verify that** authority granted to a delegated agent is a subset of the delegating agent's current authority, so that tool scope, resource access, and reversibility-class ceiling can only narrow, never widen, across a delegation chain. | 3 |
 
 ---
 

--- a/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -79,7 +79,7 @@ Every action must be authorized at execution time and constrained by scope.
 | **9.5.4** | **Verify that** secrets and credentials required by an agent at runtime are not exposed within the model's observable context, including the context window, system prompts, or tool call parameters. | 2 |
 | **9.5.5** | **Verify that** inter-agent task delegation is restricted by an explicit authorization policy. | 2 |
 | **9.5.6** | **Verify that** long-running agent sessions re-evaluate current backend authorization policy on every privileged action. | 3 |
-| **9.5.7** | **Verify that** authority granted to a delegated agent is a subset of the delegating agent's current authority, so that tool scope, resource access, and reversibility-class ceiling can only narrow, never widen, across a delegation chain. | 3 |
+| **9.5.7** | **Verify that** authority derived through delegation never exceeds the delegating agent's current authority. | 2 |
 
 ---
 


### PR DESCRIPTION
Adds C9.5.7 to close the gap in #1104. 9.5.5 requires inter-agent delegation to follow an explicit authorization policy, but does not require the delegated authority to stay within the delegator's own scope, which allows privilege widening across a delegation chain.

The new control requires delegated authority to be a subset of the delegating agent's current authority: tool scope, resource access, and reversibility-class ceiling may only narrow, never widen, across the chain. It builds on the reversibility classification in 9.2.3 and complements 9.2.10 (highest-impact reversibility class across a chain) on the authorization axis.

Placed as 9.5.7 to avoid renumbering existing controls; can move it adjacent to 9.5.5 if preferred. Level set to 3 to match the chain-wide controls; L2 is reasonable if paired with 9.5.5.

Closes #1104.