### PR TITLE
[1.01] Add 7.1.3: Stop actions on refused or invalid AI responses

### DIFF
--- a/1.01-dev/en/0x10-C07-Model-Behavior.md
+++ b/1.01-dev/en/0x10-C07-Model-Behavior.md
@@ -14,6 +14,7 @@ Model outputs must be structured and validated to reduce downstream injection ri
 | :--------: | --------------------------------------------------------------------------------------------------------------------- | :---: |
 | **7.1.1** | **Verify that** the application validates all model outputs against a defined schema and rejects any output that does not match. | 1 |
 | **7.1.2** | **Verify that** model-generated output is bounded by length limits and termination controls. | 1 |
+| **7.1.3** | **Verify that**, when an application uses an AI response to decide whether to perform an action, it does not perform that action if the AI refuses the request, reports a failure, or returns a response the application cannot correctly read or understand. | 2 |
 
 ---
 


### PR DESCRIPTION
Closes #1136.

Adds 7.1.3 at L2 to AISVS 1.01:

> Verify that, when an application uses an AI response to decide whether to perform an action, it does not perform that action if the AI refuses the request, reports a failure, or returns a response the application cannot correctly read or understand.

A schema-valid refusal must not trigger an action. This complements 7.1.1's format validation with an observable action-handling requirement, consistent with [OWASP LLM05's guidance on validating model output before backend use](https://genai.owasp.org/llmrisk/llm052025-improper-output-handling/).

Verification: supply refusal, failure, and invalid responses; confirm no requested action executes. Use a valid, authorized response as a positive control.

Validation: `git diff --check` passed. One requirement added; existing numbering and text preserved.
