### PR TITLE
C9.2: positive-control (9.2.11) and window-binding (9.2.12) requirements for control liveness

### DIFF
--- a/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -34,6 +34,8 @@ Privileged, high-impact, or hard-to-reverse agent actions must require trusted a
 | **9.2.8** | **Verify that** approvals are cryptographically bound to action parameters, requester identity, execution context, and a unique single-use nonce. | 3 |
 | **9.2.9** | **Verify that** cryptographic key material or credentials used to issue approvals are isolated from the agent runtime. | 3 |
 | **9.2.10** | **Verify that** approval gates for multi-step or multi-agent action chains enforce the highest-impact reversibility classification present anywhere in the chain. | 3 |
+| **9.2.11** | **Verify that** any approval or enforcement gate whose assurance rests on the absence of an event (for example, zero denials or zero blocks) is validated with a known-triggering input that is observed to activate the gate. | 1 |
+| **9.2.12** | **Verify that** the known-triggering input is injected and observed to activate the gate within the same assessment period as the results it qualifies, and that a period with no observed activation is recorded as unverified rather than passing. | 2 |
 
 ---
 


### PR DESCRIPTION
## Summary

Two requirements for C9.2 closing the gap in #1124: an approval or enforcement gate can be verified as *configured* without any evidence it ever *fired*. 9.2.8 and 9.2.9 are universals over issued approvals, so read in isolation they are vacuously satisfiable by a gate that never issues one, and neither requires the approval path to be reachable and exercised. A conformant assessment has to force an approval and inspect the binding, which an inert gate fails (and it fails the C9.2 parent). These two lines make that explicit.

## Requirements (C9.2, appended after 9.2.10)

- **9.2.11 (L1):** the gate whose assurance rests on the absence of an event is validated with a known-triggering input observed to activate it.
- **9.2.12 (L2):** that input is injected and observed to activate the gate within the assessment period, and a period with no activation is recorded as unverified rather than passing.

Tiered, not redundant: L1 proves the gate is wired; L2 proves it ran against the period under review. 9.2.12 keeps the inject clause and the verdict clause on one line on purpose. Per the #1124 discussion, "unverified rather than passing" is the requirement, not a note the strict table format would otherwise drop.

## Concrete example (contributed by @avp9-nexus)

**A window-bound positive control silently degraded by a performance change**

A production monitoring job scans a blockchain for events involving its own system and reconciles amounts against an on-chain source of truth. Its anti-silence guard uses a fixed positive witness: one known event at one known block, which must be found on every pass; if the scan returns zero results and cannot re-find its witness, the report refuses to publish amounts instead of printing zeros.

Originally the job re-scanned the full history every night, from the contract's deployment block to the chain head. The witness block therefore sat inside the scanned window on every pass. The positive control was window-bound by construction, and nobody had designed that property; it came free with the full scan.

The full scan grew to roughly 3,500 RPC requests per night and began failing against the public node, so incremental resumption was implemented: a cursor persists the last covered block and each pass scans only from there. Measured effect: 416 seconds down to 1 second, a scanned window of about 3.5 million blocks down to 344, and a verified-identical result on amounts, history, and outcomes. The witness was deliberately turned into a point probe (queried at its own block, outside the scan window) because otherwise every incremental pass would have reported "witness out of range" and the guard would have cried wolf daily.

The consequence, written down at the time as "the probe does not prove coverage" but not recognized as a regression: the probe still proves the instrument is wired (L1 holds), and no longer proves anything ran against the window of this pass (L2 is gone). The guard kept passing. Nothing in review caught it, because every individual check was green; only the later question "wired, or ran this period?" made it visible.

This is the failure mode the Level 2 requirement exists for: a setup-time positive control degrades silently when the window moves, and the degradation is indistinguishable from success until the period with no in-period trigger is treated as unverified rather than passing.

## Open question for maintainers: numbering

Appending as 9.2.11 (L1) / 9.2.12 (L2) puts them after the L3 block (9.2.8 to 9.2.10), which breaks the table's ascending-by-level order. Happy to renumber the tail so levels stay ascending, or leave them appended. Your call, and I will follow RELEASE.md on what a minor release allows.

## Notes

- **Canary scoping** (per @avp9-nexus's suggestion to keep this in the PR, since the format has no inline notes): a positive control that rides the live enforcement path evidences only that the path was live during the period. It does not evidence enforcement against an adversary controlling that enforcement point, who can recognize a static marker and pass it while enforcing nothing; and being produced inside the perimeter it attests, it is not sufficient as sole evidence.
- **CWE** (AISVS tables have no CWE column, so context only): the closest is CWE-390 (Detection of Error Condition Without Action), with CWE-754 / CWE-693 as the broader class. CWE-778 (Insufficient Logging) is only adjacent.
- **C10.4 mirror** left as a maintainer option: C10.4 validates responses that arrive, and the call that never came is the same gap there. Not doubled here.

Relates to #1124. Drafted with @avp9-nexus, who raised the issue, supplied the production regression that motivated the window-binding line, and measured the wording against the 1.01-dev format.
