### PR TITLE
[1.01] Clarify 2.1.6 instruction priority across retrieval, tools, and conversation turns

### DIFF
--- a/1.01-dev/en/0x10-C02-Input-Validation.md
+++ b/1.01-dev/en/0x10-C02-Input-Validation.md
@@ -17,7 +17,7 @@ Prompt injection is one of the top risks for AI systems, and defending against i
 | **2.1.3** | **Verify that** all inputs that could steer model behavior are treated as untrusted and screened by a prompt injection detection ruleset or classifier, with flagged inputs blocked. | 1 |
 | **2.1.4** | **Verify that** input length controls prevent content from exceeding the context window. The controls must reject inputs that exceed token limits rather than truncating them. | 1 |
 | **2.1.5** | **Verify that** the system implements a character set restriction for all inputs. The restriction must use an allow-list approach derived from the languages and use cases the system supports, permitting only characters that are explicitly required. | 1 |
-| **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. | 2 |
+| **2.1.6** | **Verify that** the system enforces an instruction hierarchy in which system and developer messages override user instructions and other untrusted inputs, even after user instructions have been processed. Untrusted content cannot acquire higher instruction priority through retrieval, tool processing, or persistence across conversation turns. | 2 |
 | **2.1.7** | **Verify that** reserved special tokens are encoded as literal characters and cannot be injected into the model context. | 2 |
 | **2.1.8** | **Verify that** the system can detect many-shot jailbreaking patterns. | 3 |
 


### PR DESCRIPTION
Closes #1134.

Clarifies that 2.1.6's existing instruction hierarchy continues to apply when untrusted content is retrieved, processed by tools, or persisted into later conversation turns. Application-mediated reuse must not promote that content's authority.

Appends exactly:

> Untrusted content cannot acquire higher instruction priority through retrieval, tool processing, or persistence across conversation turns.

The existing sentence, identifier, and L2 classification are retained. Only the 2.1.6 row in `1.01-dev/en/0x10-C02-Input-Validation.md` changes.

Live verification: inject a conflicting instruction into a retrieved document, tool response, or persisted conversation item and exercise each supported path, including a later turn. Observe whether it overrides a trusted system/developer constraint; use benign counterparts to confirm normal processing remains available.

Research: the [OWASP LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html) covers indirect, tool-output, RAG, and persistent attacks; the [OWASP RAG Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/RAG_Security_Cheat_Sheet.html) treats retrieved context as untrusted. These support making the existing hierarchy's application to these paths explicit while retaining L2. No particular implementation is prescribed.

Validation: `git diff --check` passed; reviewed the diff to confirm the exact requested sentence is the only content change. This documentation change does not itself demonstrate runtime enforcement in an application.
