### PR TITLE
Point the research wiki links at 1.01-dev

### DIFF
--- a/1.01-dev/research/README.md
+++ b/1.01-dev/research/README.md
@@ -2,7 +2,7 @@
 
 **OWASP AI Security Verification Standard: Research and Analysis Hub**
 
-Welcome to the AISVS research wiki. This wiki provides structured research context for every chapter and appendix in AISVS 1.0, helping developers, auditors, and security teams understand and implement each requirement. Every requirement is mapped to the threats it mitigates, the tools and techniques available to implement it, practical verification approaches, and open questions where tooling or research is still maturing. Whether you are building an AI application, auditing one, or evaluating your organization's AI security posture, this wiki is designed to help you get started.
+Welcome to the AISVS research wiki. This wiki provides structured research context for every chapter and appendix in AISVS 1.01, helping developers, auditors, and security teams understand and implement each requirement. Every requirement is mapped to the threats it mitigates, the tools and techniques available to implement it, practical verification approaches, and open questions where tooling or research is still maturing. Whether you are building an AI application, auditing one, or evaluating your organization's AI security posture, this wiki is designed to help you get started.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Organizations should select a target level based on the risk profile of their AI
 
 ## Research Wiki
 
-For every requirement in the standard, the [Research Wiki](https://github.com/OWASP/AISVS/blob/main/1.0/research/README.md) provides implementation context beyond the requirement text:
+For every requirement in the standard, the [Research Wiki](https://github.com/OWASP/AISVS/blob/main/1.01-dev/research/README.md) provides implementation context beyond the requirement text:
 
 | Column | What it tells you |
 | --- | --- |


### PR DESCRIPTION
## Summary

Now that the research wiki lives under `1.01-dev/research/` (#1144), the README link should send readers there instead of the frozen 1.0 copy. The seeded wiki intro also still described itself as covering AISVS 1.0, so it now says 1.01. Two one-line edits, nothing under `1.0/` is touched.

## Checks

- [x] Changes are limited to `README.md` and `1.01-dev/research/README.md`
- [x] Nothing under `1.0/` changes