### PR TITLE
1.01: clarify action chain approval and expansion

### DIFF
--- a/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -33,7 +33,8 @@ Privileged, high-impact, or hard-to-reverse agent actions must require trusted a
 | **9.2.7** | **Verify that** the AI-augmented review mechanism is protected against manipulation by adversarial inputs, and cannot be overridden or bypassed through prompt injection. | 2 |
 | **9.2.8** | **Verify that** approvals are cryptographically bound to action parameters, requester identity, execution context, and a unique single-use nonce. | 3 |
 | **9.2.9** | **Verify that** cryptographic key material or credentials used to issue approvals are isolated from the agent runtime. | 3 |
-| **9.2.10** | **Verify that** approval gates for multi-step or multi-agent action chains enforce the highest-impact reversibility classification present anywhere in the chain. | 3 |
+| **9.2.10** | **Verify that** approval gates for multi-step or multi-agent action chains enforce the highest-impact reversibility classification present anywhere in the chain, where the chain is established by a component outside the control of the agent being gated. | 3 |
+| **9.2.11** | **Verify that** agent execution which would exceed the approved action chain is blocked until a new approval is obtained, and that the new approval enforces the highest-impact reversibility classification present across the cumulative chain. | 3 |
 
 ---
 

--- a/1.01-dev/en/0x90-Appendix-A_Glossary.md
+++ b/1.01-dev/en/0x90-Appendix-A_Glossary.md
@@ -2,6 +2,8 @@
 
 This glossary defines key AI, ML, and security terms used throughout the AISVS to ensure clarity and common understanding.
 
+* **Action Chain** – A bounded set of related agent actions and their execution dependencies for a task, whether executed as multiple steps by one agent or delegated across multiple agents. The cumulative chain includes the original actions and all subsequent expansions.
+
 * **Adapter** – A lightweight module (e.g., LoRA, QLoRA) added to a pre-trained model to specialize its behavior on a specific task without modifying the original weights.
 
 * **Adversarial Example** – An input deliberately crafted to cause an AI model to make a mistake, often by adding subtle perturbations imperceptible to humans.

--- a/1.01-dev/en/0x91-Appendix-B_AI_Security_Controls_Inventory.md
+++ b/1.01-dev/en/0x91-Appendix-B_AI_Security_Controls_Inventory.md
@@ -399,7 +399,8 @@ Require human approval for high-impact actions and provide reliable, exercised s
 | Protection of the AI-augmented review mechanism against prompt-injection bypass | C9.2.7 |
 | Approvals cryptographically bound to parameters, requester identity, execution context, and a single-use nonce | C9.2.8 |
 | Isolation of approval-issuing key material or credentials from the agent runtime | C9.2.9 |
-| Multi-step or multi-agent chains enforcing the highest-impact reversibility classification in the chain | C9.2.10 |
+| Approval gates enforcing the highest-impact reversibility classification across action chains established outside the gated agent's control | C9.2.10 |
+| Blocking execution beyond an approved action chain until new approval enforces the highest-impact reversibility classification across the cumulative chain | C9.2.11 |
 | Manual kill-switch to immediately halt model inference and outputs | C9.6.1 |
 | Fail-closed blocking of a pending action when a human-approval gate is not satisfied within the defined time | C9.6.2 |
 | Kill-switch commands delivered through an out-of-band channel isolated from the agent runtime | C9.6.3 |


### PR DESCRIPTION
C9.2.10 leaves the action chain's boundary undefined. An agent can declare two actions and attempt a third while relying on approval for the original plan. This change makes the boundary independent of the gated agent and requires approval of the cumulative chain before execution expands beyond it.

Current C9.2.10 (Level 3):

> Verify that approval gates for multi-step or multi-agent action chains enforce the highest-impact reversibility classification present anywhere in the chain.

The amended requirement retains that rule and adds that the chain is established by a component outside the gated agent's control. New C9.2.11 (Level 3):

> Verify that agent execution which would exceed the approved action chain is blocked until a new approval is obtained, and that the new approval enforces the highest-impact reversibility classification present across the cumulative chain.

Appendix A defines Action Chain through related actions and their execution dependencies, independently of the approval decision. The cumulative chain includes the original actions and all subsequent expansions. Appendix B maps both requirements.

This follows [Otto's proposed split](https://github.com/OWASP/AISVS/issues/1123#issuecomment-5237369909) and the [reporter's cumulative-chain and glossary refinements](https://github.com/OWASP/AISVS/issues/1123#issuecomment-5237550077). C9.5.1 governs individual calls and C9.5.7 bounds delegated authority; neither establishes the scope of a chain approval. The change fits the 1.01 minor-release policy within the existing C9.2 section.

Assessment examples: attempt to narrow the chain from the gated agent, then attempt execution beyond its approved boundary. The expansion must remain blocked pending new approval, including across repeated expansions; approval must account for the original actions and prior expansions as well as the proposed addition.

Closes #1123.
