### PR TITLE
1.01: clarify who controls reversibility classifications

### DIFF
--- a/1.01-dev/en/0x90-Appendix-A_Glossary.md
+++ b/1.01-dev/en/0x90-Appendix-A_Glossary.md
@@ -218,7 +218,7 @@ This glossary defines key AI, ML, and security terms used throughout the AISVS t
 
 * **Remote Attestation** – A mechanism by which a trusted execution environment provides cryptographic proof to a remote party that specific code is running in a genuine, unmodified TEE.
 
-* **Reversibility Classification** – A trusted classification of a high-impact agent action by how hard its effect is to undo, along the scale read-only, reversible, externally reversible, or irreversible.
+* **Reversibility Classification** – A trusted classification of a high-impact agent action by how hard its effect is to undo, along the scale read-only, reversible, externally reversible, or irreversible. A _trusted_ classification is a classification created, maintained and stored outside of the agent's control.
 
 * **Reward Model** – A machine learning model trained to predict human preference scores for AI outputs, used as a proxy reward signal in RLHF training pipelines. Because reward models are ML artifacts, they are subject to data poisoning attacks that can subvert alignment training outcomes.
 


### PR DESCRIPTION
Appendix A calls a reversibility classification "trusted" without defining who controls it. The current entry reads:

> Reversibility Classification – A trusted classification of a high-impact agent action by how hard its effect is to undo, along the scale read-only, reversible, externally reversible, or irreversible.

Append [Otto Sulin's proposed sentence](https://github.com/OWASP/AISVS/issues/1126#issuecomment-5399773496), which [Jim Manico agreed with](https://github.com/OWASP/AISVS/issues/1126#issuecomment-5399936616):

> A _trusted_ classification is a classification created, maintained and stored outside of the agent's control.

This clarifies the existing trust boundary in C9.2.3 (L2), consistent with the independent policy decisions in C5.2.5 and C9.5.3. Only the existing glossary entry in `1.01-dev` changes; requirement IDs, levels, and chapter structure remain intact.

Background research supports the clarification:

- [OWASP AI Agent Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/AI_Agent_Security_Cheat_Sheet.html#high-impact-action-integrity-controls) calls for independent validation of high-impact actions by a policy service or execution component.
- [MCP ToolAnnotations](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations) are advisory; untrusted server annotations cannot establish whether an action is safe to invoke.
- [LangChain human-in-the-loop middleware](https://docs.langchain.com/oss/python/langchain/human-in-the-loop#configuring-interrupts) provides application-configured per-tool approval policies. This supports implementation at the existing level, provided the application protects that configuration from agent modification.

Related to #1126. Its separate proposal to revalidate classifications after tool behavior changes remains unresolved; this PR does not close that issue.

Validation: `git diff --check`, Markdown lint, and spelling checks passed using the repository configurations. The diff contains one added sentence in one glossary entry.
