### PR TITLE
[1.01] Clarify component coverage in 8.2.3

### DIFF
--- a/1.01-dev/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
+++ b/1.01-dev/en/0x10-C08-Memory-Embeddings-and-Vector-Database.md
@@ -26,7 +26,7 @@ Content must be pre-screened before vectorization, and memory writes treated as 
 | :--: | --- | :---: |
 | **8.2.1** | **Verify that** sensitive fields are detected before embedding and are masked, tokenized, or dropped. | 1 |
 | **8.2.2** | **Verify that** vectors that fall outside normal clustering patterns are flagged and quarantined before entering production indices. | 2 |
-| **8.2.3** | **Verify that** agent outputs and tool outputs are not automatically written to trusted agent memory without explicit source validation. | 2 |
+| **8.2.3** | **Verify that** no component reachable from agent execution can write agent outputs or tool outputs to trusted agent memory without explicit source validation. | 2 |
 | **8.2.4** | **Verify that** content crafted to manipulate retrieval results is detected and rejected or quarantined before vectorization. | 3 |
 | **8.2.5** | **Verify that** new content written to memory is checked for contradictions with what is already stored and that conflicts trigger alerts. | 3 |
 


### PR DESCRIPTION
Related to #1120. This applies [Rico's suggested revision](https://github.com/OWASP/AISVS/issues/1120#issuecomment-5591631857) to 8.2.3 in `1.01-dev`, retaining Level 2.

Current text:

> Verify that agent outputs and tool outputs are not automatically written to trusted agent memory without explicit source validation.

The revision makes explicit that source validation applies across components reachable from agent execution, not just the first adapter an auditor checks. [Microsoft's memory-safety guidance](https://learn.microsoft.com/en-us/security/zero-trust/sfi/manage-agentic-memory-safety) likewise recommends gating memory writes on provenance and enforcing boundaries architecturally rather than relying on model behavior.

Only 8.2.3 changes. This PR adds no new requirement or glossary entry and leaves deletion and reset behavior unchanged.

The old sentence is also quoted in the two C8 research pages; I can update those quotations here or leave them to the next research sync.
