### PR TITLE
Add C11.3.5: constrain caller-supplied sampling and decoding parameters

### DIFF
--- a/.github/workflows/config/local-custom.txt
+++ b/.github/workflows/config/local-custom.txt
@@ -144,6 +144,7 @@ jailbreaking
 jailbreak
 logprob
 logprobs
+logit
 SLSA
 SCVS
 Clopper

--- a/1.01-dev/en/0x10-C11-Adversarial-Robustness.md
+++ b/1.01-dev/en/0x10-C11-Adversarial-Robustness.md
@@ -44,6 +44,7 @@ Unauthorized model cloning through API abuse must be detected and deterred using
 | **11.3.2** | **Verify that** raw model outputs are not directly exposed beyond the application backend, and that externally visible responses are calibrated to the extraction risk level. | 2 |
 | **11.3.3** | **Verify that** model watermarking or fingerprinting techniques are applied so that unauthorized copies can be identified. | 3 |
 | **11.3.4** | **Verify that** detection of suspected extraction triggers response measures. | 3 |
+| **11.3.5** | **Verify that** inference endpoints constrain sampling and decoding parameters supplied by untrusted callers (e.g., temperature, top-k, top-p, logit bias, candidate/n count) to server-side approved ranges and defaults, rejecting out-of-policy values. | 2 |
 
 ---
 

--- a/1.01-dev/en/0x91-Appendix-B_AI_Security_Controls_Inventory.md
+++ b/1.01-dev/en/0x91-Appendix-B_AI_Security_Controls_Inventory.md
@@ -333,6 +333,7 @@ Test for and defend against evasion, membership inference, model inversion, extr
 | Membership-inference attack simulation demonstrating accuracy no better than random guessing | C11.2.5 |
 | Raw model outputs not exposed beyond the backend, with externally visible responses calibrated to extraction risk | C11.3.2 |
 | Model watermarking or fingerprinting so unauthorized copies can be identified | C11.3.3 |
+| Server-side constraints on caller-supplied sampling and decoding parameters, with out-of-policy values rejected | C11.3.5 |
 | Poisoning detection and human review gates protecting the safety-violation feedback pipeline | C11.4.3 |
 
 **Common pitfalls:** testing only known jailbreak patterns without adaptive attacks; not re-running the alignment suite after model updates; exposing raw confidence vectors that accelerate extraction.


### PR DESCRIPTION
Closes #1116. Adds the control agreed with @ottosulin and @RicoKomenda in the issue.

> **11.3.5** (L2) **Verify that** inference endpoints constrain sampling and decoding parameters supplied by untrusted callers (e.g., temperature, top-k, top-p, logit bias, candidate/n count) to server-side approved ranges and defaults, rejecting out-of-policy values.

Three files: the C11.3 table, the matching AD.16 row in Appendix B, and `logit` added to the cspell dictionary.

