### PR TITLE
[1.01] Align wording in 9.1.1 and 9.1.2

### DIFF
--- a/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
+++ b/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md
@@ -12,8 +12,8 @@ Runtime expansion (recursion, concurrency, cost) must be bounded, with safe halt
 
 | # | Description | Level |
 | :--: | --- | :---: |
-| **9.1.1** | **Verify that** per-tool quotas and timeouts (e.g., CPU, memory, disk, egress, and execution time) are enforced. | 1 |
-| **9.1.2** | **Verify that** per-execution budgets (e.g., max recursion depth, token use, and monetary spend) are configured and enforced by the runtime. | 1 |
+| **9.1.1** | **Verify that** per-tool quotas and timeouts (e.g., CPU, memory, disk, egress, and execution time) are enforced by the runtime. | 1 |
+| **9.1.2** | **Verify that** per-execution budgets (e.g., max recursion depth, token use, and monetary spend) are enforced by the runtime. | 1 |
 | **9.1.3** | **Verify that** a swarm-level kill-switch exists that can halt all active agent instances. | 2 |
 
 ---


### PR DESCRIPTION
Closes #1140.

Aligns [9.1.1 and 9.1.2](https://github.com/OWASP/AISVS/blob/main/1.01-dev/en/0x10-C09-Orchestration-and-Agentic-Action.md#c91-execution-budgets-loop-control-and-circuit-breakers) at L1 in AISVS 1.01.

9.1.1:

> Verify that per-tool quotas and timeouts (e.g., CPU, memory, disk, egress, and execution time) are enforced by the runtime.

9.1.2:

> Verify that per-execution budgets (e.g., max recursion depth, token use, and monetary spend) are enforced by the runtime.

Both requirements focus on runtime enforcement. Removing "configured" avoids implying that the runtime configures its own limits.
